### PR TITLE
IBX-392: content / view_embed should be sufficient to display an image variation on an embedded image

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -159,7 +159,7 @@ class ContentViewBuilder implements ViewBuilder
             && $this->permissionResolver->canUser('content', 'view_embed', $content->contentInfo)
             && !$this->permissionResolver->canUser('content', 'read', $content->contentInfo)
         ) {
-            $parameters['params']['objectParameters'] = ['doNotGenerateEmbedUrl' => true];
+            $parameters['params']['objectParameters']['doNotGenerateEmbedUrl'] = true;
         }
 
         $this->viewParametersInjector->injectViewParameters($view, $parameters);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | IBX-392
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2`,`v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

When we overwrite objectParameters (when a user doesn't have view permissions on the embedded object), we lose the image variation size information, which we still need for embedded images. So, the fix is to not overwrite objectParameters.
