### PR TITLE
IBX-1466: Moved parts of EzPlatformCoreBundle to IbexaCoreBundle

### DIFF
--- a/src/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Configures session handler based on `ezplatform.session.handler_id`
+ * and `ezplatform.session.save_path`.
+ *
+ * This ensures parameters have the highest priority and the configuration
+ * will be respected with default framework.yaml file.
+ *
+ * @internal
+ */
+final class SessionConfigurationPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $handlerId = $container->hasParameter('ezplatform.session.handler_id')
+            ? $container->getParameter('ezplatform.session.handler_id')
+            : null;
+
+        $savePath = $container->hasParameter('ezplatform.session.save_path')
+            ? $container->getParameter('ezplatform.session.save_path')
+            : null;
+
+        if (null !== $handlerId) {
+            $usedEnvs = [];
+            $container->resolveEnvPlaceholders($handlerId, null, $usedEnvs);
+
+            // code below follows FrameworkExtension from symfony/framework-bundle
+            if ($usedEnvs || preg_match('#^[a-z]++://#', $handlerId)) {
+                $id = '.cache_connection.' . ContainerBuilder::hash($handlerId);
+
+                $container->getDefinition('session.abstract_handler')
+                    ->replaceArgument(
+                        0,
+                        $container->has($id)
+                            ? new Reference($id)
+                            : $handlerId
+                    );
+
+                $container->setAlias('session.handler', 'session.abstract_handler');
+            } else {
+                $container->setAlias('session.handler', $handlerId);
+            }
+
+            if ($container->hasDefinition('session.storage.native')) {
+                $container
+                    ->getDefinition('session.storage.native')
+                    ->replaceArgument(1, new Reference('session.handler'));
+            }
+
+            if ($container->hasDefinition('session.storage.php_bridge')) {
+                $container
+                    ->getDefinition('session.storage.php_bridge')
+                    ->replaceArgument(0, new Reference('session.handler'));
+            }
+
+            if ($container->hasDefinition('session.storage.factory.native')) {
+                $container
+                    ->getDefinition('session.storage.factory.native')
+                    ->replaceArgument(1, new Reference('session.handler'));
+            }
+
+            if ($container->hasDefinition('session.storage.factory.php_bridge')) {
+                $container
+                    ->getDefinition('session.storage.factory.php_bridge')
+                    ->replaceArgument(0, new Reference('session.handler'));
+            }
+        }
+
+        if (null !== $savePath) {
+            $container->setParameter('session.save_path', $savePath);
+        }
+    }
+}
+
+class_alias(SessionConfigurationPass::class, 'EzSystems\EzPlatformCoreBundle\DependencyInjection\Compiler');

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -187,6 +187,9 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
     {
         $this->prependTranslatorConfiguration($container);
         $this->prependDoctrineConfiguration($container);
+
+        $this->configureGenericSetup($container);
+        $this->configurePlatformShSetup($container);
     }
 
     /**
@@ -638,7 +641,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         $connections = array_values(
             array_filter(
                 array_unique(
-                    array_merge(...$repositoryConnections) ?? [])
+                    array_merge(...$repositoryConnections) ?? []
+                )
             )
         );
 
@@ -703,6 +707,312 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
         $container->registerForAutoconfiguration(FilteringSortClauseQueryBuilder::class)
             ->addTag(ServiceTags::FILTERING_SORT_CLAUSE_QUERY_BUILDER);
+    }
+
+    /**
+     * Moved from {@see \EzSystems\EzPlatformCoreBundle\DependencyInjection\EzPlatformCoreExtension::configureGenericSetup}.
+     *
+     * @throws \Exception
+     */
+    private function configureGenericSetup(ContainerBuilder $container): void
+    {
+        // One of `legacy` (default) or `solr`
+        $container->setParameter('search_engine', '%env(SEARCH_ENGINE)%');
+
+        // Session save path as used by symfony session handlers (eg. used for dsn with redis)
+        $container->setParameter('ezplatform.session.save_path', '%kernel.project_dir%/var/sessions/%kernel.environment%');
+
+        // Predefined pools are located in config/packages/cache_pool/
+        // You can add your own cache pool to the folder mentioned above.
+        // In order to change the default cache_pool use environmental variable export.
+        // The line below must not be altered as required cache service files are resolved based on environmental config.
+        $container->setParameter('cache_pool', '%env(CACHE_POOL)%');
+
+        // By default cache ttl is set to 24h, when using Varnish you can set a much higher value. High values depends on
+        // using EzSystemsPlatformHttpCacheBundle (default as of v1.12) which by design expires affected cache on changes
+        $container->setParameter('httpcache_default_ttl', '%env(HTTPCACHE_DEFAULT_TTL)%');
+
+        // Settings for HttpCache
+        $container->setParameter('purge_server', '%env(HTTPCACHE_PURGE_SERVER)%');
+
+        // Identifier used to generate the CSRF token. Commenting this line will result in authentication
+        // issues both in AdminUI and REST calls
+        $container->setParameter('ezpublish_rest.csrf_token_intention', 'authenticate');
+
+        // Varnish invalidation/purge token (for use on platform.sh, eZ Platform Cloud and other places you can't use IP for ACL)
+        $container->setParameter('varnish_invalidate_token', '%env(resolve:default::HTTPCACHE_VARNISH_INVALIDATE_TOKEN)%');
+
+        // Compile time handlers
+        // These are defined at compile time, and hence can't be set at runtime using env()
+        // config/env/generic.php takes care about letting you set them by env variables
+
+        // Session handler, by default set to file based (instead of ~) in order to be able to use %ezplatform.session.save_path%
+        $container->setParameter('ezplatform.session.handler_id', 'session.handler.native_file');
+
+        // Purge type used by HttpCache system ("local", "varnish"/"http", and on ee also "fastly")
+        $container->setParameter('purge_type', '%env(HTTPCACHE_PURGE_TYPE)%');
+
+        $container->setParameter('solr_dsn', '%env(SOLR_DSN)%');
+        $container->setParameter('solr_core', '%env(SOLR_CORE)%');
+
+        $container->setParameter('siso_search.solr.host', '%env(SISO_SEARCH_SOLR_HOST)%');
+        $container->setParameter('siso_search.solr.port', '%env(SISO_SEARCH_SOLR_PORT)%');
+        $container->setParameter('siso_search.solr.core', '%env(SISO_SEARCH_SOLR_CORE)%');
+        $container->setParameter('siso_search.solr.path', '%env(SISO_SEARCH_SOLR_PATH)%');
+
+        $projectDir = $container->getParameter('kernel.project_dir');
+
+        if ($dfsNfsPath = $_SERVER['DFS_NFS_PATH'] ?? false) {
+            $container->setParameter('dfs_nfs_path', $dfsNfsPath);
+
+            $parameterMap = [
+                'dfs_database_charset' => 'database_charset',
+                'dfs_database_driver' => 'database_driver',
+                'dfs_database_collation' => 'database_collation',
+            ];
+
+            foreach ($parameterMap as $dfsParameter => $platformParameter) {
+                $container->setParameter(
+                    $dfsParameter,
+                    $_SERVER[strtoupper($dfsParameter)] ?? $container->getParameter($platformParameter)
+                );
+            }
+
+            $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/dfs'));
+            $loader->load('dfs.yaml');
+        }
+
+        // Cache settings
+        // If CACHE_POOL env variable is set, check if there is a yml file that needs to be loaded for it
+        if (($pool = $_SERVER['CACHE_POOL'] ?? false) && file_exists($projectDir . "/config/packages/cache_pool/${pool}.yaml")) {
+            $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/cache_pool'));
+            $loader->load($pool . '.yaml');
+        }
+
+        if ($purgeType = $_SERVER['HTTPCACHE_PURGE_TYPE'] ?? false) {
+            $container->setParameter('purge_type', $purgeType);
+            $container->setParameter('ezpublish.http_cache.purge_type', $purgeType);
+        }
+
+        if ($value = $_SERVER['MAILER_TRANSPORT'] ?? false) {
+            $container->setParameter('mailer_transport', $value);
+        }
+
+        if ($value = $_SERVER['LOG_TYPE'] ?? false) {
+            $container->setParameter('log_type', $value);
+        }
+
+        if ($value = $_SERVER['SESSION_HANDLER_ID'] ?? false) {
+            $container->setParameter('ezplatform.session.handler_id', $value);
+        }
+
+        if ($value = $_SERVER['SESSION_SAVE_PATH'] ?? false) {
+            $container->setParameter('ezplatform.session.save_path', $value);
+        }
+    }
+
+    /**
+     * Moved from {@see \EzSystems\EzPlatformCoreBundle\DependencyInjection\EzPlatformCoreExtension::configurePlatformShSetup}.
+     *
+     * @throws \Exception
+     */
+    private function configurePlatformShSetup(ContainerBuilder $container): void
+    {
+        $projectDir = $container->getParameter('kernel.project_dir');
+
+        // Run for all hooks, incl build step
+        if ($_SERVER['PLATFORM_PROJECT_ENTROPY'] ?? false) {
+            // Disable PHPStormPass as we don't have write access & it's not localhost
+            $container->setParameter('ezdesign.phpstorm.enabled', false);
+        }
+
+        // Will not be executed on build step
+        $relationships = $_SERVER['PLATFORM_RELATIONSHIPS'] ?? false;
+        if (!$relationships) {
+            return;
+        }
+        $routes = $_SERVER['PLATFORM_ROUTES'];
+
+        $relationships = json_decode(base64_decode($relationships), true);
+        $routes = json_decode(base64_decode($routes), true);
+
+        // PLATFORMSH_DFS_NFS_PATH is different compared to DFS_NFS_PATH in the sense that it is relative to ezplatform dir
+        // DFS_NFS_PATH is an absolute path
+        if ($dfsNfsPath = $_SERVER['PLATFORMSH_DFS_NFS_PATH'] ?? false) {
+            $container->setParameter('dfs_nfs_path', sprintf('%s/%s', $projectDir, $dfsNfsPath));
+
+            // Map common parameters
+            $container->setParameter('dfs_database_charset', $container->getParameter('database_charset'));
+            $container->setParameter(
+                'dfs_database_collation',
+                $container->getParameter('database_collation')
+            );
+            if (\array_key_exists('dfs_database', $relationships)) {
+                // process dedicated P.sh dedicated config
+                foreach ($relationships['dfs_database'] as $endpoint) {
+                    if (empty($endpoint['query']['is_master'])) {
+                        continue;
+                    }
+                    $container->setParameter('dfs_database_driver', 'pdo_' . $endpoint['scheme']);
+                    $container->setParameter(
+                        'dfs_database_url',
+                        sprintf(
+                            '%s://%s:%s:%d@%s/%s',
+                            $endpoint['scheme'],
+                            $endpoint['username'],
+                            $endpoint['password'],
+                            $endpoint['port'],
+                            $endpoint['host'],
+                            $endpoint['path']
+                        )
+                    );
+                }
+            } else {
+                // or set fallback from the Repository database, if not configured
+                $container->setParameter('dfs_database_driver', $container->getParameter('database_driver'));
+            }
+
+            $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/dfs'));
+            $loader->load('dfs.yaml');
+        }
+
+        // Use Redis-based caching if possible.
+        if (isset($relationships['rediscache'])) {
+            foreach ($relationships['rediscache'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'redis') {
+                    continue;
+                }
+
+                $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/cache_pool'));
+                $loader->load('cache.redis.yaml');
+
+                $container->setParameter('cache_pool', 'cache.redis');
+                $container->setParameter('cache_dsn', sprintf('%s:%d', $endpoint['host'], $endpoint['port']) . '?retry_interval=3');
+            }
+        } elseif (isset($relationships['cache'])) {
+            // Fallback to memcached if here (deprecated, we will only handle redis here in the future)
+            foreach ($relationships['cache'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'memcached') {
+                    continue;
+                }
+
+                @trigger_error('Usage of Memcached is deprecated, redis is recommended', E_USER_DEPRECATED);
+
+                $container->setParameter('cache_pool', 'cache.memcached');
+                $container->setParameter('cache_dsn', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+
+                $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/cache_pool'));
+                $loader->load('cache.memcached.yaml');
+            }
+        }
+
+        // Use Redis-based sessions if possible. If a separate Redis instance
+        // is available, use that.  If not, share a Redis instance with the
+        // Cache.  (That should be safe to do except on especially high-traffic sites.)
+        if (isset($relationships['redissession'])) {
+            foreach ($relationships['redissession'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'redis') {
+                    continue;
+                }
+
+                $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
+                $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+            }
+        } elseif (isset($relationships['rediscache'])) {
+            foreach ($relationships['rediscache'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'redis') {
+                    continue;
+                }
+
+                $container->setParameter('ezplatform.session.handler_id', 'ezplatform.core.session.handler.native_redis');
+                $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+            }
+        }
+
+        if (isset($relationships['solr'])) {
+            foreach ($relationships['solr'] as $endpoint) {
+                if ($endpoint['scheme'] !== 'solr') {
+                    continue;
+                }
+
+                $container->setParameter('search_engine', 'solr');
+
+                $container->setParameter('solr_dsn', sprintf('http://%s:%d/%s', $endpoint['host'], $endpoint['port'], 'solr'));
+                // To set solr_core parameter we assume path is in form like: "solr/collection1"
+                $container->setParameter('solr_core', substr($endpoint['path'], 5));
+
+                // Ibexa DXP Commerce needs special treatment due to Solarium use
+                // @todo Remove this once Commerce is fully rewritten
+                $bundles = $container->getParameter('kernel.bundles');
+
+                if (isset($bundles['IbexaCommerceSearchBundle'])) {
+                    $container->setParameter('solr_dsn', sprintf('http://%s:%d', $endpoint['host'], $endpoint['port']));
+                    // To set solr_core parameter we assume path is in form like: "solr/collection1"
+                    $container->setParameter('solr_core', substr($endpoint['path'], 5));
+
+                    $container->setParameter('siso_search.solr.host', $endpoint['host']);
+                    $container->setParameter('siso_search.solr.port', $endpoint['port']);
+                    $container->setParameter('siso_search.solr.core', $endpoint['rel']);
+                }
+            }
+        }
+
+        if (isset($relationships['elasticsearch'])) {
+            foreach ($relationships['elasticsearch'] as $endpoint) {
+                $dsn = sprintf('%s:%d', $endpoint['host'], $endpoint['port']);
+
+                if ($endpoint['username'] !== null && $endpoint['password'] !== null) {
+                    $dsn = $endpoint['username'] . ':' . $endpoint['password'] . '@' . $dsn;
+                }
+
+                if ($endpoint['path'] !== null) {
+                    $dsn .= '/' . $endpoint['path'];
+                }
+
+                $dsn = $endpoint['scheme'] . '://' . $dsn;
+
+                $container->setParameter('search_engine', 'elasticsearch');
+                $container->setParameter('elasticsearch_dsn', $dsn);
+            }
+        }
+
+        // We will pick a varnish route by the following prioritization:
+        // - The first route found that has upstream: varnish
+        // - if primary route has upstream: varnish, that route will be prioritised
+        // If no route is found with upstream: varnish, then purge_server will not be set
+        $route = null;
+        foreach ($routes as $host => $info) {
+            if ($route === null && $info['type'] === 'upstream' && $info['upstream'] === 'varnish') {
+                $route = $host;
+            }
+            if ($info['type'] === 'upstream' && $info['upstream'] === 'varnish' && $info['primary'] === true) {
+                $route = $host;
+                break;
+            }
+        }
+
+        if ($route !== null && !($_SERVER['SKIP_HTTPCACHE_PURGE'] ?? false)) {
+            $purgeServer = rtrim($route, '/');
+            if (($_SERVER['HTTPCACHE_USERNAME'] ?? false) && ($_SERVER['HTTPCACHE_PASSWORD'] ?? false)) {
+                $domain = parse_url($purgeServer, PHP_URL_HOST);
+                $credentials = urlencode($_SERVER['HTTPCACHE_USERNAME']) . ':' . urlencode($_SERVER['HTTPCACHE_PASSWORD']);
+                $purgeServer = str_replace($domain, $credentials . '@' . $domain, $purgeServer);
+            }
+
+            $container->setParameter('ezpublish.http_cache.purge_type', 'varnish');
+            $container->setParameter('purge_type', 'varnish');
+            $container->setParameter('purge_server', $purgeServer);
+        }
+        // Setting default value for HTTPCACHE_VARNISH_INVALIDATE_TOKEN if it is not explicitly set
+        if (!($_SERVER['HTTPCACHE_VARNISH_INVALIDATE_TOKEN'] ?? false)) {
+            $container->setParameter('varnish_invalidate_token', $_SERVER['PLATFORM_PROJECT_ENTROPY']);
+        }
+
+        // Adapt config based on enabled PHP extensions
+        // Get imagine to use imagick if enabled, to avoid using php memory for image conversions
+        if (\extension_loaded('imagick')) {
+            $container->setParameter('liip_imagine_driver', 'imagick');
+        }
     }
 }
 

--- a/src/bundle/Core/IbexaCoreBundle.php
+++ b/src/bundle/Core/IbexaCoreBundle.php
@@ -12,6 +12,7 @@ use Ibexa\Bundle\Core\DependencyInjection\Compiler\ConsoleCommandPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\EntityManagerFactoryServiceLocatorPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\FieldTypeParameterProviderRegistryPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\FragmentPass;
+use Ibexa\Bundle\Core\DependencyInjection\Compiler\SessionConfigurationPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\ViewMatcherRegistryPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\InjectEntityManagerMappingsPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\LazyDoctrineRepositoriesPass;
@@ -83,6 +84,8 @@ class IbexaCoreBundle extends Bundle
         $container->addCompilerPass(new LazyDoctrineRepositoriesPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new EntityManagerFactoryServiceLocatorPass());
         $container->addCompilerPass(new InjectEntityManagerMappingsPass());
+        $container->addCompilerPass(new SessionConfigurationPass());
+
 
         // Storage passes
         $container->addCompilerPass(new ExternalStorageRegistryPass());

--- a/src/bundle/Core/IbexaCoreBundle.php
+++ b/src/bundle/Core/IbexaCoreBundle.php
@@ -86,7 +86,6 @@ class IbexaCoreBundle extends Bundle
         $container->addCompilerPass(new InjectEntityManagerMappingsPass());
         $container->addCompilerPass(new SessionConfigurationPass());
 
-
         // Storage passes
         $container->addCompilerPass(new ExternalStorageRegistryPass());
         // Legacy Storage passes

--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -252,3 +252,10 @@ parameters:
     # Siteaccess aware Entity Manager
     ##
     ibexa.orm.entity_mappings: []
+
+    ibexa.platform.io.nfs.adapter.config:
+        root: './'
+        path: '$var_dir$/$storage_dir$/'
+        writeFlags: ~
+        linkHandling: ~
+        permissions: [ ]

--- a/tests/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPassTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Compiler;
+
+use Ibexa\Bundle\Core\DependencyInjection\Compiler\SessionConfigurationPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory;
+
+class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new SessionConfigurationPass());
+    }
+
+    public function testCompilesWithoutStorageDefinitions(): void
+    {
+        $this->assertContainerBuilderNotHasService('session.storage.native');
+        $this->assertContainerBuilderNotHasService('session.storage.php_bridge');
+        $this->assertContainerBuilderNotHasService('session.storage.factory.native');
+        $this->assertContainerBuilderNotHasService('session.storage.factory.php_bridge');
+
+        $this->doCompile();
+    }
+
+    public function testCompileUsingStorageFactory(): void
+    {
+        $this->container->setDefinition(
+            'session.storage.factory.native',
+            (new Definition())->setArguments([null, null, null])
+        );
+        $this->container->setDefinition(
+            'session.storage.factory.php_bridge',
+            (new Definition())->setArguments([null, null])
+        );
+
+        $this->doCompile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.factory.native',
+            1,
+            new Reference('session.handler')
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.factory.php_bridge',
+            0,
+            new Reference('session.handler')
+        );
+    }
+
+    public function testCompileUsingStorage(): void
+    {
+        $this->container->setDefinition(
+            'session.storage.native',
+            (new Definition())->setArguments([null, null, null])
+        );
+        $this->container->setDefinition(
+            'session.storage.php_bridge',
+            (new Definition())->setArguments([null, null])
+        );
+
+        $this->doCompile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.native',
+            1,
+            new Reference('session.handler')
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'session.storage.php_bridge',
+            0,
+            new Reference('session.handler')
+        );
+    }
+
+    private function doCompile(): void
+    {
+        $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
+        $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('session.handler', 'my_handler');
+        $this->assertContainerBuilderHasParameter('session.save_path', 'my_save_path');
+    }
+
+    public function testCompileWithDsn(): void
+    {
+        $dsn = 'redis://instance.local:1234';
+
+        $definition = new Definition(AbstractSessionHandler::class);
+        $definition->setFactory([SessionHandlerFactory::class, 'createHandler']);
+        $definition->setArguments([$dsn]);
+
+        $this->container->setDefinition('session.abstract_handler', $definition);
+        $this->container->setParameter('ezplatform.session.handler_id', $dsn);
+        $this->container->setDefinition(
+            'session.storage.native',
+            (new Definition())->setArguments([null, null, null])
+        );
+        $this->container->setDefinition(
+            'session.storage.php_bridge',
+            (new Definition())->setArguments([null, null])
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('session.handler', 'session.abstract_handler');
+    }
+
+    public function testCompileWithNullValues(): void
+    {
+        $this->container->setParameter('ezplatform.session.handler_id', null);
+        $this->container->setParameter('ezplatform.session.save_path', null);
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('session.handler');
+        self::assertNotTrue($this->container->hasParameter('session.save_path'));
+    }
+}

--- a/tests/bundle/Core/DependencyInjection/Fixtures/parameters.yml
+++ b/tests/bundle/Core/DependencyInjection/Fixtures/parameters.yml
@@ -1,2 +1,3 @@
 parameters:
     kernel.environment: unit
+    kernel.project_dir: '.'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1466](https://issues.ibexa.co/browse/IBX-1466)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

The PR "merges" in parts of EzPlatformCoreBundle that now belong to IbexaCoreBundle (and Extension).


The methods:
* `\Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension::configureGenericSetup`
* `\Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension::configurePlatformShSetup`
are almost direct copy-paste of those in `EzPlatformCoreBundle`. They definitely need to be refactored later on, but it's out of scope here.

#### Documentation

The whole section

```php
        /** @Deprecated since 3.3, to be removed in 4.0, use symfony semantic configuration instead of ENVs */
        if (!$container->hasParameter('kernel.trusted_proxies')
            && !$container->hasParameter('kernel.trusted_headers')
            && $value = $_SERVER['TRUSTED_PROXIES'] ?? false
        ) {
            $container->setParameter('kernel.trusted_proxies', $value);
            $container->setParameter('kernel.trusted_headers', Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
        }

        if (!$container->hasParameter('kernel.trusted_hosts') && $value = $_SERVER['TRUSTED_HOSTS'] ?? false) {
            $container->setParameter('kernel.trusted_hosts', $value);
        }
```
has been dropped while moving the code. Essentially environment variables setting trusted proxies (`TRUSTED_PROXIES`, `TRUSTED_HOSTS`) are no longer handled. Symfony [semantic configuration](https://symfony.com/doc/current/deployment/proxies.html#solution-settrustedproxies) needs to be used instead.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
