### PR TITLE
IBX-1580: External storage for field type settings

### DIFF
--- a/src/contracts/FieldType/FieldConstraintsStorage.php
+++ b/src/contracts/FieldType/FieldConstraintsStorage.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\FieldType;
+
+use Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints;
+
+interface FieldConstraintsStorage
+{
+    public function storeFieldConstraintsData(
+        int $fieldDefinitionId,
+        FieldTypeConstraints $fieldTypeConstraints
+    );
+
+    public function getFieldConstraintsData(
+        int $fieldDefinitionId
+    ): FieldTypeConstraints;
+
+    public function deleteFieldConstraintsData(
+        int $fieldDefinitionId
+    ): void;
+}

--- a/src/contracts/FieldType/FieldConstraintsStorage.php
+++ b/src/contracts/FieldType/FieldConstraintsStorage.php
@@ -15,7 +15,7 @@ interface FieldConstraintsStorage
     public function storeFieldConstraintsData(
         int $fieldDefinitionId,
         FieldTypeConstraints $fieldTypeConstraints
-    );
+    ): void;
 
     public function getFieldConstraintsData(
         int $fieldDefinitionId

--- a/src/contracts/Persistence/Content/Type/Handler.php
+++ b/src/contracts/Persistence/Content/Type/Handler.php
@@ -261,7 +261,7 @@ interface Handler
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException If field is not found
      */
-    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId);
+    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null);
 
     /**
      * This method updates the given $fieldDefinition on a Type.

--- a/src/contracts/Persistence/Content/Type/Handler.php
+++ b/src/contracts/Persistence/Content/Type/Handler.php
@@ -261,7 +261,11 @@ interface Handler
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException If field is not found
      */
-    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null);
+    public function removeFieldDefinition(
+        int $contentTypeId,
+        int $status,
+        FieldDefinition $fieldDefinition
+    ): void;
 
     /**
      * This method updates the given $fieldDefinition on a Type.

--- a/src/lib/Persistence/Cache/ContentTypeHandler.php
+++ b/src/lib/Persistence/Cache/ContentTypeHandler.php
@@ -482,14 +482,21 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
     /**
      * {@inheritdoc}
      */
-    public function removeFieldDefinition($typeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null)
-    {
-        $this->logger->logCall(__METHOD__, ['type' => $typeId, 'status' => $status, 'field' => $fieldDefinitionId]);
+    public function removeFieldDefinition(
+        int $typeId,
+        int $status,
+        FieldDefinition $fieldDefinition
+    ): void {
+        $this->logger->logCall(__METHOD__, [
+            'type' => $typeId,
+            'status' => $status,
+            'field' => $fieldDefinition,
+        ]);
+
         $this->persistenceHandler->contentTypeHandler()->removeFieldDefinition(
             $typeId,
             $status,
-            $fieldDefinitionId,
-            $fieldTypeIdentifier
+            $fieldDefinition
         );
 
         if ($status === Type::STATUS_DEFINED) {

--- a/src/lib/Persistence/Cache/ContentTypeHandler.php
+++ b/src/lib/Persistence/Cache/ContentTypeHandler.php
@@ -482,13 +482,14 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
     /**
      * {@inheritdoc}
      */
-    public function removeFieldDefinition($typeId, $status, $fieldDefinitionId)
+    public function removeFieldDefinition($typeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null)
     {
         $this->logger->logCall(__METHOD__, ['type' => $typeId, 'status' => $status, 'field' => $fieldDefinitionId]);
         $this->persistenceHandler->contentTypeHandler()->removeFieldDefinition(
             $typeId,
             $status,
-            $fieldDefinitionId
+            $fieldDefinitionId,
+            $fieldTypeIdentifier
         );
 
         if ($status === Type::STATUS_DEFINED) {

--- a/src/lib/Persistence/Legacy/Content/Type/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Handler.php
@@ -557,9 +557,7 @@ class Handler implements BaseContentTypeHandler
      */
     public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null)
     {
-        if ($fieldTypeIdentifier === null) {
-            $fieldTypeIdentifier = $this->getFieldDefinition($fieldDefinitionId, $status)->fieldType;
-        }
+        $fieldTypeIdentifier ??= $this->getFieldDefinition($fieldDefinitionId, $status)->fieldType;
 
         $this->storageDispatcher->deleteFieldConstraintsData($fieldTypeIdentifier, $fieldDefinitionId);
         $this->contentTypeGateway->deleteFieldDefinition($contentTypeId, $status, $fieldDefinitionId);

--- a/src/lib/Persistence/Legacy/Content/Type/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Handler.php
@@ -330,6 +330,8 @@ class Handler implements BaseContentTypeHandler
                 $fieldDef,
                 $storageFieldDef
             );
+
+            $this->storageDispatcher->storeFieldConstraintsData($fieldDef);
         }
 
         return $contentType;
@@ -367,6 +369,16 @@ class Handler implements BaseContentTypeHandler
                 '$contentTypeId',
                 'Content Type with the given ID still has Content items and cannot be deleted'
             );
+        }
+
+        try {
+            $fieldDefinitions = $this->load($contentTypeId, $status)->fieldDefinitions;
+        } catch (Exception\TypeNotFound $e) {
+            $fieldDefinitions = [];
+        }
+
+        foreach ($fieldDefinitions as $fieldDefinition) {
+            $this->storageDispatcher->deleteFieldConstraintsData($fieldDefinition->fieldType, $fieldDefinition->id);
         }
 
         $this->contentTypeGateway->delete($contentTypeId, $status);

--- a/src/lib/Persistence/Legacy/Content/Type/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Handler.php
@@ -555,15 +555,21 @@ class Handler implements BaseContentTypeHandler
      *
      * @return bool
      */
-    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null)
-    {
-        $fieldTypeIdentifier ??= $this->getFieldDefinition($fieldDefinitionId, $status)->fieldType;
+    public function removeFieldDefinition(
+        int $contentTypeId,
+        int $status,
+        FieldDefinition $fieldDefinition
+    ): void {
+        $this->storageDispatcher->deleteFieldConstraintsData(
+            $fieldDefinition->fieldType,
+            $fieldDefinition->id
+        );
 
-        $this->storageDispatcher->deleteFieldConstraintsData($fieldTypeIdentifier, $fieldDefinitionId);
-        $this->contentTypeGateway->deleteFieldDefinition($contentTypeId, $status, $fieldDefinitionId);
-
-        // @todo FIXME: Return true only if deletion happened
-        return true;
+        $this->contentTypeGateway->deleteFieldDefinition(
+            $contentTypeId,
+            $status,
+            $fieldDefinition->id
+        );
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Type/Mapper.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Mapper.php
@@ -34,16 +34,22 @@ class Mapper
     /** @var \Ibexa\Core\Persistence\Legacy\Content\Language\MaskGenerator */
     private $maskGenerator;
 
+    private StorageDispatcherInterface $storageDispatcher;
+
     /**
      * Creates a new content type mapper.
      *
      * @param \Ibexa\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry
      * @param \Ibexa\Core\Persistence\Legacy\Content\Language\MaskGenerator $maskGenerator
      */
-    public function __construct(ConverterRegistry $converterRegistry, MaskGenerator $maskGenerator)
-    {
+    public function __construct(
+        ConverterRegistry $converterRegistry,
+        MaskGenerator $maskGenerator,
+        StorageDispatcherInterface $storageDispatcher
+    ) {
         $this->converterRegistry = $converterRegistry;
         $this->maskGenerator = $maskGenerator;
+        $this->storageDispatcher = $storageDispatcher;
     }
 
     /**
@@ -459,6 +465,8 @@ class Mapper
             $storageFieldDef,
             $fieldDef
         );
+
+        $this->storageDispatcher->loadFieldConstraintsData($fieldDef);
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -340,11 +340,13 @@ class MemoryCachingHandler implements BaseContentTypeHandler
     /**
      * {@inheritdoc}
      */
-    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null)
-    {
+    public function removeFieldDefinition(
+        int $contentTypeId,
+        int $status,
+        FieldDefinition $fieldDefinition
+    ): void {
         $this->deleteTypeCache($contentTypeId, $status);
-
-        return $this->innerHandler->removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, $fieldTypeIdentifier);
+        $this->innerHandler->removeFieldDefinition($contentTypeId, $status, $fieldDefinition);
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -340,11 +340,11 @@ class MemoryCachingHandler implements BaseContentTypeHandler
     /**
      * {@inheritdoc}
      */
-    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId)
+    public function removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, ?string $fieldTypeIdentifier = null)
     {
         $this->deleteTypeCache($contentTypeId, $status);
 
-        return $this->innerHandler->removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId);
+        return $this->innerHandler->removeFieldDefinition($contentTypeId, $status, $fieldDefinitionId, $fieldTypeIdentifier);
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Persistence\Legacy\Content\Type;
+
+use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
+
+final class StorageDispatcher implements StorageDispatcherInterface
+{
+    private StorageRegistryInterface $registry;
+
+    public function __construct(StorageRegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    public function storeFieldConstraintsData(FieldDefinition $fieldDefinition): void
+    {
+        if ($this->registry->hasStorage($fieldDefinition->fieldType)) {
+            $storage = $this->registry->getStorage($fieldDefinition->fieldType);
+            $storage->storeFieldConstraintsData($fieldDefinition->id, $fieldDefinition->fieldTypeConstraints);
+        }
+    }
+
+    public function loadFieldConstraintsData(FieldDefinition $fieldDefinition): void
+    {
+        if ($this->registry->hasStorage($fieldDefinition->fieldType)) {
+            $storage = $this->registry->getStorage($fieldDefinition->fieldType);
+
+            $fieldDefinition->fieldTypeConstraints = $storage->getFieldConstraintsData($fieldDefinition->id);
+        }
+    }
+
+    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $fieldDefinitionId): void
+    {
+        if ($this->registry->hasStorage($fieldTypeIdentifier)) {
+            $storage = $this->registry->getStorage($fieldTypeIdentifier);
+            $storage->deleteFieldConstraintsData($fieldDefinitionId);
+        }
+    }
+}

--- a/src/lib/Persistence/Legacy/Content/Type/StorageDispatcherInterface.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageDispatcherInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Persistence\Legacy\Content\Type;
+
+use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
+
+interface StorageDispatcherInterface
+{
+    public function storeFieldConstraintsData(FieldDefinition $fieldDefinition): void;
+
+    public function loadFieldConstraintsData(FieldDefinition $fieldDefinition): void;
+
+    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $fieldDefinitionId): void;
+}

--- a/src/lib/Persistence/Legacy/Content/Type/StorageRegistry.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageRegistry.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Persistence\Legacy\Content\Type;
+
+use Ibexa\Contracts\Core\Exception\InvalidArgumentException;
+use Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage;
+
+final class StorageRegistry implements StorageRegistryInterface
+{
+    /** @var iterable<string,\Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage> */
+    private iterable $storages;
+
+    public function __construct(iterable $storages)
+    {
+        $this->storages = $storages;
+    }
+
+    public function hasStorage(string $fieldTypeName): bool
+    {
+        return $this->findStorage($fieldTypeName) !== null;
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getStorage(string $fieldTypeName): FieldConstraintsStorage
+    {
+        $storage = $this->findStorage($fieldTypeName);
+        if ($storage === null) {
+            throw new InvalidArgumentException(
+                '$typeName',
+                sprintf('Undefined %s for "%s" field type', FieldConstraintsStorage::class, $fieldTypeName)
+            );
+        }
+
+        return $storage;
+    }
+
+    private function findStorage(string $needle): ?FieldConstraintsStorage
+    {
+        foreach ($this->storages as $fieldTypeName => $storage) {
+            if ($fieldTypeName === $needle) {
+                return $storage;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/lib/Persistence/Legacy/Content/Type/StorageRegistryInterface.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageRegistryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Persistence\Legacy\Content\Type;
+
+use Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage;
+
+interface StorageRegistryInterface
+{
+    public function hasStorage(string $fieldTypeName): bool;
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getStorage(string $fieldTypeName): FieldConstraintsStorage;
+}

--- a/src/lib/Repository/ContentTypeService.php
+++ b/src/lib/Repository/ContentTypeService.php
@@ -1383,7 +1383,8 @@ class ContentTypeService implements ContentTypeServiceInterface
             $this->contentTypeHandler->removeFieldDefinition(
                 $contentTypeDraft->id,
                 SPIContentType::STATUS_DRAFT,
-                $fieldDefinition->id
+                $fieldDefinition->id,
+                $fieldDefinition->fieldTypeIdentifier
             );
             $this->repository->commit();
         } catch (Exception $e) {

--- a/src/lib/Repository/ContentTypeService.php
+++ b/src/lib/Repository/ContentTypeService.php
@@ -1383,8 +1383,10 @@ class ContentTypeService implements ContentTypeServiceInterface
             $this->contentTypeHandler->removeFieldDefinition(
                 $contentTypeDraft->id,
                 SPIContentType::STATUS_DRAFT,
-                $fieldDefinition->id,
-                $fieldDefinition->fieldTypeIdentifier
+                $this->contentTypeHandler->getFieldDefinition(
+                    $fieldDefinition->id,
+                    SPIContentType::STATUS_DRAFT
+                ),
             );
             $this->repository->commit();
         } catch (Exception $e) {

--- a/src/lib/Resources/settings/storage_engines/legacy/content_type.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/content_type.yml
@@ -67,7 +67,7 @@ services:
 
     Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistry:
         arguments:
-            $storages: !tagged_iterator { tag: ibexa.field_type.external_constraints_storage, index_by: alias }
+            $storages: !tagged_iterator { tag: ibexa.field_type.storage.external.constraints.handler, index_by: alias }
 
     Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface:
         alias: Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcher

--- a/src/lib/Resources/settings/storage_engines/legacy/content_type.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/content_type.yml
@@ -20,6 +20,7 @@ services:
         arguments:
             - "@ezpublish.persistence.legacy.field_value_converter.registry"
             - '@ezpublish.persistence.legacy.language.mask_generator'
+            - '@Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface'
 
     ezpublish.persistence.legacy.content_type.content_updater:
         class: Ibexa\Core\Persistence\Legacy\Content\Type\ContentUpdater
@@ -49,6 +50,7 @@ services:
             - "@ezpublish.persistence.legacy.content_type.gateway"
             - "@ezpublish.persistence.legacy.content_type.mapper"
             - "@ezpublish.persistence.legacy.content_type.update_handler"
+            - '@Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface'
 
     ezpublish.spi.persistence.legacy.content_type.handler.caching:
         class: Ibexa\Core\Persistence\Legacy\Content\Type\MemoryCachingHandler
@@ -59,3 +61,17 @@ services:
 
     ezpublish.spi.persistence.legacy.content_type.handler:
         alias: ezpublish.spi.persistence.legacy.content_type.handler.caching
+
+    Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistryInterface:
+        alias: Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistry
+
+    Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistry:
+        arguments:
+            $storages: !tagged_iterator { tag: ibexa.field_type.external_constraints_storage, index_by: alias }
+
+    Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface:
+        alias: Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcher
+
+    Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcher:
+        arguments:
+            $registry: '@Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistryInterface'

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/FieldConstraintsStorageTest.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/FieldConstraintsStorageTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage;
+
+use Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints;
+use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeCreateStruct;
+use Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldConstraintsStorage;
+use Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldType;
+use Ibexa\Tests\Integration\Core\Repository\BaseTest;
+
+final class FieldConstraintsStorageTest extends BaseTest
+{
+    private const EXAMPLE_FIELD_IDENTIFIER = 'example';
+
+    private const EXAMPLE_FIELD_SETTINGS = [
+        'format' => 'AAA-000-99',
+    ];
+
+    private const EXAMPLE_FIELD_SETTINGS_UPDATED = [
+        'format' => 'aaa-999-00',
+    ];
+
+    private const EXAMPLE_VALIDATOR_CONFIGURATION = [
+        'StringLengthValidator' => [
+            'minStringLength' => 3,
+            'maxStringLength' => 10,
+        ],
+    ];
+
+    private const EXAMPLE_VALIDATOR_CONFIGURATION_UPDATED = [
+        'StringLengthValidator' => [
+            'minStringLength' => 5,
+            'maxStringLength' => 16,
+        ],
+    ];
+
+    public function testStorageDataIsCreatedOnContentTypeCreate(): ContentType
+    {
+        $repository = $this->getRepository();
+
+        $contentTypeService = $repository->getContentTypeService();
+        $permissionResolver = $repository->getPermissionResolver();
+
+        $fieldDefCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct(
+            self::EXAMPLE_FIELD_IDENTIFIER,
+            ExampleFieldType::FIELD_TYPE_IDENTIFIER
+        );
+
+        $fieldDefCreateStruct->names = ['eng-GB' => 'Example'];
+        $fieldDefCreateStruct->descriptions = [
+            'eng-GB' => 'Example field with external storage for field constraints',
+        ];
+        $fieldDefCreateStruct->fieldSettings = self::EXAMPLE_FIELD_SETTINGS;
+        $fieldDefCreateStruct->validatorConfiguration = self::EXAMPLE_VALIDATOR_CONFIGURATION;
+
+        $contentTypeCreateStruct = $this->createTypeCreateStruct($contentTypeService, $permissionResolver);
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefCreateStruct);
+
+        $contentType = $contentTypeService->createContentType($contentTypeCreateStruct, [
+            $contentTypeService->loadContentTypeGroupByIdentifier('Content'),
+        ]);
+
+        $contentTypeService->publishContentTypeDraft($contentType);
+
+        $actualFieldTypeConstraints = $this
+            ->getExampleFieldConstraintsStorage()
+            ->getFieldConstraintsDataIfAvailable(
+                $contentType->getFieldDefinition(self::EXAMPLE_FIELD_IDENTIFIER)->id
+            );
+
+        self::assertEquals(
+            new FieldTypeConstraints(
+                [
+                    'fieldSettings' => self::EXAMPLE_FIELD_SETTINGS,
+                    'validators' => self::EXAMPLE_VALIDATOR_CONFIGURATION,
+                ]
+            ),
+            $actualFieldTypeConstraints
+        );
+
+        return $contentTypeService->loadContentTypeByIdentifier($contentType->identifier);
+    }
+
+    /**
+     * @depends Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\FieldConstraintsStorageTest::testStorageDataIsCreatedOnContentTypeCreate
+     */
+    public function testStorageDataIsUpdatedOnContentTypeUpdate(ContentType $contentType): ContentType
+    {
+        $repository = $this->getRepository(false);
+
+        $contentTypeService = $repository->getContentTypeService();
+
+        $updateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
+        $updateStruct->fieldSettings = self::EXAMPLE_FIELD_SETTINGS_UPDATED;
+        $updateStruct->validatorConfiguration = self::EXAMPLE_VALIDATOR_CONFIGURATION_UPDATED;
+
+        $fieldDefinition = $contentType->getFieldDefinition(self::EXAMPLE_FIELD_IDENTIFIER);
+
+        $contentTypeDraft = $contentTypeService->createContentTypeDraft($contentType);
+        $contentTypeService->updateFieldDefinition($contentTypeDraft, $fieldDefinition, $updateStruct);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        $actualFieldTypeConstraints = $this
+            ->getExampleFieldConstraintsStorage()
+            ->getFieldConstraintsDataIfAvailable(
+                $contentType->getFieldDefinition(self::EXAMPLE_FIELD_IDENTIFIER)->id
+            );
+
+        self::assertEquals(
+            new FieldTypeConstraints(
+                [
+                    'fieldSettings' => self::EXAMPLE_FIELD_SETTINGS_UPDATED,
+                    'validators' => self::EXAMPLE_VALIDATOR_CONFIGURATION_UPDATED,
+                ]
+            ),
+            $actualFieldTypeConstraints
+        );
+
+        return $contentTypeService->loadContentTypeByIdentifier($contentType->identifier);
+    }
+
+    /**
+     * @depends Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\FieldConstraintsStorageTest::testStorageDataIsUpdatedOnContentTypeUpdate
+     */
+    public function testStorageDataIsDeletedOnContentTypeDelete(ContentType $contentType): void
+    {
+        $fieldDefinition = $contentType->getFieldDefinition(self::EXAMPLE_FIELD_IDENTIFIER);
+
+        $storage = $this->getExampleFieldConstraintsStorage();
+        self::assertTrue($storage->hasFieldConstraintsData($fieldDefinition->id));
+
+        $contentTypeService = $this->getRepository(false)->getContentTypeService();
+        $contentTypeService->deleteContentType($contentType);
+
+        self::assertFalse($storage->hasFieldConstraintsData($fieldDefinition->id));
+    }
+
+    private function createTypeCreateStruct(
+        ContentTypeService $contentTypeService,
+        PermissionResolver $permissionResolver
+    ): ContentTypeCreateStruct {
+        $creatorId = $this->generateId('user', $permissionResolver->getCurrentUserReference()->getUserId());
+
+        $typeCreateStruct = $contentTypeService->newContentTypeCreateStruct('field_constraints_storage_test');
+        $typeCreateStruct->mainLanguageCode = 'eng-GB';
+        $typeCreateStruct->names = ['eng-GB' => 'FieldConstraintsStorageTest'];
+        $typeCreateStruct->creatorId = $creatorId;
+        $typeCreateStruct->creationDate = $this->createDateTime();
+
+        return $typeCreateStruct;
+    }
+
+    private function getExampleFieldConstraintsStorage(): ExampleFieldConstraintsStorage
+    {
+        /** @var \Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldConstraintsStorage $storage */
+        $storage = $this->getSetupFactory()->getServiceContainer()->get(ExampleFieldConstraintsStorage::class);
+
+        return $storage;
+    }
+}

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub;
+
+use Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage;
+use Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints;
+
+/**
+ * Dummy in-memory implementation of \Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage.
+ */
+final class ExampleFieldConstraintsStorage implements FieldConstraintsStorage
+{
+    /** @var \Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints[] */
+    private array $fieldConstraints;
+
+    /**
+     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints[]
+     */
+    public function __construct(array $fieldConstraints = [])
+    {
+        $this->fieldConstraints = $fieldConstraints;
+    }
+
+    public function storeFieldConstraintsData(
+        int $fieldDefinitionId,
+        FieldTypeConstraints $fieldTypeConstraints
+    ): void {
+        $this->fieldConstraints[$fieldDefinitionId] = $fieldTypeConstraints;
+    }
+
+    public function hasFieldConstraintsData(
+        int $fieldDefinitionId
+    ): bool {
+        return isset($this->fieldConstraints[$fieldDefinitionId]);
+    }
+
+    public function getFieldConstraintsData(
+        int $fieldDefinitionId
+    ): FieldTypeConstraints {
+        return $this->fieldConstraints[$fieldDefinitionId];
+    }
+
+    public function getFieldConstraintsDataIfAvailable(
+        int $fieldDefinitionId
+    ): ?FieldTypeConstraints {
+        return $this->fieldConstraints[$fieldDefinitionId] ?? null;
+    }
+
+    public function deleteFieldConstraintsData(int $fieldDefinitionId): void
+    {
+        unset($this->fieldConstraints[$fieldDefinitionId]);
+    }
+}

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldType.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldType.php
@@ -43,6 +43,7 @@ final class ExampleFieldType extends FieldType
 
     protected function checkValueStructure(Value $value): void
     {
+        // Nothing to do here.
     }
 
     public function toHash(Value $value)
@@ -52,6 +53,7 @@ final class ExampleFieldType extends FieldType
 
     protected static function checkValueType($value): void
     {
+        // Nothing to do here.
     }
 
     public function validateFieldSettings($fieldSettings): array

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldType.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldType.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub;
+
+use Ibexa\Contracts\Core\FieldType\Value;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\Core\FieldType\FieldType;
+
+final class ExampleFieldType extends FieldType
+{
+    public const FIELD_TYPE_IDENTIFIER = 'example';
+
+    protected function createValueFromInput($inputValue): ExampleFieldTypeValue
+    {
+        return new ExampleFieldTypeValue();
+    }
+
+    public function getFieldTypeIdentifier(): string
+    {
+        return self::FIELD_TYPE_IDENTIFIER;
+    }
+
+    public function getName(Value $value, FieldDefinition $fieldDefinition, string $languageCode): string
+    {
+        return '';
+    }
+
+    public function getEmptyValue(): ExampleFieldTypeValue
+    {
+        return new ExampleFieldTypeValue();
+    }
+
+    public function fromHash($hash): ExampleFieldTypeValue
+    {
+        return new ExampleFieldTypeValue();
+    }
+
+    protected function checkValueStructure(Value $value): void
+    {
+    }
+
+    public function toHash(Value $value)
+    {
+        return null;
+    }
+
+    protected static function checkValueType($value): void
+    {
+    }
+
+    public function validateFieldSettings($fieldSettings): array
+    {
+        return [];
+    }
+
+    public function validateValidatorConfiguration($validatorConfiguration): array
+    {
+        return [];
+    }
+}

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldTypeValue.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldTypeValue.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub;
+
+use Ibexa\Core\FieldType\Value;
+
+final class ExampleFieldTypeValue extends Value
+{
+    public function __toString(): string
+    {
+        return '';
+    }
+}

--- a/tests/integration/Core/LegacyTestContainerBuilder.php
+++ b/tests/integration/Core/LegacyTestContainerBuilder.php
@@ -64,6 +64,7 @@ final class LegacyTestContainerBuilder extends ContainerBuilder
             new FileLocator([$settingsPath, __DIR__ . '/Resources/settings'])
         );
 
+        $loader->load('fieldtype_constraints_storage.yaml');
         $loader->load('fieldtype_external_storages.yml');
         $loader->load('fieldtype_services.yml');
         $loader->load('fieldtypes.yml');

--- a/tests/integration/Core/Resources/settings/fieldtype_constraints_storage.yaml
+++ b/tests/integration/Core/Resources/settings/fieldtype_constraints_storage.yaml
@@ -6,7 +6,7 @@ services:
     Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldConstraintsStorage:
         public: true
         tags:
-            - { name: ibexa.field_type.external_constraints_storage, alias: example }
+            - { name: ibexa.field_type.storage.external.constraints.handler, alias: example }
 
     ibexa.test.field_type.example.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter

--- a/tests/integration/Core/Resources/settings/fieldtype_constraints_storage.yaml
+++ b/tests/integration/Core/Resources/settings/fieldtype_constraints_storage.yaml
@@ -1,0 +1,14 @@
+services:
+    Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldType:
+        tags:
+            - { name: ezplatform.field_type, alias: example }
+
+    Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldConstraintsStorage:
+        public: true
+        tags:
+            - { name: ibexa.field_type.external_constraints_storage, alias: example }
+
+    ibexa.test.field_type.example.converter:
+        class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
+        tags:
+            - { name: ezplatform.field_type.legacy_storage.converter, alias: example }

--- a/tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
@@ -137,7 +137,7 @@ class ContentTypeHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['addFieldDefinition', [5, 1, new SPITypeFieldDefinition()]],
             [
                 'removeFieldDefinition',
-                [5, 0, 7],
+                [5, 0, new SPITypeFieldDefinition(['id' => 7])],
                 [
                     ['type', [5], false],
                     ['type_map', [], false],
@@ -146,7 +146,7 @@ class ContentTypeHandlerTest extends AbstractInMemoryCacheHandlerTest
                 null,
                 ['t-5', 'tm', 'cft-5'],
             ],
-            ['removeFieldDefinition', [5, 1, 7]],
+            ['removeFieldDefinition', [5, 1, new SPITypeFieldDefinition(['id' => 7])]],
             [
                 'updateFieldDefinition',
                 [5, 0, new SPITypeFieldDefinition()],

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -18,6 +18,7 @@ use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Gateway;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Handler;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Mapper;
+use Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Update\Handler as UpdateHandler;
 use Ibexa\Core\Persistence\Legacy\Exception;
 use PHPUnit\Framework\TestCase;
@@ -47,6 +48,9 @@ class ContentTypeHandlerTest extends TestCase
      * @var \Ibexa\Core\Persistence\Legacy\Content\Type\Update\Handler
      */
     protected $updateHandlerMock;
+
+    /** @var \Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
+    protected $storageDispatcherMock;
 
     public function testCreateGroup()
     {
@@ -107,7 +111,12 @@ class ContentTypeHandlerTest extends TestCase
 
         $handlerMock = $this->getMockBuilder(Handler::class)
             ->setMethods(['loadGroup'])
-            ->setConstructorArgs([$gatewayMock, $mapperMock, $this->getUpdateHandlerMock()])
+            ->setConstructorArgs([
+                $gatewayMock,
+                $mapperMock,
+                $this->getUpdateHandlerMock(),
+                $this->getStorageDispatcherMock(),
+            ])
             ->getMock();
 
         $handlerMock->expects($this->once())
@@ -515,7 +524,12 @@ class ContentTypeHandlerTest extends TestCase
 
         $handlerMock = $this->getMockBuilder(Handler::class)
             ->setMethods(['load'])
-            ->setConstructorArgs([$gatewayMock, $this->getMapperMock(), $this->getUpdateHandlerMock()])
+            ->setConstructorArgs([
+                $gatewayMock,
+                $this->getMapperMock(),
+                $this->getUpdateHandlerMock(),
+                $this->getStorageDispatcherMock(),
+            ])
             ->getMock();
 
         $handlerMock->expects($this->once())
@@ -604,7 +618,12 @@ class ContentTypeHandlerTest extends TestCase
 
         $handlerMock = $this->getMockBuilder(Handler::class)
             ->setMethods(['load', 'internalCreate'])
-            ->setConstructorArgs([$gatewayMock, $mapperMock, $this->getUpdateHandlerMock()])
+            ->setConstructorArgs([
+                $gatewayMock,
+                $mapperMock,
+                $this->getUpdateHandlerMock(),
+                $this->getStorageDispatcherMock(),
+            ])
             ->getMock();
 
         $handlerMock->expects($this->once())
@@ -651,7 +670,12 @@ class ContentTypeHandlerTest extends TestCase
 
         $handlerMock = $this->getMockBuilder(Handler::class)
             ->setMethods(['load', 'internalCreate', 'update'])
-            ->setConstructorArgs([$gatewayMock, $mapperMock, $this->getUpdateHandlerMock()])
+            ->setConstructorArgs([
+                $gatewayMock,
+                $mapperMock,
+                $this->getUpdateHandlerMock(),
+                $this->getStorageDispatcherMock(),
+            ])
             ->getMock();
 
         $userId = 42;
@@ -847,6 +871,12 @@ class ContentTypeHandlerTest extends TestCase
 
         $fieldDef = new FieldDefinition();
 
+        $storageDispatcherMock = $this->getStorageDispatcherMock();
+        $storageDispatcherMock
+            ->expects($this->once())
+            ->method('storeFieldConstraintsData')
+            ->with($fieldDef);
+
         $handler = $this->getHandler();
         $handler->addFieldDefinition(23, 1, $fieldDef);
 
@@ -877,6 +907,12 @@ class ContentTypeHandlerTest extends TestCase
 
     public function testRemoveFieldDefinition()
     {
+        $storageDispatcherMock = $this->getStorageDispatcherMock();
+        $storageDispatcherMock
+            ->expects($this->once())
+            ->method('deleteFieldConstraintsData')
+            ->with('ezstring', 42);
+
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())
             ->method('deleteFieldDefinition')
@@ -887,26 +923,21 @@ class ContentTypeHandlerTest extends TestCase
             );
 
         $handler = $this->getHandler();
-        $res = $handler->removeFieldDefinition(23, 1, 42);
+        $res = $handler->removeFieldDefinition(23, 1, 42, 'ezstring');
 
         $this->assertTrue($res);
     }
 
     public function testUpdateFieldDefinition()
     {
+        $fieldDef = new FieldDefinition();
+
         $mapperMock = $this->getMapperMock(
             ['toStorageFieldDefinition']
         );
         $mapperMock->expects($this->once())
             ->method('toStorageFieldDefinition')
-            ->with(
-                $this->isInstanceOf(
-                    FieldDefinition::class
-                ),
-                $this->isInstanceOf(
-                    StorageFieldDefinition::class
-                )
-            );
+            ->with($fieldDef, $this->isInstanceOf(StorageFieldDefinition::class));
 
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())
@@ -914,17 +945,17 @@ class ContentTypeHandlerTest extends TestCase
             ->with(
                 $this->equalTo(23),
                 $this->equalTo(1),
-                $this->isInstanceOf(
-                    FieldDefinition::class
-                )
+                $fieldDef
             );
 
-        $fieldDef = new FieldDefinition();
+        $storageDispatcherMock = $this->getStorageDispatcherMock();
+        $storageDispatcherMock
+            ->expects($this->once())
+            ->method('storeFieldConstraintsData')
+            ->with($fieldDef);
 
         $handler = $this->getHandler();
-        $res = $handler->updateFieldDefinition(23, 1, $fieldDef);
-
-        $this->assertNull($res);
+        $handler->updateFieldDefinition(23, 1, $fieldDef);
     }
 
     public function testPublish()
@@ -1012,7 +1043,8 @@ class ContentTypeHandlerTest extends TestCase
         return new Handler(
             $this->getGatewayMock(),
             $this->getMapperMock(),
-            $this->getUpdateHandlerMock()
+            $this->getUpdateHandlerMock(),
+            $this->getStorageDispatcherMock()
         );
     }
 
@@ -1032,6 +1064,7 @@ class ContentTypeHandlerTest extends TestCase
                     $this->getGatewayMock(),
                     $this->getMapperMock(),
                     $this->getUpdateHandlerMock(),
+                    $this->getStorageDispatcherMock(),
                 ]
             )
             ->getMock();
@@ -1090,6 +1123,18 @@ class ContentTypeHandlerTest extends TestCase
     }
 
     /**
+     * @return \Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    public function getStorageDispatcherMock(): StorageDispatcherInterface
+    {
+        if (!isset($this->storageDispatcherMock)) {
+            $this->storageDispatcherMock = $this->createMock(StorageDispatcherInterface::class);
+        }
+
+        return $this->storageDispatcherMock;
+    }
+
+    /**
      * Returns a CreateStruct fixture.
      *
      * @return \Ibexa\Contracts\Core\Persistence\Content\Type\CreateStruct
@@ -1132,7 +1177,12 @@ class ContentTypeHandlerTest extends TestCase
 
         $handlerMock = $this->getMockBuilder(Handler::class)
             ->setMethods(['load', 'update'])
-            ->setConstructorArgs([$this->getGatewayMock(), $mapperMock, $this->getUpdateHandlerMock()])
+            ->setConstructorArgs([
+                $this->getGatewayMock(),
+                $mapperMock,
+                $this->getUpdateHandlerMock(),
+                $this->getStorageDispatcherMock(),
+            ])
             ->getMock();
 
         $handlerMock->expects($this->once())

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -923,9 +923,7 @@ class ContentTypeHandlerTest extends TestCase
             );
 
         $handler = $this->getHandler();
-        $res = $handler->removeFieldDefinition(23, 1, 42, 'ezstring');
-
-        $this->assertTrue($res);
+        $handler->removeFieldDefinition(23, 1, new FieldDefinition(['id' => 42, 'fieldType' => 'ezstring']));
     }
 
     public function testUpdateFieldDefinition()

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -562,6 +562,11 @@ class ContentTypeHandlerTest extends TestCase
             $this->returnValue(0)
         );
 
+        $gatewayMock->expects($this->once())->method('loadTypeData')->with(23, 0)->willReturn([]);
+
+        $mapperMock = $this->getMapperMock();
+        $mapperMock->expects($this->once())->method('extractTypesFromRows')->with([])->willReturn([new Type()]);
+
         $gatewayMock->expects(
             $this->once()
         )->method(

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -935,7 +935,10 @@ class ContentTypeHandlerTest extends TestCase
         );
         $mapperMock->expects($this->once())
             ->method('toStorageFieldDefinition')
-            ->with($fieldDef, $this->isInstanceOf(StorageFieldDefinition::class));
+            ->with(
+                $this->identicalTo($fieldDef),
+                $this->isInstanceOf(StorageFieldDefinition::class)
+            );
 
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -49,7 +49,7 @@ class ContentTypeHandlerTest extends TestCase
      */
     protected $updateHandlerMock;
 
-    /** @var \Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface&\PHPUnit\Framework\MockObject\MockObject */
     protected $storageDispatcherMock;
 
     public function testCreateGroup()

--- a/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Persistence\Legacy\Content\Type;
+
+use Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage;
+use Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints;
+use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
+use Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcher;
+use Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class StorageDispatcherTest extends TestCase
+{
+    private const EXAMPLE_FIELD_DEFINITION_ID = 1;
+    private const EXAMPLE_FIELD_TYPE_IDENTIFIER = 'example_ft';
+
+    public function testStoreFieldConstraintsData(): void
+    {
+        $constraints = $this->createMock(FieldTypeConstraints::class);
+
+        $storage = $this->createMock(FieldConstraintsStorage::class);
+        $storage
+            ->expects($this->once())
+            ->method('storeFieldConstraintsData')
+            ->with(self::EXAMPLE_FIELD_DEFINITION_ID, $constraints);
+
+        $fieldDefinition = new FieldDefinition();
+        $fieldDefinition->fieldTypeConstraints = $constraints;
+        $fieldDefinition->id = self::EXAMPLE_FIELD_DEFINITION_ID;
+        $fieldDefinition->fieldType = self::EXAMPLE_FIELD_TYPE_IDENTIFIER;
+
+        $registry = $this->createStorageRegistryMockWithExternalStorage($storage);
+
+        $dispatcher = new StorageDispatcher($registry);
+        $dispatcher->storeFieldConstraintsData($fieldDefinition);
+    }
+
+    public function testStoreFieldConstraintsDataForNonSupportedFieldType(): void
+    {
+        $fieldDefinition = new FieldDefinition();
+        $fieldDefinition->id = self::EXAMPLE_FIELD_DEFINITION_ID;
+        $fieldDefinition->fieldType = self::EXAMPLE_FIELD_TYPE_IDENTIFIER;
+
+        $registry = $this->createStorageRegistryMockWithoutExternalStorage();
+
+        $dispatcher = new StorageDispatcher($registry);
+        $dispatcher->storeFieldConstraintsData($fieldDefinition);
+    }
+
+    public function testLoadFieldConstraintsData(): void
+    {
+        $constraints = $this->createMock(FieldTypeConstraints::class);
+
+        $storage = $this->createMock(FieldConstraintsStorage::class);
+        $storage
+            ->expects($this->once())
+            ->method('getFieldConstraintsData')
+            ->with(self::EXAMPLE_FIELD_DEFINITION_ID)
+            ->willReturn($constraints);
+
+        $fieldDefinition = new FieldDefinition();
+        $fieldDefinition->id = self::EXAMPLE_FIELD_DEFINITION_ID;
+        $fieldDefinition->fieldType = self::EXAMPLE_FIELD_TYPE_IDENTIFIER;
+
+        $registry = $this->createStorageRegistryMockWithExternalStorage($storage);
+
+        $dispatcher = new StorageDispatcher($registry);
+        $dispatcher->loadFieldConstraintsData($fieldDefinition);
+
+        self::assertSame(
+            $constraints,
+            $fieldDefinition->fieldTypeConstraints
+        );
+    }
+
+    public function testLoadFieldConstraintsDataForNonSupportedFieldType(): void
+    {
+        $constraints = $this->createMock(FieldTypeConstraints::class);
+
+        $fieldDefinition = new FieldDefinition();
+        $fieldDefinition->id = self::EXAMPLE_FIELD_DEFINITION_ID;
+        $fieldDefinition->fieldType = self::EXAMPLE_FIELD_TYPE_IDENTIFIER;
+        $fieldDefinition->fieldTypeConstraints = $constraints;
+
+        $registry = $this->createStorageRegistryMockWithoutExternalStorage();
+
+        $dispatcher = new StorageDispatcher($registry);
+        $dispatcher->loadFieldConstraintsData($fieldDefinition);
+
+        self::assertSame(
+            $constraints,
+            $fieldDefinition->fieldTypeConstraints
+        );
+    }
+
+    public function testDeleteFieldConstraintsData(): void
+    {
+        $storage = $this->createMock(FieldConstraintsStorage::class);
+        $storage
+            ->expects($this->once())
+            ->method('deleteFieldConstraintsData')
+            ->with(self::EXAMPLE_FIELD_DEFINITION_ID);
+
+        $registry = $this->createStorageRegistryMockWithExternalStorage($storage);
+
+        $dispatcher = new StorageDispatcher($registry);
+        $dispatcher->deleteFieldConstraintsData(
+            self::EXAMPLE_FIELD_TYPE_IDENTIFIER,
+            self::EXAMPLE_FIELD_DEFINITION_ID
+        );
+    }
+
+    public function testDeleteFieldConstraintsDataForNonSupportedFieldType(): void
+    {
+        $registry = $this->createStorageRegistryMockWithoutExternalStorage();
+
+        $dispatcher = new StorageDispatcher($registry);
+        $dispatcher->deleteFieldConstraintsData(
+            self::EXAMPLE_FIELD_TYPE_IDENTIFIER,
+            self::EXAMPLE_FIELD_DEFINITION_ID
+        );
+    }
+
+    private function createStorageRegistryMockWithoutExternalStorage(): StorageRegistryInterface
+    {
+        $registry = $this->createMock(StorageRegistryInterface::class);
+        $registry->method('hasStorage')->with(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)->willReturn(false);
+        $registry
+            ->expects($this->never())
+            ->method('getStorage')
+            ->with(self::EXAMPLE_FIELD_TYPE_IDENTIFIER);
+
+        return $registry;
+    }
+
+    private function createStorageRegistryMockWithExternalStorage(
+        FieldConstraintsStorage $storage
+    ): StorageRegistryInterface {
+        $registry = $this->createMock(StorageRegistryInterface::class);
+        $registry->method('hasStorage')->with(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)->willReturn(true);
+        $registry->method('getStorage')->with(self::EXAMPLE_FIELD_TYPE_IDENTIFIER)->willReturn($storage);
+
+        return $registry;
+    }
+}

--- a/tests/lib/Persistence/Legacy/Content/Type/StorageRegistryTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/StorageRegistryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Persistence\Legacy\Content\Type;
+
+use Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
+use Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class StorageRegistryTest extends TestCase
+{
+    public function testHasStorage(): void
+    {
+        $registry = new StorageRegistry([
+            'foo' => $this->createMock(FieldConstraintsStorage::class),
+            'bar' => $this->createMock(FieldConstraintsStorage::class),
+        ]);
+
+        self::assertTrue($registry->hasStorage('foo'));
+        self::assertTrue($registry->hasStorage('bar'));
+        // baz field type is not supported
+        self::assertFalse($registry->hasStorage('baz'));
+    }
+
+    public function testGetStorage(): void
+    {
+        $storages = [
+            'foo' => $this->createMock(FieldConstraintsStorage::class),
+            'bar' => $this->createMock(FieldConstraintsStorage::class),
+        ];
+
+        $registry = new StorageRegistry($storages);
+
+        self::assertSame($storages['foo'], $registry->getStorage('foo'));
+        self::assertSame($storages['bar'], $registry->getStorage('bar'));
+    }
+
+    public function testGetStorageForNonSupportedFieldType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Argument \'$typeName\' is invalid: Undefined Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage for "baz" field type');
+
+        $registry = new StorageRegistry([
+            'foo' => $this->createMock(FieldConstraintsStorage::class),
+            'bar' => $this->createMock(FieldConstraintsStorage::class),
+        ]);
+        $registry->getStorage('baz');
+    }
+}

--- a/tests/lib/Search/Legacy/Content/AbstractTestCase.php
+++ b/tests/lib/Search/Legacy/Content/AbstractTestCase.php
@@ -12,6 +12,7 @@ use Ibexa\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
+use Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
 use Ibexa\Tests\Core\Persistence\Legacy\Content\LanguageAwareTestCase;
 
@@ -82,10 +83,15 @@ class AbstractTestCase extends LanguageAwareTestCase
                 new ContentTypeGateway(
                     $this->getDatabaseConnection(),
                     $this->getSharedGateway(),
-                    $this->getLanguageMaskGenerator()
+                    $this->getLanguageMaskGenerator(),
                 ),
-                new ContentTypeMapper($this->getConverterRegistry(), $this->getLanguageMaskGenerator()),
-                $this->createMock(ContentTypeUpdateHandler::class)
+                new ContentTypeMapper(
+                    $this->getConverterRegistry(),
+                    $this->getLanguageMaskGenerator(),
+                    $this->createMock(StorageDispatcherInterface::class)
+                ),
+                $this->createMock(ContentTypeUpdateHandler::class),
+                $this->createMock(StorageDispatcherInterface::class)
             );
         }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1580](https://issues.ibexa.co/browse/IBX-1580)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Added extension point which allows o load field type settings from external source.

External storage for Field Type settings needs implement

```php
interface FieldConstraintsStorage
{
    public function storeFieldConstraintsData(
        int $fieldDefinitionId,
        FieldTypeConstraints $fieldTypeConstraints
    );

    public function getFieldConstraintsData(
        int $fieldDefinitionId
    ): FieldTypeConstraints;

    public function deleteFieldConstraintsData(
        int $fieldDefinitionId
    ): void;
}
```

and be registered as a service with tag `ibexa.field_type.external_constraints_storage` e.g.

```yaml
App\FieldType\Example\ExternalStorage:
    tags:
        - { name: ibexa.field_type.external_constraints_storage, alias: example }
```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Document removeFieldDefitnion signature change 
- [ ] Asked for a review (ping `@ibexa/engineering`).
