### PR TITLE
IBX-1308: Fixed system flag persistence while creating content type group

### DIFF
--- a/src/lib/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -154,6 +154,10 @@ final class DoctrineDatabase extends Gateway
                         $group->identifier,
                         ParameterType::STRING
                     ),
+                    'is_system' => $query->createPositionalParameter(
+                        $group->isSystem ?? false,
+                        ParameterType::BOOLEAN
+                    ),
                 ]
             );
         $query->execute();

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -121,9 +121,12 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
             $group
         );
 
+        // Sleep to avoid in-memory cache
+        sleep(1);
+
         return [
             'createStruct' => $groupCreate,
-            'group' => $group,
+            'group' => $contentTypeService->loadContentTypeGroup($group->id),
         ];
     }
 

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -121,12 +121,11 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
             $group
         );
 
-        // Sleep to avoid in-memory cache
-        sleep(1);
+        $reloadedGroup = $contentTypeService->loadContentTypeGroup($group->id);
 
         return [
             'createStruct' => $groupCreate,
-            'group' => $contentTypeService->loadContentTypeGroup($group->id),
+            'group' => $reloadedGroup,
         ];
     }
 

--- a/tests/integration/Core/Resources/settings/override.yml
+++ b/tests/integration/Core/Resources/settings/override.yml
@@ -7,3 +7,5 @@ parameters:
         - eng-US
         - eng-GB
         - ger-DE
+
+    ezpublish.spi.persistence.cache.inmemory.ttl: 0


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1308](https://issues.ibexa.co/browse/IBX-1308)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

`is_system` flag was not persisted into database during content type group create.

#### Why integration tests didn't detect issue ?

Assertions are made on VO created from create struct: https://github.com/ibexa/core/blob/c902f2a38888367018bce45f739e63a3d6c10cdc/src/lib/Persistence/Legacy/Content/Type/Handler.php#L65-L76 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
