### PR TITLE
IBX-88: [Rebranding] Renamed ezpublish extension to ibexa

### DIFF
--- a/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
+++ b/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
@@ -44,7 +44,7 @@ class RepositoryConfigurationProvider
 
         if (empty($repositoryAlias) || !isset($this->repositories[$repositoryAlias])) {
             throw new InvalidRepositoryException(
-                "Undefined Repository '$repositoryAlias'. Check if the Repository is configured in ezpublish_*.yml."
+                "Undefined Repository '$repositoryAlias'. Check if the Repository is configured in your project's ibexa.yaml."
             );
         }
 

--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -74,7 +74,7 @@ However, you can also manually set <comment>--scope[=NAME]</comment> yourself if
 set by the system. You can also override the namespace to get something other than the default "ezsettings" namespace by using
 the <comment>--namespace[=NS]</comment> option.
 
-NOTE: To see *all* compiled SiteAccess settings, use: <comment>debug:config ezpublish [system.default]</comment>
+NOTE: To see *all* compiled SiteAccess settings, use: <comment>debug:config ibexa [system.default]</comment>
 
 EOM
         );

--- a/src/bundle/Core/DependencyInjection/Configuration.php
+++ b/src/bundle/Core/DependencyInjection/Configuration.php
@@ -408,7 +408,7 @@ EOT;
      *
      * The configuration is available at:
      * <code>
-     * ezpublish:
+     * ibexa:
      *     url_alias:
      *         slug_converter:
      *             transformation: name_of_transformation_group_to_use
@@ -455,7 +455,7 @@ EOT;
      *
      * The configuration is available at:
      * <code>
-     * ezpublish:
+     * ibexa:
      *     url_wildcards:
      *         enabled: true
      * </code>
@@ -484,7 +484,7 @@ EOT;
      *
      * The configuration is available at:
      * <code>
-     * ezpublish:
+     * ibexa:
      *     orm:
      *         entity_mappings:
      *              IbexaCoreBundle:

--- a/src/bundle/Core/DependencyInjection/Configuration.php
+++ b/src/bundle/Core/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration extends SiteAccessConfiguration
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('ezpublish');
+        $treeBuilder = new TreeBuilder('ibexa');
 
         $rootNode = $treeBuilder->getRootNode();
 

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Common.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Common.php
@@ -24,16 +24,16 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
     /**
      * Adds semantic configuration definition.
      *
-     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ibexa.system.<siteaccess>
      */
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {
         $nodeBuilder
-            ->scalarNode('repository')->info('The repository to use. Choose among ezpublish.repositories.')->end()
+            ->scalarNode('repository')->info('The repository to use. Choose among ibexa.repositories.')->end()
             // @deprecated
-            // Use ezpublish.repositories / repository settings instead.
+            // Use ibexa.repositories / repository settings instead.
             ->arrayNode('database')
-                ->info('DEPRECATED. Use ezpublish.repositories / repository settings instead.')
+                ->info('DEPRECATED. Use ibexa.repositories / repository settings instead.')
                 ->children()
                     ->enumNode('type')->values(['mysql', 'pgsql', 'sqlite'])->info('The database driver. Can be mysql, pgsql or sqlite.')->end()
                     ->scalarNode('server')->end()
@@ -118,7 +118,7 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
                 ->info('Settings related to Http cache')
                 ->children()
                     ->arrayNode('purge_servers')
-                        ->info('Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')
+                        ->info('Servers to use for Http PURGE (will NOT be used if ibexa.http_cache.purge_type is "local").')
                         ->example(['http://localhost/', 'http://another.server/'])
                         ->requiresAtLeastOneElement()
                         ->prototype('scalar')->end()
@@ -232,11 +232,11 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
     {
         $suggestion = new ConfigSuggestion(
 <<<EOT
-Database configuration has changed for eZ Content repository.
+Database configuration has changed for Ibexa Content repository.
 Please define:
- - An entry in ezpublish.repositories
+ - An entry in ibexa.repositories
  - A Doctrine connection (You may check configuration reference for Doctrine "config:dump-reference doctrine" console command.)
- - A reference to configured repository in ezpublish.system.$sa.repository
+ - A reference to configured repository in ibexa.system.$sa.repository
 EOT
         );
         $suggestion->setMandatory(true);
@@ -278,7 +278,7 @@ EOT
                         ],
                     ],
                 ],
-                'ezpublish' => [
+                'ibexa' => [
                     'repositories' => [
                         'my_repository' => [
                             'storage' => [

--- a/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/Configuration.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/Configuration.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * Key is the context name.
  *
  * <code>
- * ezpublish:
+ * ibexa:
  *     system:
  *         eng:
  *             languages:

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -78,7 +78,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
     public function getAlias()
     {
-        return 'ezpublish';
+        return 'ibexa';
     }
 
     /**

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -508,8 +508,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
      * ```php
      * public function build(ContainerBuilder $container)
      * {
-     *     $ezExtension = $container->getExtension('ezpublish');
-     *     $ezExtension->addPolicyProvider($myPolicyProvider);
+     *     $ibexaExtension = $container->getExtension('ibexa');
+     *     $ibexaExtension->addPolicyProvider($myPolicyProvider);
      * }
      * ```
      *
@@ -529,8 +529,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
      * ```php
      * public function build(ContainerBuilder $container)
      * {
-     *     $ezExtension = $container->getExtension('ezpublish');
-     *     $ezExtension->addConfigParser($myConfigParser);
+     *     $ibexaExtension = $container->getExtension('ibexa');
+     *     $ibexaExtension->addConfigParser($myConfigParser);
      * }
      * ```
      *
@@ -555,8 +555,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
      * ```php
      * public function build(ContainerBuilder $container)
      * {
-     *     $ezExtension = $container->getExtension('ezpublish');
-     *     $ezExtension->addDefaultSettings(
+     *     $ibexaExtension = $container->getExtension('ibexa');
+     *     $ibexaExtension->addDefaultSettings(
      *         __DIR__ . '/Resources/config',
      *         ['default_settings.yml']
      *     );
@@ -614,10 +614,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
             return;
         }
 
-        $kernelConfigs = array_merge(
-            $container->getExtensionConfig('ezpublish'),
-            $container->getExtensionConfig('ezplatform')
-        );
+        $kernelConfigs = $container->getExtensionConfig('ibexa');
         $entityMappings = [];
 
         $repositoryConnections = [];

--- a/src/bundle/Core/Imagine/Filter/FilterConfiguration.php
+++ b/src/bundle/Core/Imagine/Filter/FilterConfiguration.php
@@ -33,8 +33,8 @@ class FilterConfiguration extends BaseFilterConfiguration
         $filterConfig = isset($this->filters[$filter]) ? parent::get($filter) : [];
 
         return [
-            'cache' => 'ezpublish',
-            'data_loader' => 'ezpublish',
+            'cache' => 'ibexa',
+            'data_loader' => 'ibexa',
             'reference' => isset($configuredVariations[$filter]['reference']) ? $configuredVariations[$filter]['reference'] : null,
             'filters' => $this->getVariationFilters($filter, $configuredVariations),
             'post_processors' => $this->getVariationPostProcessors($filter, $configuredVariations),

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -33,7 +33,7 @@ services:
         class: Ibexa\Bundle\Core\Imagine\BinaryLoader
         arguments: ["@ezpublish.fieldType.ezimage.io_service", "@mime_types"]
         tags:
-            - { name: liip_imagine.binary.loader, loader: ezpublish }
+            - { name: liip_imagine.binary.loader, loader: ibexa }
 
     ezpublish.image_alias.imagine.cache_resolver:
         class: Ibexa\Bundle\Core\Imagine\IORepositoryResolver
@@ -44,7 +44,7 @@ services:
             - "@ezpublish.image_alias.variation_purger"
             - "@ezpublish.image_alias.variation_path_generator"
         tags:
-            - { name: liip_imagine.cache.resolver, resolver: ezpublish }
+            - { name: liip_imagine.cache.resolver, resolver: ibexa }
 
     ezpublish.image_alias.imagine.cache_resolver_decorator_factory:
         class: Ibexa\Bundle\Core\Imagine\Cache\ResolverFactory

--- a/tests/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
@@ -413,7 +413,7 @@ class ContextualizerTest extends TestCase
 
     public function testGetSetNamespace()
     {
-        $ns = 'ezpublish';
+        $ns = 'ibexa';
         $this->assertSame($this->namespace, $this->contextualizer->getNamespace());
         $this->contextualizer->setNamespace($ns);
         $this->assertSame($ns, $this->contextualizer->getNamespace());

--- a/tests/bundle/Core/DependencyInjection/Configuration/Suggestion/Formatter/YamlSuggestionFormatterTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Suggestion/Formatter/YamlSuggestionFormatterTest.php
@@ -38,7 +38,7 @@ EOT;
                     ],
                 ],
             ],
-            'ezpublish' => [
+            'ibexa' => [
                 'repositories' => [
                     'my_repository' => ['engine' => 'legacy', 'connection' => 'default'],
                 ],
@@ -72,7 +72,7 @@ doctrine:
                 user: my_user
                 password: some_password
                 charset: UTF8
-ezpublish:
+ibexa:
     repositories:
         my_repository:
             engine: legacy

--- a/tests/bundle/Core/Imagine/Filter/FilterConfigurationTest.php
+++ b/tests/bundle/Core/Imagine/Filter/FilterConfigurationTest.php
@@ -102,8 +102,8 @@ class FilterConfigurationTest extends TestCase
 
         $this->assertSame(
             [
-                'cache' => 'ezpublish',
-                'data_loader' => 'ezpublish',
+                'cache' => 'ibexa',
+                'data_loader' => 'ibexa',
                 'reference' => null,
                 'filters' => $filters,
                 'post_processors' => [],
@@ -132,8 +132,8 @@ class FilterConfigurationTest extends TestCase
 
         $this->assertSame(
             [
-                'cache' => 'ezpublish',
-                'data_loader' => 'ezpublish',
+                'cache' => 'ibexa',
+                'data_loader' => 'ibexa',
                 'reference' => $reference,
                 'filters' => $filters,
                 'post_processors' => [],
@@ -160,8 +160,8 @@ class FilterConfigurationTest extends TestCase
 
         $this->assertSame(
             [
-                'cache' => 'ezpublish',
-                'data_loader' => 'ezpublish',
+                'cache' => 'ibexa',
+                'data_loader' => 'ibexa',
                 'reference' => $reference,
                 'filters' => $filters,
                 'post_processors' => [],
@@ -191,8 +191,8 @@ class FilterConfigurationTest extends TestCase
 
         $this->assertSame(
             [
-                'cache' => 'ezpublish',
-                'data_loader' => 'ezpublish',
+                'cache' => 'ibexa',
+                'data_loader' => 'ibexa',
                 'reference' => $reference,
                 'filters' => $filters,
                 'post_processors' => [],

--- a/tests/bundle/Core/Resources/config/ezpublish.yaml
+++ b/tests/bundle/Core/Resources/config/ezpublish.yaml
@@ -1,7 +1,7 @@
 parameters:
     env(SEARCH_ENGINE): 'legacy'
 
-ezpublish:
+ibexa:
     siteaccess:
           default_siteaccess: '__default_site_access__'
           list:

--- a/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
+++ b/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
@@ -79,8 +79,8 @@ class IbexaIOExtensionTest extends AbstractExtensionTestCase
             )
         );
         $this->container->prependExtensionConfig(
-            'ezpublish',
-            Yaml::parseFile(self::FIXTURES_DIR . '/url_prefix_test_config.yaml')['ezplatform']
+            'ibexa',
+            Yaml::parseFile(self::FIXTURES_DIR . '/url_prefix_test_config.yaml')['ibexa']
         );
         $this->buildMinimalContainerForUrlPrefixTest();
 

--- a/tests/bundle/IO/_fixtures/url_prefix_test_config.yaml
+++ b/tests/bundle/IO/_fixtures/url_prefix_test_config.yaml
@@ -1,4 +1,4 @@
-ezplatform:
+ibexa:
     siteaccess:
         list: [site]
         default_siteaccess: site

--- a/tests/lib/MVC/Symfony/Component/Serializer/HostElementNormalizerTest.php
+++ b/tests/lib/MVC/Symfony/Component/Serializer/HostElementNormalizerTest.php
@@ -24,14 +24,14 @@ final class HostElementNormalizerTest extends TestCase
 
         $matcher = new HostElement(2);
         // Set request and invoke match to initialize HostElement::$hostElements
-        $matcher->setRequest(SimplifiedRequest::fromUrl('http://ezpublish.dev/foo/bar'));
+        $matcher->setRequest(SimplifiedRequest::fromUrl('http://ibexa.dev/foo/bar'));
         $matcher->match();
 
         $this->assertEquals(
             [
                 'elementNumber' => 2,
                 'hostElements' => [
-                    'ezpublish',
+                    'ibexa',
                     'dev',
                 ],
             ],


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-88](https://issues.ibexa.co/browse/IBX-88)
| **Requires**                            | ibexa/compatibility-layer#3
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#3

Core change:
* https://github.com/ibexa/core/pull/21/commits/2a4537033b965eb054eda1bdf761dc9a6db9daaa

With Ibexa Compatibility Layer Bundle it should be enough to run a fresh project installation, without 1st party changes.

There are also other changes getting rid of extension-related (directly and not directly) strings containing `ezpublish`. The ones prepending config and changing suggestions format are necessary, the others are cosmetic.

Aiming to merge it quickly to unblock further work, with possible follow-ups if something comes up by future QA tests.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Aligned automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code
- [x] Asked for a review (ping `@ibexa/engineering`).
