### PR TITLE
IBX-538: Added externally used legacy test namespaces to autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,8 @@
             "Ibexa\\Bundle\\LegacySearchEngine\\": "src/bundle/LegacySearchEngine",
             "Ibexa\\Contracts\\Core\\": "src/contracts",
             "Ibexa\\Core\\": "src/lib",
+            "Ibexa\\Tests\\Core\\": "tests/lib",
+            "Ibexa\\Tests\\Integration\\Core\\": "tests/integration/Core",
             "eZ\\Publish\\API\\Repository\\Tests\\": "src/contracts/Test/Repository",
             "eZ\\Publish\\SPI\\Tests\\": "src/contracts/Test",
             "eZ\\Publish\\API\\": "src/contracts",
@@ -97,6 +99,9 @@
             "eZ\\Bundle\\EzPublishDebugBundle\\": "src/bundle/Debug",
             "eZ\\Bundle\\EzPublishIOBundle\\": "src/bundle/IO",
             "eZ\\Bundle\\EzPublishLegacySearchEngineBundle\\": "src/bundle/LegacySearchEngine",
+            "eZ\\Bundle\\EzPublishCoreBundle\\Tests\\": "tests/bundle/Core",
+            "eZ\\Publish\\Core\\MVC\\Symfony\\Templating\\Tests\\": "tests/lib/MVC/Symfony/Templating",
+            "eZ\\Publish\\Core\\Persistence\\Legacy\\Tests\\": "tests/lib/Persistence/Legacy",
             "EzSystems\\PlatformInstallerBundle\\": "src/bundle/RepositoryInstaller"
         }
     },


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-538](https://issues.ibexa.co/browse/IBX-538)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Looks like a lot of 1st party packages are relying on some chosen base test classes. Therefore, for the time being, those chosen legacy namespaces, are added to the autoloader. As a follow up, for later, those specific base test classes should be moved to `Ibexa\Contracts\Core\Test` namespace.

#### TODO:
- [x] See if anything else is needed, before merging, at least for current changes

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // already there
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Asked for a review
