### PR TITLE
IBX-1589: Renamed remaining Core Extensions (IO, LSE)

### DIFF
--- a/src/bundle/IO/DependencyInjection/Configuration.php
+++ b/src/bundle/IO/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('ez_io');
+        $treeBuilder = new TreeBuilder(IbexaIOExtension::EXTENSION_NAME);
 
         $rootNode = $treeBuilder->getRootNode();
 

--- a/src/bundle/IO/DependencyInjection/IbexaIOExtension.php
+++ b/src/bundle/IO/DependencyInjection/IbexaIOExtension.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class IbexaIOExtension extends Extension
 {
+    public const EXTENSION_NAME = 'ibexa_io';
+
     /** @var \Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory[]|\ArrayObject */
     private $metadataHandlerFactories;
 
@@ -72,7 +74,7 @@ class IbexaIOExtension extends Extension
 
     public function getAlias()
     {
-        return 'ez_io';
+        return self::EXTENSION_NAME;
     }
 
     /**

--- a/src/bundle/LegacySearchEngine/DependencyInjection/IbexaLegacySearchEngineExtension.php
+++ b/src/bundle/LegacySearchEngine/DependencyInjection/IbexaLegacySearchEngineExtension.php
@@ -15,7 +15,7 @@ class IbexaLegacySearchEngineExtension extends Extension
 {
     public function getAlias()
     {
-        return 'ez_search_engine_legacy';
+        return 'ibexa_legacy_search_engine';
     }
 
     public function load(array $configs, ContainerBuilder $container)


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#5

- [x] IBX-1589: Renamed Extension ez_search_engine_legacy to ibexa_legacy_search_engine
- [x] IBX-1589: Renamed Extension ez_io to ibexa_io

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // full stack Behat coverage
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review
