### PR TITLE
Merge IBX-1182: Added cache invalidation to liip:imagine:cache:remove command

### DIFF
--- a/src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
@@ -129,6 +129,11 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
             $this->cacheIdentifierGenerator->generateTag(self::CONTENT_VERSION_IDENTIFIER, [$contentId, $versionInfo->versionNo]),
         ];
     }
+
+    public function getVariationNameTag(): string
+    {
+        return self::IMAGE_VARIATION_NAME_IDENTIFIER;
+    }
 }
 
 class_alias(AliasGeneratorDecorator::class, 'eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator');

--- a/src/bundle/Core/Imagine/VariationPurger/IOVariationPurger.php
+++ b/src/bundle/Core/Imagine/VariationPurger/IOVariationPurger.php
@@ -28,7 +28,7 @@ class IOVariationPurger implements VariationPurger
     /** @var \Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface */
     private $cacheIdentifierGenerator;
 
-    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator */
+    /** @var \Ibexa\Bundle\Core\Imagine\Cache\AliasGeneratorDecorator */
     private $aliasGeneratorDecorator;
 
     /** @var \Psr\Log\LoggerInterface */

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -244,8 +244,11 @@ services:
     ezpublish.image_alias.variation_purger.io:
         class: Ibexa\Bundle\Core\Imagine\VariationPurger\IOVariationPurger
         arguments:
-            - "@ezpublish.fieldType.ezimage.io_service"
-            - "@ezpublish.image_alias.variation_path_generator.alias_directory"
+            - '@ezpublish.fieldType.ezimage.io_service'
+            - '@ezpublish.cache_pool'
+            - '@Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface'
+            - '@ezpublish.image_alias.imagine.cache.alias_generator_decorator'
+            - '@ezpublish.image_alias.variation_path_generator.alias_directory'
         calls:
             - [setLogger, ["@?logger"]]
 

--- a/tests/bundle/Core/Imagine/VariationPurger/IOVariationPurgerTest.php
+++ b/tests/bundle/Core/Imagine/VariationPurger/IOVariationPurgerTest.php
@@ -6,23 +6,56 @@
  */
 namespace Ibexa\Tests\Bundle\Core\Imagine\VariationPurger;
 
+use Ibexa\Bundle\Core\Imagine\Cache\AliasGeneratorDecorator;
 use Ibexa\Bundle\Core\Imagine\VariationPurger\IOVariationPurger;
 use Ibexa\Core\IO\IOServiceInterface;
+use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
 class IOVariationPurgerTest extends TestCase
 {
-    public function testPurgesAliasList()
+    public function testPurgesAliasList(): void
     {
         $ioService = $this->createMock(IOServiceInterface::class);
+        $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
+        $cacheIdentifierGenerator = $this->createMock(CacheIdentifierGeneratorInterface::class);
+        $aliasGeneratorDecorator = $this->createMock(AliasGeneratorDecorator::class);
+
+        $aliasGeneratorDecorator
+            ->expects(self::once())
+            ->method('getVariationNameTag')
+            ->willReturn('image_variation_name');
         $ioService
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('deleteDirectory')
             ->withConsecutive(
                 ['_aliases/medium'],
                 ['_aliases/large']
             );
-        $purger = new IOVariationPurger($ioService);
+        $cacheIdentifierGenerator
+            ->expects(self::exactly(2))
+            ->method('generateTag')
+            ->withConsecutive(
+                ['image_variation_name', ['medium']],
+                ['image_variation_name', ['large']]
+            )
+            ->willReturnOnConsecutiveCalls('ign-medium', 'ign-large');
+        $tagAwareAdapter
+            ->expects(self::exactly(2))
+            ->method('invalidateTags')
+            ->withConsecutive(
+                [['ign-medium']],
+                [['ign-large']]
+            );
+
+        $purger = new IOVariationPurger(
+            $ioService,
+            $tagAwareAdapter,
+            $cacheIdentifierGenerator,
+            $aliasGeneratorDecorator
+        );
+
         $purger->purge(['medium', 'large']);
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1182](https://issues.ibexa.co/browse/IBX-1182)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Parent PR: https://github.com/ezsystems/ezpublish-kernel/pull/3130