### PR TITLE
IBX-538: [Composer] Added legacy namespaces to PSR4 autoloader for BC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,17 @@
             "Ibexa\\Bundle\\Installer\\": "src/bundle/Installer",
             "Ibexa\\Bundle\\LegacySearchEngine\\": "src/bundle/LegacySearchEngine",
             "Ibexa\\Contracts\\Core\\": "src/contracts",
-            "Ibexa\\Core\\": "src/lib"
+            "Ibexa\\Core\\": "src/lib",
+            "eZ\\Publish\\API\\Repository\\Tests\\": "src/contracts/Test/Repository",
+            "eZ\\Publish\\SPI\\Tests\\": "src/contracts/Test",
+            "eZ\\Publish\\API\\": "src/contracts",
+            "eZ\\Publish\\SPI\\": "src/contracts",
+            "eZ\\Publish\\Core\\": "src/lib",
+            "eZ\\Bundle\\EzPublishCoreBundle\\": "src/bundle/Core",
+            "eZ\\Bundle\\EzPublishDebugBundle\\": "src/bundle/Debug",
+            "eZ\\Bundle\\EzPublishIOBundle\\": "src/bundle/IO",
+            "eZ\\Bundle\\EzPublishLegacySearchEngineBundle\\": "src/bundle/LegacySearchEngine",
+            "EzSystems\\PlatformInstallerBundle\\": "src/bundle/Installer"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-538](https://issues.ibexa.co/browse/IBX-538)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

This PR adds legacy `eZ\*` namespaces to PSR4 Composer autoloader to make BC layer lighter - everything with matching prefix is going to be handled by that autoloader, instead of BC layer class-map.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Asked for a review
