### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
         "phpstan/phpstan": "^1.2"
     },
     "conflict": {
+        "friendsofphp/php-cs-fixer": "3.5.0",
         "symfony/dependency-injection": "5.3.7",
         "symfony/security-core": "5.3.0",
         "doctrine/dbal": "2.7.0",

--- a/src/bundle/Core/ApiLoader/SearchEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/SearchEngineFactory.php
@@ -55,30 +55,33 @@ class SearchEngineFactory
 
     /**
      * Builds search engine identified by its identifier (the "alias" attribute in the service tag),
-     * resolved for current siteaccess.
-     *
-     * @return \Ibexa\Contracts\Core\Search\Handler
+     * resolved for current SiteAccess.
      *
      * @throws \Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine
      */
-    public function buildSearchEngine()
+    public function buildSearchEngine(): SearchHandler
     {
         $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
 
-        if (
-            !(
-                isset($repositoryConfig['search']['engine'])
-                && isset($this->searchEngines[$repositoryConfig['search']['engine']])
-            )
-        ) {
+        $searchEngineAlias = $repositoryConfig['search']['engine'] ?? null;
+        if (null === $searchEngineAlias) {
             throw new InvalidSearchEngine(
-                "Invalid search engine '{$repositoryConfig['search']['engine']}'. " .
-                "Could not find any service tagged with 'ezplatform.search_engine' " .
-                "with alias '{$repositoryConfig['search']['engine']}'."
+                sprintf(
+                    'Ibexa "%s" Repository has no Search Engine configured',
+                    $this->repositoryConfigurationProvider->getCurrentRepositoryAlias()
+                )
             );
         }
 
-        return $this->searchEngines[$repositoryConfig['search']['engine']];
+        if (!isset($this->searchEngines[$searchEngineAlias])) {
+            throw new InvalidSearchEngine(
+                "Invalid search engine '{$searchEngineAlias}'. " .
+                "Could not find any service tagged with 'ibexa.search.engine' " .
+                "with alias '{$searchEngineAlias}'."
+            );
+        }
+
+        return $this->searchEngines[$searchEngineAlias];
     }
 }
 

--- a/src/bundle/Core/ApiLoader/StorageEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/StorageEngineFactory.php
@@ -55,23 +55,26 @@ class StorageEngineFactory
      * Builds storage engine identified by $storageEngineIdentifier (the "alias" attribute in the service tag).
      *
      * @throws \Ibexa\Bundle\Core\ApiLoader\Exception\InvalidStorageEngine
-     *
-     * @return \Ibexa\Contracts\Core\Persistence\Handler
      */
-    public function buildStorageEngine()
+    public function buildStorageEngine(): PersistenceHandler
     {
         $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
 
-        if (
-            !(
-                isset($repositoryConfig['storage']['engine'])
-                && isset($this->storageEngines[$repositoryConfig['storage']['engine']])
-            )
-        ) {
+        $storageEngineAlias = $repositoryConfig['storage']['engine'] ?? null;
+        if (null === $storageEngineAlias) {
             throw new InvalidStorageEngine(
-                "Invalid storage engine '{$repositoryConfig['storage']['engine']}'. " .
-                'Could not find any service tagged with ezpublish.storageEngine ' .
-                "with alias {$repositoryConfig['storage']['engine']}."
+                sprintf(
+                    'Ibexa "%s" Repository has no Storage Engine configured',
+                    $this->repositoryConfigurationProvider->getCurrentRepositoryAlias()
+                )
+            );
+        }
+
+        if (!isset($this->storageEngines[$storageEngineAlias])) {
+            throw new InvalidStorageEngine(
+                "Invalid storage engine '{$storageEngineAlias}'. " .
+                'Could not find any service tagged with ibexa.storage ' .
+                "with alias {$storageEngineAlias}."
             );
         }
 

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
@@ -12,7 +12,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * The ChainConfigResolverPass will register all services tagged as "ezpublish.config.resolver" to the chain config resolver.
+ * The ChainConfigResolverPass will register all services tagged as "ibexa.site.config.resolver"
+ * to the chain config resolver.
  */
 class ChainConfigResolverPass implements CompilerPassInterface
 {
@@ -27,7 +28,7 @@ class ChainConfigResolverPass implements CompilerPassInterface
 
         $chainResolver = $container->getDefinition(ChainConfigResolver::class);
 
-        foreach ($container->findTaggedServiceIds('ezpublish.config.resolver') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('ibexa.site.config.resolver') as $id => $attributes) {
             $priority = isset($attributes[0]['priority']) ? (int)$attributes[0]['priority'] : 0;
             // Priority range is between -255 (the lowest) and 255 (the highest)
             if ($priority > 255) {

--- a/src/bundle/Core/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class FieldTypeParameterProviderRegistryPass implements CompilerPassInterface
 {
-    public const FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG = 'ezplatform.field_type.parameter_provider';
+    public const FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG = 'ibexa.field_type.view.parameter.provider';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container

--- a/src/bundle/Core/DependencyInjection/Compiler/NotificationRendererPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/NotificationRendererPass.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class NotificationRendererPass implements CompilerPassInterface
 {
-    public const TAG_NAME = 'ezpublish.notification.renderer';
+    public const TAG_NAME = 'ibexa.notification.renderer';
     public const REGISTRY_DEFINITION_ID = 'notification.renderer.registry';
 
     public function process(ContainerBuilder $container)

--- a/src/bundle/Core/DependencyInjection/Compiler/PlaceholderProviderPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/PlaceholderProviderPass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class PlaceholderProviderPass implements CompilerPassInterface
 {
-    public const TAG_NAME = 'ezpublish.placeholder_provider';
+    public const TAG_NAME = 'ibexa.media.images.placeholder.provider';
     public const REGISTRY_DEFINITION_ID = 'ezpublish.image_alias.imagine.placeholder_provider.registry';
 
     public function process(ContainerBuilder $container)

--- a/src/bundle/Core/DependencyInjection/Compiler/QueryTypePass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/QueryTypePass.php
@@ -13,11 +13,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Processes services tagged as ezplatform.query_type, and registers them with ezpublish.query_type.registry.
+ * Processes services tagged as ibexa.query_type, and registers them with ezpublish.query_type.registry.
  */
 final class QueryTypePass implements CompilerPassInterface
 {
-    public const QUERY_TYPE_SERVICE_TAG = 'ezplatform.query_type';
+    public const QUERY_TYPE_SERVICE_TAG = 'ibexa.query_type';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterSearchEngineIndexerPass implements CompilerPassInterface
 {
-    public const SEARCH_ENGINE_INDEXER_SERVICE_TAG = 'ezplatform.search_engine.indexer';
+    public const SEARCH_ENGINE_INDEXER_SERVICE_TAG = 'ibexa.search.engine.indexer';
 
     /**
      * Container service id of the SearchEngineIndexerFactory.

--- a/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEnginePass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEnginePass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterSearchEnginePass implements CompilerPassInterface
 {
-    public const SEARCH_ENGINE_SERVICE_TAG = 'ezplatform.search_engine';
+    public const SEARCH_ENGINE_SERVICE_TAG = 'ibexa.search.engine';
 
     /**
      * Container service id of the SearchEngineFactory.

--- a/src/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePass.php
@@ -16,6 +16,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterStorageEnginePass implements CompilerPassInterface
 {
+    public const STORAGE_ENGINE_TAG = 'ibexa.storage';
+
     /**
      * Performs compiler passes for persistence factories.
      *
@@ -33,17 +35,24 @@ class RegisterStorageEnginePass implements CompilerPassInterface
         }
 
         $storageEngineFactoryDef = $container->getDefinition('ezpublish.api.storage_engine.factory');
-        foreach ($container->findTaggedServiceIds('ezpublish.storageEngine') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds(self::STORAGE_ENGINE_TAG) as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
-                    throw new LogicException('ezpublish.storageEngine service tag needs an "alias" attribute to identify the storage engine.');
+                    throw new LogicException(
+                        sprintf(
+                            'Service "%s" tagged with "%s" service tag needs an "alias" ' .
+                            'attribute to identify the storage engine.',
+                            $serviceId,
+                            self::STORAGE_ENGINE_TAG
+                        )
+                    );
                 }
 
                 // Register the storage engine on the main storage engine factory
                 $storageEngineFactoryDef->addMethodCall(
                     'registerStorageEngine',
                     [
-                        new Reference($id),
+                        new Reference($serviceId),
                         $attribute['alias'],
                     ]
                 );

--- a/src/bundle/Core/DependencyInjection/Compiler/StorageConnectionPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/StorageConnectionPass.php
@@ -18,12 +18,19 @@ class StorageConnectionPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        foreach ($container->findTaggedServiceIds('ezpublish.storageEngine') as $id => $attributes) {
+        $taggedServiceIds = $container->findTaggedServiceIds(
+            RegisterStorageEnginePass::STORAGE_ENGINE_TAG
+        );
+        foreach ($taggedServiceIds as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new LogicException(
-                        'ezpublish.storageEngine service tag needs an "alias" attribute to ' .
-                        'identify the storage engine.'
+                        sprintf(
+                            'Service "%s" tagged with "%s" service tag needs an "alias" ' .
+                            'attribute to identify the storage engine.',
+                            $serviceId,
+                            RegisterStorageEnginePass::STORAGE_ENGINE_TAG
+                        )
                     );
                 }
 

--- a/src/bundle/Core/DependencyInjection/Compiler/URLHandlerPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/URLHandlerPass.php
@@ -26,12 +26,12 @@ class URLHandlerPass implements CompilerPassInterface
         }
 
         $definition = $container->findDefinition('ezpublish.url_checker.handler_registry');
-        foreach ($container->findTaggedServiceIds('ezpublish.url_handler') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('ibexa.url_checker.handler') as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['scheme'])) {
                     throw new LogicException(sprintf(
                         '%s service tag needs a "scheme" attribute to identify which scheme is supported by the handler.',
-                        'ezpublish.url_handler'
+                        'ibexa.url_checker.handler'
                     ));
                 }
 

--- a/src/bundle/Core/DependencyInjection/Compiler/ViewMatcherRegistryPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ViewMatcherRegistryPass.php
@@ -14,11 +14,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * The MatcherServiceRegistryPass will register all services tagged as "ezplatform.view.matcher" to the registry.
+ * The MatcherServiceRegistryPass will register all services tagged as "ibexa.view.matcher" to the registry.
  */
 final class ViewMatcherRegistryPass implements CompilerPassInterface
 {
-    public const MATCHER_TAG = 'ezplatform.view.matcher';
+    public const MATCHER_TAG = 'ibexa.view.matcher';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/bundle/Core/DependencyInjection/Compiler/ViewProvidersPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ViewProvidersPass.php
@@ -12,23 +12,31 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Registers services tagged as ezpublish.view_provider into the view_provider registry.
+ * Registers services tagged as "ibexa.view.provider" into the view_provider registry.
  */
 class ViewProvidersPass implements CompilerPassInterface
 {
+    private const VIEW_PROVIDER_TAG = 'ibexa.view.provider';
+
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
         $rawViewProviders = [];
-        foreach ($container->findTaggedServiceIds('ezpublish.view_provider') as $serviceId => $tags) {
+        foreach ($container->findTaggedServiceIds(self::VIEW_PROVIDER_TAG) as $serviceId => $tags) {
             foreach ($tags as $attributes) {
                 // Priority range is between -255 (the lowest) and 255 (the highest)
                 $priority = isset($attributes['priority']) ? max(min((int)$attributes['priority'], 255), -255) : 0;
 
                 if (!isset($attributes['type'])) {
-                    throw new LogicException("Missing mandatory attribute 'type' for ezpublish.view_provider tag");
+                    throw new LogicException(
+                        sprintf(
+                            'Service "%s" tagged with "%s" service tag needs a "type" attribute',
+                            $serviceId,
+                            self::VIEW_PROVIDER_TAG
+                        )
+                    );
                 }
                 $type = $attributes['type'];
 

--- a/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
+++ b/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
@@ -16,7 +16,7 @@ use Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigBuilderInterface;
  * E.g. "content/read": "content" is the module, "read" is the function.
  *
  * Each function can provide a collection of limitations.
- * These need to be implemented as "limitation types" and declared as services with "ezpublish.limitationType" service tag.
+ * These need to be implemented as "limitation types" and declared as services with "ibexa.permissions.limitation_type" service tag.
  * Limitation types also provide value objects based on {@see \Ibexa\Contracts\Core\Repository\Values\User\Limitation} abstract class.
  *
  * @since 6.0

--- a/src/bundle/Core/DependencyInjection/ServiceTags.php
+++ b/src/bundle/Core/DependencyInjection/ServiceTags.php
@@ -17,13 +17,13 @@ class ServiceTags
      * Auto-configured tag name for
      * {@see \Ibexa\Contracts\Core\Repository\Values\Filter\CriterionQueryBuilder}.
      */
-    public const FILTERING_CRITERION_QUERY_BUILDER = 'ezplatform.filter.criterion.query_builder';
+    public const FILTERING_CRITERION_QUERY_BUILDER = 'ibexa.filter.criterion.query.builder';
 
     /**
      * Auto-configured tag name for
      * {@see \Ibexa\Contracts\Core\Repository\Values\Filter\SortClauseQueryBuilder}.
      */
-    public const FILTERING_SORT_CLAUSE_QUERY_BUILDER = 'ezplatform.filter.sort_clause.query_builder';
+    public const FILTERING_SORT_CLAUSE_QUERY_BUILDER = 'ibexa.filter.sort_clause.query.builder';
 }
 
 class_alias(ServiceTags::class, 'eZ\Bundle\EzPublishCoreBundle\DependencyInjection\ServiceTags');

--- a/src/bundle/Core/Resources/config/fieldtype_services.yml
+++ b/src/bundle/Core/Resources/config/fieldtype_services.yml
@@ -9,23 +9,23 @@ services:
         calls:
             - [setRequestStack, ["@request_stack"]]
         tags:
-            - {name: ezplatform.field_type.parameter_provider, alias: ezdatetime}
-            - {name: ezplatform.field_type.parameter_provider, alias: ezdate}
-            - {name: ezplatform.field_type.parameter_provider, alias: eztime}
+            - {name: ibexa.field_type.view.parameter.provider, alias: ezdatetime}
+            - {name: ibexa.field_type.view.parameter.provider, alias: ezdate}
+            - {name: ibexa.field_type.view.parameter.provider, alias: eztime}
 
     ezpublish.fieldType.ezobjectrelation.parameterProvider:
         class: Ibexa\Core\MVC\Symfony\FieldType\Relation\ParameterProvider
         arguments:
             - "@ezpublish.api.service.content"
         tags:
-            - {name: ezplatform.field_type.parameter_provider, alias: ezobjectrelation}
+            - {name: ibexa.field_type.view.parameter.provider, alias: ezobjectrelation}
 
     ezpublish.fieldType.ezobjectrelationlist.parameterProvider:
         class: Ibexa\Core\MVC\Symfony\FieldType\RelationList\ParameterProvider
         arguments:
             - "@ezpublish.api.service.content"
         tags:
-            - {name: ezplatform.field_type.parameter_provider, alias: ezobjectrelationlist}
+            - {name: ibexa.field_type.view.parameter.provider, alias: ezobjectrelationlist}
 
     ezpublish.fieldType.ezimageasset.parameterProvider:
         class: Ibexa\Core\MVC\Symfony\FieldType\ImageAsset\ParameterProvider
@@ -33,14 +33,14 @@ services:
         arguments:
             - "@ezpublish.siteaccessaware.repository"
         tags:
-            - {name: ezplatform.field_type.parameter_provider, alias: ezimageasset}
+            - {name: ibexa.field_type.view.parameter.provider, alias: ezimageasset}
 
     Ibexa\Core\MVC\Symfony\FieldType\User\ParameterProvider:
         lazy: true
         arguments:
             - "@ezpublish.api.service.user"
         tags:
-            - {name: ezplatform.field_type.parameter_provider, alias: ezuser}
+            - {name: ibexa.field_type.view.parameter.provider, alias: ezuser}
 
     # Image
     ezpublish.fieldType.ezimage.io_service:

--- a/src/bundle/Core/Resources/config/helpers.yml
+++ b/src/bundle/Core/Resources/config/helpers.yml
@@ -26,7 +26,7 @@ services:
     ezpublish.config_scope_listener:
         class: Ibexa\Bundle\Core\EventListener\ConfigScopeListener
         arguments:
-            $configResolvers: !tagged ezpublish.config.resolver
+            $configResolvers: !tagged ibexa.site.config.resolver
             $viewManager: '@ezpublish.view_manager'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -128,12 +128,12 @@ services:
         arguments:
             - '@liip_imagine'
         tags:
-            - { name: 'ezpublish.placeholder_provider', type: 'generic' }
+            - { name: 'ibexa.media.images.placeholder.provider', type: 'generic' }
 
     ezpublish.image_alias.imagine.placeholder_provider.remote:
         class: 'Ibexa\Bundle\Core\Imagine\PlaceholderProvider\RemoteProvider'
         tags:
-            - { name: 'ezpublish.placeholder_provider', type: 'remote' }
+            - { name: 'ibexa.media.images.placeholder.provider', type: 'remote' }
 
     ezpublish.image_alias.imagine.filter.loader.scaledown.base:
         abstract: true

--- a/src/bundle/Core/Resources/config/query_types.yml
+++ b/src/bundle/Core/Resources/config/query_types.yml
@@ -6,27 +6,27 @@ services:
 
     Ibexa\Core\QueryType\BuiltIn\AncestorsQueryType:
         tags:
-            - { name: ezplatform.query_type, alias: 'Ancestors' }
+            - { name: ibexa.query_type, alias: 'Ancestors' }
 
     Ibexa\Core\QueryType\BuiltIn\ChildrenQueryType:
         tags:
-            - { name: ezplatform.query_type, alias: 'Children' }
+            - { name: ibexa.query_type, alias: 'Children' }
 
     Ibexa\Core\QueryType\BuiltIn\SiblingsQueryType:
         tags:
-            - { name: ezplatform.query_type, alias: 'Siblings' }
+            - { name: ibexa.query_type, alias: 'Siblings' }
 
     Ibexa\Core\QueryType\BuiltIn\RelatedToContentQueryType:
         tags:
-            - { name: ezplatform.query_type, alias: 'RelatedTo' }
+            - { name: ibexa.query_type, alias: 'RelatedTo' }
 
     Ibexa\Core\QueryType\BuiltIn\GeoLocationQueryType:
         tags:
-            - { name: ezplatform.query_type, alias: 'GeoLocation' }
+            - { name: ibexa.query_type, alias: 'GeoLocation' }
 
     Ibexa\Core\QueryType\BuiltIn\SubtreeQueryType:
         tags:
-            - { name: ezplatform.query_type, alias: 'Subtree' }
+            - { name: ibexa.query_type, alias: 'Subtree' }
 
     Ibexa\Core\QueryType\BuiltIn\SortClausesFactory:
         arguments:

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -74,12 +74,12 @@ services:
             - "%ezpublish.siteaccess.list%"
             - "%ezpublish.siteaccess.groups_by_siteaccess%"
         tags:
-            - { name: ezplatform.siteaccess.provider, priority: 10 }
+            - { name: ibexa.site_access.provider, priority: 10 }
 
     ezpublish.siteaccess.provider.chain:
         class: Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider
         arguments:
-            $providers: !tagged ezplatform.siteaccess.provider
+            $providers: !tagged ibexa.site_access.provider
 
     ezpublish.siteaccess.provider:
         alias: ezpublish.siteaccess.provider.chain

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -22,7 +22,7 @@ services:
             - [setContainer, ['@service_container']]
         lazy: true
         tags:
-            - { name: ezpublish.config.resolver, priority: 0 }
+            - { name: ibexa.site.config.resolver, priority: 0 }
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\SiteAccessGroupConfigResolver:
         arguments:
@@ -34,7 +34,7 @@ services:
             - [setContainer, ['@service_container']]
         lazy: true
         tags:
-            - { name: ezpublish.config.resolver, priority: 50 }
+            - { name: ibexa.site.config.resolver, priority: 50 }
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\StaticSiteAccessConfigResolver:
         arguments:
@@ -45,7 +45,7 @@ services:
             - [setContainer, ['@service_container']]
         lazy: true
         tags:
-            - { name: ezpublish.config.resolver, priority: 100 }
+            - { name: ibexa.site.config.resolver, priority: 100 }
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver:
         arguments:
@@ -54,7 +54,7 @@ services:
             - [setContainer, ['@service_container']]
         lazy: true
         tags:
-            - { name: ezpublish.config.resolver, priority: 255 }
+            - { name: ibexa.site.config.resolver, priority: 255 }
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ChainConfigResolver:
         public: true # @todo should be private

--- a/src/bundle/Core/Resources/config/sort_spec.yml
+++ b/src/bundle/Core/Resources/config/sort_spec.yml
@@ -6,23 +6,23 @@ services:
 
     Ibexa\Core\QueryType\BuiltIn\SortSpec\SortClauseParserDispatcher:
         arguments:
-            $parsers: !tagged_iterator ezplatform.query_type.sort_clause_parser
+            $parsers: !tagged_iterator ibexa.query_type.sort_clause.parser
 
     Ibexa\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\CustomFieldSortClauseParser:
         tags:
-            - { name: ezplatform.query_type.sort_clause_parser }
+            - { name: ibexa.query_type.sort_clause.parser }
 
     Ibexa\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\FieldSortClauseParser:
         tags:
-            - { name: ezplatform.query_type.sort_clause_parser }
+            - { name: ibexa.query_type.sort_clause.parser }
 
     Ibexa\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\MapDistanceSortClauseParser:
         tags:
-            - { name: ezplatform.query_type.sort_clause_parser }
+            - { name: ibexa.query_type.sort_clause.parser }
 
     Ibexa\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\RandomSortClauseParser:
         tags:
-            - { name: ezplatform.query_type.sort_clause_parser }
+            - { name: ibexa.query_type.sort_clause.parser }
 
     Ibexa\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\DefaultSortClauseParser:
         arguments:
@@ -42,4 +42,4 @@ services:
                 location_priority: \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Priority
                 location_visibility: \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Visibility
         tags:
-            - { name: ezplatform.query_type.sort_clause_parser }
+            - { name: ibexa.query_type.sort_clause.parser }

--- a/src/bundle/Core/Resources/config/templating.yml
+++ b/src/bundle/Core/Resources/config/templating.yml
@@ -37,7 +37,7 @@ services:
         class: Ibexa\Bundle\Core\View\Provider\Configured
         arguments: ["@ezpublish.content_view.matcher_factory"]
         tags:
-            - {name: ezpublish.view_provider, type: 'Ibexa\Core\MVC\Symfony\View\ContentView', priority: 10}
+            - {name: ibexa.view.provider, type: 'Ibexa\Core\MVC\Symfony\View\ContentView', priority: 10}
 
     ezpublish.content_view.matcher_factory:
         class: Ibexa\Bundle\Core\Matcher\ServiceAwareMatcherFactory
@@ -58,7 +58,7 @@ services:
         class: Ibexa\Bundle\Core\View\Provider\Configured
         arguments: ["@ezpublish.content_view.default_matcher_factory"]
         tags:
-            - {name: ezpublish.view_provider, type: 'Ibexa\Core\MVC\Symfony\View\ContentView', priority: -1}
+            - {name: ibexa.view.provider, type: 'Ibexa\Core\MVC\Symfony\View\ContentView', priority: -1}
 
     ezpublish.content_view.default_matcher_factory:
         class: Ibexa\Bundle\Core\Matcher\ServiceAwareMatcherFactory
@@ -79,7 +79,7 @@ services:
         class: Ibexa\Bundle\Core\View\Provider\Configured
         arguments: ["@ezpublish.location_view.matcher_factory"]
         tags:
-            - {name: ezpublish.view_provider, type: 'Ibexa\Core\MVC\Symfony\View\ContentView', priority: 10}
+            - {name: ibexa.view.provider, type: 'Ibexa\Core\MVC\Symfony\View\ContentView', priority: 10}
 
     ezpublish.location_view.matcher_factory:
         class: Ibexa\Bundle\Core\Matcher\ServiceAwareMatcherFactory
@@ -178,7 +178,7 @@ services:
 
     Ibexa\Core\MVC\Symfony\Templating\RenderStrategy:
         arguments:
-            $strategies: !tagged_iterator ibexa.platform.render.strategy
+            $strategies: !tagged_iterator ibexa.view.render.strategy
 
     Ibexa\Contracts\Core\MVC\Templating\RenderStrategy: '@Ibexa\Core\MVC\Symfony\Templating\RenderStrategy'
 
@@ -189,7 +189,7 @@ services:
             $siteAccess: '@ezpublish.siteaccess'
             $requestStack: '@request_stack'
         tags:
-            - { name: ibexa.platform.render.strategy }
+            - { name: ibexa.view.render.strategy }
 
     Ibexa\Core\MVC\Symfony\Templating\RenderLocationStrategy:
         arguments:
@@ -198,7 +198,7 @@ services:
             $siteAccess: '@ezpublish.siteaccess'
             $requestStack: '@request_stack'
         tags:
-            - { name: ibexa.platform.render.strategy }
+            - { name: ibexa.view.render.strategy }
 
     ezpublish.twig.extension.image:
         class: Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\ImageExtension
@@ -221,7 +221,7 @@ services:
     ezpublish.view_builder.registry:
         class: Ibexa\Core\MVC\Symfony\View\Builder\Registry\ControllerMatch
         arguments:
-            $viewBuilders: !tagged_iterator { tag: ibexa.view_builder }
+            $viewBuilders: !tagged_iterator { tag: ibexa.view.builder }
 
     ezpublish.view_builder.content:
         class: Ibexa\Core\MVC\Symfony\View\Builder\ContentViewBuilder
@@ -232,7 +232,7 @@ services:
             - "@request_stack"
             - "@ezpublish.content_info_location_loader.main"
         tags:
-            - { name: ibexa.view_builder }
+            - { name: ibexa.view.builder }
 
     ezpublish.view.builder_parameter_collector.request_attributes:
         class: Ibexa\Core\MVC\Symfony\View\Builder\ParametersFilter\RequestAttributes

--- a/src/bundle/Core/Resources/config/thumbnails.yml
+++ b/src/bundle/Core/Resources/config/thumbnails.yml
@@ -32,8 +32,8 @@ services:
             $fieldTypeService: '@ezpublish.api.service.field_type'
             $contentFieldStrategy: '@Ibexa\Core\Repository\Strategy\ContentThumbnail\Field\ContentFieldStrategy'
         tags:
-            - { name: ezplatform.spi.content.thumbnail_strategy, priority: 0 }
+            - { name: ibexa.repository.thumbnail.strategy.content, priority: 0 }
 
     Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy:
         arguments:
-            $strategies: !tagged_iterator ezplatform.spi.content.thumbnail_strategy
+            $strategies: !tagged_iterator ibexa.repository.thumbnail.strategy.content

--- a/src/bundle/Core/Resources/config/url_checker.yml
+++ b/src/bundle/Core/Resources/config/url_checker.yml
@@ -25,7 +25,7 @@ services:
             $configResolver: '@ezpublish.config.resolver'
             $parameterName: url_handler.http.options
         tags:
-            - { name: ezpublish.url_handler, scheme: http }
+            - { name: ibexa.url_checker.handler, scheme: http }
 
     ezpublish.url_checker.handler.https:
         class: 'Ibexa\Bundle\Core\URLChecker\Handler\HTTPHandler'
@@ -34,7 +34,7 @@ services:
             $configResolver: '@ezpublish.config.resolver'
             $parameterName: url_handler.https.options
         tags:
-            - { name: ezpublish.url_handler, scheme: https }
+            - { name: ibexa.url_checker.handler, scheme: https }
 
     ezpublish.url_checker.handler.mailto:
         class: 'Ibexa\Bundle\Core\URLChecker\Handler\MailToHandler'
@@ -42,4 +42,4 @@ services:
         arguments:
             $configResolver: '@ezpublish.config.resolver'
         tags:
-            - { name: ezpublish.url_handler, scheme: mailto }
+            - { name: ibexa.url_checker.handler, scheme: mailto }

--- a/src/bundle/Debug/DependencyInjection/Compiler/DataCollectorPass.php
+++ b/src/bundle/Debug/DependencyInjection/Compiler/DataCollectorPass.php
@@ -19,7 +19,7 @@ class DataCollectorPass implements CompilerPassInterface
         }
 
         $dataCollectorDef = $container->getDefinition('ezpublish_debug.data_collector');
-        foreach ($container->findTaggedServiceIds('ezpublish_data_collector') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('ibexa.debug.data_collector') as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 $dataCollectorDef->addMethodCall(
                     'addCollector',

--- a/src/bundle/Debug/Resources/config/services.yml
+++ b/src/bundle/Debug/Resources/config/services.yml
@@ -11,7 +11,7 @@ services:
         class: Ibexa\Bundle\Debug\Collector\SiteAccessCollector
         tags:
             -
-                name: ezpublish_data_collector
+                name: ibexa.debug.data_collector
                 id: "ezpublish.debug.siteaccess"
                 panelTemplate: '@IbexaDebug/Profiler/siteaccess/panel.html.twig'
                 toolbarTemplate: '@IbexaDebug/Profiler/siteaccess/toolbar.html.twig'
@@ -21,7 +21,7 @@ services:
         arguments: ["@ezpublish.spi.persistence.cache.persistenceLogger"]
         tags:
             -
-                name: ezpublish_data_collector
+                name: ibexa.debug.data_collector
                 id: "ezpublish.debug.persistence"
                 panelTemplate: '@IbexaDebug/Profiler/persistence/panel.html.twig'
                 toolbarTemplate: '@IbexaDebug/Profiler/persistence/toolbar.html.twig'

--- a/src/bundle/IO/DependencyInjection/Compiler/MigrationFileListerPass.php
+++ b/src/bundle/IO/DependencyInjection/Compiler/MigrationFileListerPass.php
@@ -23,7 +23,7 @@ final class MigrationFileListerPass implements CompilerPassInterface
             return;
         }
 
-        $fileListersTagged = $container->findTaggedServiceIds('ezpublish.core.io.migration.file_lister');
+        $fileListersTagged = $container->findTaggedServiceIds('ibexa.io.migration.file_lister');
 
         $fileListers = [];
         foreach ($fileListersTagged as $id => $tags) {

--- a/src/bundle/IO/Resources/config/io.yml
+++ b/src/bundle/IO/Resources/config/io.yml
@@ -26,7 +26,7 @@ services:
             - "@ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator"
             - "%ezsettings.default.binary_dir%"
         tags:
-            - { name: "ezpublish.core.io.migration.file_lister", identifier: "binary_file" }
+            - { name: "ibexa.io.migration.file_lister", identifier: "binary_file" }
         lazy: true
 
     ezpublish.core.io.migration.file_lister.media_file_lister:
@@ -36,7 +36,7 @@ services:
             - "@ezpublish.core.io.migration.file_lister.file_iterator.media_file_iterator"
             - "%ezsettings.default.binary_dir%"
         tags:
-            - { name: "ezpublish.core.io.migration.file_lister", identifier: "media_file" }
+            - { name: "ibexa.io.migration.file_lister", identifier: "media_file" }
         lazy: true
 
     ezpublish.core.io.migration.file_lister.image_file_lister:
@@ -48,7 +48,7 @@ services:
             - "@liip_imagine.filter.configuration"
             - "%ezsettings.default.image.published_images_dir%"
         tags:
-            - { name: "ezpublish.core.io.migration.file_lister", identifier: "image_file" }
+            - { name: "ibexa.io.migration.file_lister", identifier: "image_file" }
         lazy: true
 
     ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator:

--- a/src/bundle/RepositoryInstaller/DependencyInjection/Compiler/InstallerTagPass.php
+++ b/src/bundle/RepositoryInstaller/DependencyInjection/Compiler/InstallerTagPass.php
@@ -13,11 +13,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Compiles services tagged as ezplatform.installer to %ezplatform.installers%.
+ * Injects services tagged as "ibexa.installer" into
+ * {@see \Ibexa\Bundle\RepositoryInstaller\Command\InstallPlatformCommand::$installers}.
  */
 class InstallerTagPass implements CompilerPassInterface
 {
-    public const INSTALLER_TAG = 'ezplatform.installer';
+    public const INSTALLER_TAG = 'ibexa.installer';
 
     public function process(ContainerBuilder $container)
     {

--- a/src/bundle/RepositoryInstaller/Resources/config/services.yml
+++ b/src/bundle/RepositoryInstaller/Resources/config/services.yml
@@ -14,7 +14,6 @@ services:
         autowire: true
         parent: Ibexa\Bundle\RepositoryInstaller\Installer\DbBasedInstaller
         tags:
-            - { name: ibexa.installer, type: clean } # left for BC, should be removed in Ibexa 4.0
             - { name: ibexa.installer, type: ibexa-oss }
 
     Ibexa\Bundle\RepositoryInstaller\Command\InstallPlatformCommand:

--- a/src/bundle/RepositoryInstaller/Resources/config/services.yml
+++ b/src/bundle/RepositoryInstaller/Resources/config/services.yml
@@ -14,8 +14,8 @@ services:
         autowire: true
         parent: Ibexa\Bundle\RepositoryInstaller\Installer\DbBasedInstaller
         tags:
-            - { name: ezplatform.installer, type: clean } # left for BC, should be removed in Ibexa 4.0
-            - { name: ezplatform.installer, type: ibexa-oss }
+            - { name: ibexa.installer, type: clean } # left for BC, should be removed in Ibexa 4.0
+            - { name: ibexa.installer, type: ibexa-oss }
 
     Ibexa\Bundle\RepositoryInstaller\Command\InstallPlatformCommand:
         arguments:

--- a/src/lib/Base/Container/Compiler/AbstractFieldTypeBasedPass.php
+++ b/src/lib/Base/Container/Compiler/AbstractFieldTypeBasedPass.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 abstract class AbstractFieldTypeBasedPass implements CompilerPassInterface
 {
-    public const FIELD_TYPE_SERVICE_TAG = 'ezplatform.field_type';
+    public const FIELD_TYPE_SERVICE_TAG = 'ibexa.field_type';
 
     public const FIELD_TYPE_SERVICE_TAGS = [
         self::FIELD_TYPE_SERVICE_TAG,

--- a/src/lib/Base/Container/Compiler/Search/AggregateFieldValueMapperPass.php
+++ b/src/lib/Base/Container/Compiler/Search/AggregateFieldValueMapperPass.php
@@ -29,7 +29,7 @@ class AggregateFieldValueMapperPass implements CompilerPassInterface
         );
 
         $taggedServiceIds = $container->findTaggedServiceIds(
-            'ezpublish.search.common.field_value_mapper'
+            'ibexa.search.common.field_value.mapper'
         );
         foreach ($taggedServiceIds as $id => $attributes) {
             $aggregateFieldValueMapperDefinition->addMethodCall(

--- a/src/lib/Base/Container/Compiler/Search/FieldRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Search/FieldRegistryPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class FieldRegistryPass implements CompilerPassInterface
 {
-    public const FIELD_TYPE_INDEXABLE_SERVICE_TAG = 'ezplatform.field_type.indexable';
+    public const FIELD_TYPE_INDEXABLE_SERVICE_TAG = 'ibexa.field_type.indexable';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container

--- a/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
@@ -33,7 +33,7 @@ class CriteriaConverterPass implements CompilerPassInterface
         if ($container->hasDefinition('ezpublish.search.legacy.gateway.criteria_converter.content')) {
             $criteriaConverterContent = $container->getDefinition('ezpublish.search.legacy.gateway.criteria_converter.content');
 
-            $contentHandlers = $container->findTaggedServiceIds('ezpublish.search.legacy.gateway.criterion_handler.content');
+            $contentHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.gateway.criterion_handler.content');
 
             $this->addHandlers($criteriaConverterContent, $contentHandlers);
         }
@@ -41,21 +41,21 @@ class CriteriaConverterPass implements CompilerPassInterface
         if ($container->hasDefinition('ezpublish.search.legacy.gateway.criteria_converter.location')) {
             $criteriaConverterLocation = $container->getDefinition('ezpublish.search.legacy.gateway.criteria_converter.location');
 
-            $locationHandlers = $container->findTaggedServiceIds('ezpublish.search.legacy.gateway.criterion_handler.location');
+            $locationHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.gateway.criterion_handler.location');
 
             $this->addHandlers($criteriaConverterLocation, $locationHandlers);
         }
 
         if ($container->hasDefinition('ezplatform.trash.search.legacy.gateway.criteria_converter')) {
             $trashCriteriaConverter = $container->getDefinition('ezplatform.trash.search.legacy.gateway.criteria_converter');
-            $trashCriteriaHandlers = $container->findTaggedServiceIds('ezplatform.trash.search.legacy.gateway.criterion_handler');
+            $trashCriteriaHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.trash.gateway.criterion.handler');
 
             $this->addHandlers($trashCriteriaConverter, $trashCriteriaHandlers);
         }
 
         if ($container->hasDefinition('ezpublish.spi.persistence.legacy.url.criterion_converter')) {
             $urlCriteriaConverter = $container->getDefinition('ezpublish.spi.persistence.legacy.url.criterion_converter');
-            $urlCriteriaHandlers = $container->findTaggedServiceIds('ezpublish.persistence.legacy.url.criterion_handler');
+            $urlCriteriaHandlers = $container->findTaggedServiceIds('ibexa.storage.legacy.url.criterion.handler');
 
             $this->addHandlers($urlCriteriaConverter, $urlCriteriaHandlers);
         }

--- a/src/lib/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPass.php
@@ -16,6 +16,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CriterionFieldValueHandlerRegistryPass implements CompilerPassInterface
 {
+    private const SEARCH_LEGACY_GATEWAY_CRITERION_HANDLER_FIELD_VALUE_TAG = 'ibexa.search.legacy.gateway.criterion_handler.field_value';
+
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
@@ -27,11 +29,18 @@ class CriterionFieldValueHandlerRegistryPass implements CompilerPassInterface
 
         $registry = $container->getDefinition('ezpublish.search.legacy.gateway.criterion_field_value_handler.registry');
 
-        foreach ($container->findTaggedServiceIds('ezpublish.search.legacy.gateway.criterion_field_value_handler') as $id => $attributes) {
+        $taggedServiceIds = $container->findTaggedServiceIds(
+            self::SEARCH_LEGACY_GATEWAY_CRITERION_HANDLER_FIELD_VALUE_TAG
+        );
+        foreach ($taggedServiceIds as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new LogicException(
-                        'ezpublish.search.legacy.gateway.criterion_field_value_handler service tag needs an "alias" attribute to identify the Field Type.'
+                        sprintf(
+                            'Service "%s" tagged with "%s" service tag needs an "alias" attribute to identify the Field Type.',
+                            $serviceId,
+                            self::SEARCH_LEGACY_GATEWAY_CRITERION_HANDLER_FIELD_VALUE_TAG
+                        )
                     );
                 }
 
@@ -39,7 +48,7 @@ class CriterionFieldValueHandlerRegistryPass implements CompilerPassInterface
                     'register',
                     [
                         $attribute['alias'],
-                        new Reference($id),
+                        new Reference($serviceId),
                     ]
                 );
             }

--- a/src/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
@@ -32,7 +32,7 @@ class SortClauseConverterPass implements CompilerPassInterface
         if ($container->hasDefinition('ezpublish.search.legacy.gateway.sort_clause_converter.content')) {
             $sortClauseConverterContent = $container->getDefinition('ezpublish.search.legacy.gateway.sort_clause_converter.content');
 
-            $contentHandlers = $container->findTaggedServiceIds('ezpublish.search.legacy.gateway.sort_clause_handler.content');
+            $contentHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.gateway.sort_clause_handler.content');
 
             $this->addHandlers($sortClauseConverterContent, $contentHandlers);
         }
@@ -40,7 +40,7 @@ class SortClauseConverterPass implements CompilerPassInterface
         if ($container->hasDefinition('ezpublish.search.legacy.gateway.sort_clause_converter.location')) {
             $sortClauseConverterLocation = $container->getDefinition('ezpublish.search.legacy.gateway.sort_clause_converter.location');
 
-            $locationHandlers = $container->findTaggedServiceIds('ezpublish.search.legacy.gateway.sort_clause_handler.location');
+            $locationHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.gateway.sort_clause_handler.location');
 
             $this->addHandlers($sortClauseConverterLocation, $locationHandlers);
         }
@@ -48,7 +48,7 @@ class SortClauseConverterPass implements CompilerPassInterface
         if ($container->hasDefinition('ezplatform.trash.search.legacy.gateway.sort_clause_converter')) {
             $sortClauseConverterTrash = $container->getDefinition('ezplatform.trash.search.legacy.gateway.sort_clause_converter');
 
-            $trashHandlers = $container->findTaggedServiceIds('ezplatform.trash.search.legacy.gateway.sort_clause_handler');
+            $trashHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.trash.gateway.sort_clause.handler');
 
             $this->addHandlers($sortClauseConverterTrash, $trashHandlers);
         }

--- a/src/lib/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
@@ -17,8 +17,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ExternalStorageRegistryPass implements CompilerPassInterface
 {
-    public const EXTERNAL_STORAGE_HANDLER_SERVICE_TAG = 'ezplatform.field_type.external_storage_handler';
-    public const EXTERNAL_STORAGE_HANDLER_GATEWAY_SERVICE_TAG = 'ezplatform.field_type.external_storage_handler.gateway';
+    public const EXTERNAL_STORAGE_HANDLER_SERVICE_TAG = 'ibexa.field_type.storage.external.handler';
+    public const EXTERNAL_STORAGE_HANDLER_GATEWAY_SERVICE_TAG = 'ibexa.field_type.storage.external.handler.gateway';
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
@@ -103,8 +103,13 @@ class ExternalStorageRegistryPass implements CompilerPassInterface
                 ) {
                     if (!isset($externalStorageGateways[$attribute['alias']])) {
                         throw new LogicException(
-                            "External storage handler '$serviceId' for Field Type {$attribute['alias']} needs a storage gateway.
-                            Consider defining a storage gateway as a service for this Field Type and add the 'ezplatform.field_type.external_storage_handler.gateway tag'"
+                            sprintf(
+                                'External storage handler "%s" for Field Type "%s" needs a storage gateway. ' .
+                                'Consider defining a storage gateway as a service for this Field Type and add the "%s" tag',
+                                $serviceId,
+                                $attribute['alias'],
+                                self::EXTERNAL_STORAGE_HANDLER_GATEWAY_SERVICE_TAG
+                            )
                         );
                     }
 

--- a/src/lib/Base/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPass.php
@@ -18,7 +18,7 @@ class FieldValueConverterRegistryPass implements CompilerPassInterface
 {
     public const CONVERTER_REGISTRY_SERVICE_ID = 'ezpublish.persistence.legacy.field_value_converter.registry';
 
-    public const CONVERTER_SERVICE_TAG = 'ezplatform.field_type.legacy_storage.converter';
+    public const CONVERTER_SERVICE_TAG = 'ibexa.field_type.storage.legacy.converter';
 
     public const CONVERTER_SERVICE_TAGS = [
         self::CONVERTER_SERVICE_TAG,

--- a/src/lib/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPass.php
@@ -28,7 +28,7 @@ class RoleLimitationConverterPass implements CompilerPassInterface
 
         $roleLimitationConverter = $container->getDefinition('ezpublish.persistence.legacy.role.limitation.converter');
 
-        foreach ($container->findTaggedServiceIds('ezpublish.persistence.legacy.role.limitation.handler') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('ibexa.storage.legacy.role.limitation.handler') as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 $roleLimitationConverter->addMethodCall(
                     'addHandler',

--- a/src/lib/QueryType/QueryType.php
+++ b/src/lib/QueryType/QueryType.php
@@ -9,7 +9,7 @@ namespace Ibexa\Core\QueryType;
 /**
  * A QueryType is a pre-defined content or location query.
  *
- * QueryTypes must be registered with the service container using the `ezplatform.query_type` service tag.
+ * QueryTypes must be registered with the service container using the `ibexa.query_type` service tag.
  */
 interface QueryType
 {

--- a/src/lib/Resources/settings/fieldtype_external_storages.yml
+++ b/src/lib/Resources/settings/fieldtype_external_storages.yml
@@ -7,7 +7,7 @@ services:
             - "@ezpublish.fieldType.ezbinaryfile.pathGenerator"
             - "@ezpublish.core.io.mimeTypeDetector"
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezbinaryfile}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezbinaryfile}
 
     ezpublish.fieldType.ezimage.externalStorage:
         class: Ibexa\Core\FieldType\Image\ImageStorage
@@ -20,13 +20,13 @@ services:
             $aliasCleaner: '@Ibexa\Core\FieldType\Image\AliasCleanerInterface'
             $filePathNormalizer: '@Ibexa\Core\IO\FilePathNormalizerInterface'
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezimage}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezimage}
 
     ezpublish.fieldType.ezkeyword.externalStorage:
         class: Ibexa\Core\FieldType\Keyword\KeywordStorage
         arguments: ["@ezpublish.fieldType.ezkeyword.storage_gateway"]
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezkeyword}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezkeyword}
 
     ezpublish.fieldType.ezmedia.externalStorage:
         class: Ibexa\Core\FieldType\Media\MediaStorage
@@ -36,7 +36,7 @@ services:
             - "@ezpublish.fieldType.ezbinaryfile.pathGenerator"
             - "@ezpublish.core.io.mimeTypeDetector"
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezmedia}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezmedia}
 
     ezpublish.fieldType.ezurl.externalStorage:
         class: Ibexa\Core\FieldType\Url\UrlStorage
@@ -44,19 +44,19 @@ services:
             - "@ezpublish.fieldType.ezurl.storage_gateway"
             - "@?logger"
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezurl}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezurl}
 
     ezpublish.fieldType.ezgmaplocation.externalStorage:
         class: Ibexa\Core\FieldType\MapLocation\MapLocationStorage
         arguments: ["@ezpublish.fieldType.externalStorageHandler.ezgmaplocation.gateway"]
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezgmaplocation}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezgmaplocation}
 
     ezpublish.fieldType.ezuser.externalStorage:
         class: Ibexa\Core\FieldType\User\UserStorage
         arguments: ["@ezpublish.fieldType.ezuser.storage_gateway"]
         tags:
-            - {name: ezplatform.field_type.external_storage_handler, alias: ezuser}
+            - {name: ibexa.field_type.storage.external.handler, alias: ezuser}
 
     ezpublish.fieldType.metadataHandler.imagesize:
         class: Ibexa\Core\IO\MetadataHandler\ImageSize

--- a/src/lib/Resources/settings/fieldtypes.yml
+++ b/src/lib/Resources/settings/fieldtypes.yml
@@ -260,7 +260,7 @@ services:
         class: Ibexa\Core\FieldType\Author\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezauthor}
+            - {name: ibexa.field_type, alias: ezauthor}
 
     ezpublish.fieldType.ezbinaryfile:
         class: Ibexa\Core\FieldType\BinaryFile\Type
@@ -269,58 +269,58 @@ services:
             - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezbinaryfile}
+            - {name: ibexa.field_type, alias: ezbinaryfile}
 
     ezpublish.fieldType.ezboolean:
         class: Ibexa\Core\FieldType\Checkbox\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezboolean}
+            - {name: ibexa.field_type, alias: ezboolean}
 
     ezpublish.fieldType.ezcountry:
         class: Ibexa\Core\FieldType\Country\Type
         arguments: ["%ezpublish.fieldType.ezcountry.data%"]
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezcountry}
+            - {name: ibexa.field_type, alias: ezcountry}
 
     ezpublish.fieldType.ezdate:
         class: Ibexa\Core\FieldType\Date\Type
         parent: ezpublish.fieldType
         arguments: [ "ezdate" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezdate}
+            - {name: ibexa.field_type, alias: ezdate}
 
     ezpublish.fieldType.ezdatetime:
         class: Ibexa\Core\FieldType\DateAndTime\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezdatetime}
+            - {name: ibexa.field_type, alias: ezdatetime}
 
     ezpublish.fieldType.eztime:
         class: Ibexa\Core\FieldType\Time\Type
         parent: ezpublish.fieldType
         arguments: [ "eztime" ]
         tags:
-            - {name: ezplatform.field_type, alias: eztime}
+            - {name: ibexa.field_type, alias: eztime}
 
     ezpublish.fieldType.ezemail:
         class: Ibexa\Core\FieldType\EmailAddress\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezemail}
+            - {name: ibexa.field_type, alias: ezemail}
 
     ezpublish.fieldType.ezfloat:
         class: Ibexa\Core\FieldType\Float\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezfloat}
+            - {name: ibexa.field_type, alias: ezfloat}
 
     ezpublish.fieldType.ezinteger:
         class: Ibexa\Core\FieldType\Integer\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezinteger}
+            - {name: ibexa.field_type, alias: ezinteger}
 
     ezpublish.fieldType.ezimage:
         class: Ibexa\Core\FieldType\Image\Type
@@ -328,19 +328,19 @@ services:
             - ['@ezpublish.fieldType.validator.black_list', '@ezpublish.fieldType.validator.image']
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezimage}
+            - {name: ibexa.field_type, alias: ezimage}
 
     ezpublish.fieldType.ezisbn:
         class: Ibexa\Core\FieldType\ISBN\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezisbn}
+            - {name: ibexa.field_type, alias: ezisbn}
 
     ezpublish.fieldType.ezkeyword:
         class: Ibexa\Core\FieldType\Keyword\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezkeyword}
+            - {name: ibexa.field_type, alias: ezkeyword}
 
     ezpublish.fieldType.ezmedia:
         class: Ibexa\Core\FieldType\Media\Type
@@ -349,7 +349,7 @@ services:
             - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezmedia}
+            - {name: ibexa.field_type, alias: ezmedia}
 
     ezpublish.fieldType.ezobjectrelation:
         class: Ibexa\Core\FieldType\Relation\Type
@@ -357,37 +357,37 @@ services:
         arguments:
             - "@ezpublish.spi.persistence.cache.contentHandler"
         tags:
-            - {name: ezplatform.field_type, alias: ezobjectrelation}
+            - {name: ibexa.field_type, alias: ezobjectrelation}
 
     ezpublish.fieldType.ezselection:
         class: Ibexa\Core\FieldType\Selection\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezselection}
+            - {name: ibexa.field_type, alias: ezselection}
 
     ezpublish.fieldType.eztext:
         class: Ibexa\Core\FieldType\TextBlock\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: eztext}
+            - {name: ibexa.field_type, alias: eztext}
 
     ezpublish.fieldType.ezstring:
         class: Ibexa\Core\FieldType\TextLine\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezstring}
+            - {name: ibexa.field_type, alias: ezstring}
 
     ezpublish.fieldType.ezurl:
         class: Ibexa\Core\FieldType\Url\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezurl}
+            - {name: ibexa.field_type, alias: ezurl}
 
     ezpublish.fieldType.ezgmaplocation:
         class: Ibexa\Core\FieldType\MapLocation\Type
         parent: ezpublish.fieldType
         tags:
-            - {name: ezplatform.field_type, alias: ezgmaplocation}
+            - {name: ibexa.field_type, alias: ezgmaplocation}
 
     ezpublish.fieldType.ezobjectrelationlist:
         class: Ibexa\Core\FieldType\RelationList\Type
@@ -395,7 +395,7 @@ services:
         arguments:
             - "@ezpublish.spi.persistence.cache.contentHandler"
         tags:
-            - {name: ezplatform.field_type, alias: ezobjectrelationlist}
+            - {name: ibexa.field_type, alias: ezobjectrelationlist}
 
     ezpublish.fieldType.ezuser:
         class: Ibexa\Core\FieldType\User\Type
@@ -405,7 +405,7 @@ services:
             - '@Ibexa\Contracts\Core\Repository\PasswordHashService'
             - '@Ibexa\Core\Repository\User\PasswordValidatorInterface'
         tags:
-            - {name: ezplatform.field_type, alias: ezuser}
+            - {name: ibexa.field_type, alias: ezuser}
 
     # Not implemented fieldtypes
     # Configured to use the Null type to not throw exception
@@ -415,84 +415,84 @@ services:
         parent: ezpublish.fieldType
         arguments: [ "ezenum" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezenum}
+            - {name: ibexa.field_type, alias: ezenum}
 
     ezpublish.fieldType.ezidentifier:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezidentifier" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezidentifier}
+            - {name: ibexa.field_type, alias: ezidentifier}
 
     ezpublish.fieldType.ezinisetting:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezinisetting" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezinisetting}
+            - {name: ibexa.field_type, alias: ezinisetting}
 
     ezpublish.fieldType.ezmatrix:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezmatrix" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezmatrix}
+            - {name: ibexa.field_type, alias: ezmatrix}
 
     ezpublish.fieldType.ezmultioption:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezmultioption" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezmultioption}
+            - {name: ibexa.field_type, alias: ezmultioption}
 
     ezpublish.fieldType.ezmultioption2:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezmultioption2" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezmultioption2}
+            - {name: ibexa.field_type, alias: ezmultioption2}
 
     ezpublish.fieldType.ezmultiprice:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezmultiprice" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezmultiprice}
+            - {name: ibexa.field_type, alias: ezmultiprice}
 
     ezpublish.fieldType.ezoption:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezoption" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezoption}
+            - {name: ibexa.field_type, alias: ezoption}
 
     ezpublish.fieldType.ezpackage:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezpackage" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezpackage}
+            - {name: ibexa.field_type, alias: ezpackage}
 
     ezpublish.fieldType.ezproductcategory:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezproductcategory" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezproductcategory}
+            - {name: ibexa.field_type, alias: ezproductcategory}
 
     ezpublish.fieldType.ezrangeoption:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezrangeoption" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezrangeoption}
+            - {name: ibexa.field_type, alias: ezrangeoption}
 
     ezpublish.fieldType.ezsubtreesubscription:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezsubtreesubscription" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezsubtreesubscription}
+            - {name: ibexa.field_type, alias: ezsubtreesubscription}
 
     # not implemented fieldtypes from extensions
     ezpublish.fieldType.ezcomcomments:
@@ -500,35 +500,35 @@ services:
         parent: ezpublish.fieldType
         arguments: [ "ezcomcomments" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezcomcomments}
+            - {name: ibexa.field_type, alias: ezcomcomments}
 
     ezpublish.fieldType.ezpaex:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezpaex" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezpaex}
+            - {name: ibexa.field_type, alias: ezpaex}
 
     ezpublish.fieldType.ezsurvey:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezsurvey" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezsurvey}
+            - {name: ibexa.field_type, alias: ezsurvey}
 
     ezpublish.fieldType.eztags:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "eztags" ]
         tags:
-            - {name: ezplatform.field_type, alias: eztags}
+            - {name: ibexa.field_type, alias: eztags}
 
     ezpublish.fieldType.ezrecommendation:
         class: Ibexa\Core\FieldType\Null\Type
         parent: ezpublish.fieldType
         arguments: [ "ezrecommendation" ]
         tags:
-            - {name: ezplatform.field_type, alias: ezrecommendation}
+            - {name: ibexa.field_type, alias: ezrecommendation}
 
     Ibexa\Core\FieldType\ImageAsset\Type:
         parent: ezpublish.fieldType
@@ -538,7 +538,7 @@ services:
             - '@Ibexa\Core\FieldType\ImageAsset\AssetMapper'
             - '@ezpublish.spi.persistence.cache.contentHandler'
         tags:
-            - {name: ezplatform.field_type, alias: ezimageasset}
+            - {name: ibexa.field_type, alias: ezimageasset}
 
     ezpublish.fieldType.ezimageasset:
         alias: Ibexa\Core\FieldType\ImageAsset\Type

--- a/src/lib/Resources/settings/indexable_fieldtypes.yml
+++ b/src/lib/Resources/settings/indexable_fieldtypes.yml
@@ -6,133 +6,133 @@ services:
     ezpublish.fieldType.indexable.ezkeyword:
         class: Ibexa\Core\FieldType\Keyword\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezkeyword}
+            - {name: ibexa.field_type.indexable, alias: ezkeyword}
 
     ezpublish.fieldType.indexable.ezauthor:
         class: Ibexa\Core\FieldType\Author\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezauthor}
+            - {name: ibexa.field_type.indexable, alias: ezauthor}
 
     ezpublish.fieldType.indexable.ezstring:
         class: Ibexa\Core\FieldType\TextLine\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezstring}
+            - {name: ibexa.field_type.indexable, alias: ezstring}
 
     ezpublish.fieldType.indexable.ezgmaplocation:
         class: Ibexa\Core\FieldType\MapLocation\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezgmaplocation}
+            - {name: ibexa.field_type.indexable, alias: ezgmaplocation}
 
     ezpublish.fieldType.indexable.ezcountry:
         class: Ibexa\Core\FieldType\Country\SearchField
         arguments:
             - "%ezpublish.fieldType.ezcountry.data%"
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezcountry}
+            - {name: ibexa.field_type.indexable, alias: ezcountry}
 
     ezpublish.fieldType.indexable.ezdate:
         class: Ibexa\Core\FieldType\Date\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezdate}
+            - {name: ibexa.field_type.indexable, alias: ezdate}
 
     ezpublish.fieldType.indexable.ezinteger:
         class: Ibexa\Core\FieldType\Integer\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezinteger}
+            - {name: ibexa.field_type.indexable, alias: ezinteger}
 
     ezpublish.fieldType.indexable.ezfloat:
         class: Ibexa\Core\FieldType\Float\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezfloat}
+            - {name: ibexa.field_type.indexable, alias: ezfloat}
 
     ezpublish.fieldType.indexable.ezemail:
         class: Ibexa\Core\FieldType\EmailAddress\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezemail}
+            - {name: ibexa.field_type.indexable, alias: ezemail}
 
     ezpublish.fieldType.indexable.ezimage:
         class: Ibexa\Core\FieldType\Image\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezimage}
+            - {name: ibexa.field_type.indexable, alias: ezimage}
 
     ezpublish.fieldType.indexable.ezmedia:
         class: Ibexa\Core\FieldType\Media\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezmedia}
+            - {name: ibexa.field_type.indexable, alias: ezmedia}
 
     ezpublish.fieldType.indexable.ezbinaryfile:
         class: Ibexa\Core\FieldType\BinaryFile\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezbinaryfile}
+            - {name: ibexa.field_type.indexable, alias: ezbinaryfile}
 
     ezpublish.fieldType.indexable.eztime:
         class: Ibexa\Core\FieldType\Time\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: eztime}
+            - {name: ibexa.field_type.indexable, alias: eztime}
 
     ezpublish.fieldType.indexable.eztext:
         class: Ibexa\Core\FieldType\TextBlock\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: eztext}
+            - {name: ibexa.field_type.indexable, alias: eztext}
 
     ezpublish.fieldType.indexable.ezboolean:
         class: Ibexa\Core\FieldType\Checkbox\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezboolean}
+            - {name: ibexa.field_type.indexable, alias: ezboolean}
 
     ezpublish.fieldType.indexable.ezdatetime:
         class: Ibexa\Core\FieldType\DateAndTime\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezdatetime}
+            - {name: ibexa.field_type.indexable, alias: ezdatetime}
 
     ezpublish.fieldType.indexable.ezisbn:
         class: Ibexa\Core\FieldType\ISBN\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezisbn}
+            - {name: ibexa.field_type.indexable, alias: ezisbn}
 
     ezpublish.fieldType.indexable.ezobjectrelation:
         class: Ibexa\Core\FieldType\Relation\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezobjectrelation}
+            - {name: ibexa.field_type.indexable, alias: ezobjectrelation}
 
     ezpublish.fieldType.indexable.ezselection:
         class: Ibexa\Core\FieldType\Selection\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezselection}
+            - {name: ibexa.field_type.indexable, alias: ezselection}
 
     ezpublish.fieldType.indexable.ezobjectrelationlist:
         class: Ibexa\Core\FieldType\RelationList\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezobjectrelationlist}
+            - {name: ibexa.field_type.indexable, alias: ezobjectrelationlist}
 
     ezpublish.fieldType.indexable.ezurl:
         class: Ibexa\Core\FieldType\Url\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezurl}
+            - {name: ibexa.field_type.indexable, alias: ezurl}
 
     ezpublish.fieldType.indexable.ezimageasset:
         class: Ibexa\Core\FieldType\ImageAsset\SearchField
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezimageasset}
+            - {name: ibexa.field_type.indexable, alias: ezimageasset}
 
 
     ezpublish.fieldType.indexable.unindexed:
         class: Ibexa\Core\FieldType\Unindexed
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezuser}
-            - {name: ezplatform.field_type.indexable, alias: ezenum}
-            - {name: ezplatform.field_type.indexable, alias: ezidentifier}
-            - {name: ezplatform.field_type.indexable, alias: ezinisetting}
-            - {name: ezplatform.field_type.indexable, alias: ezmatrix}
-            - {name: ezplatform.field_type.indexable, alias: ezmultioption}
-            - {name: ezplatform.field_type.indexable, alias: ezmultioption2}
-            - {name: ezplatform.field_type.indexable, alias: ezmultiprice}
-            - {name: ezplatform.field_type.indexable, alias: ezoption}
-            - {name: ezplatform.field_type.indexable, alias: ezpackage}
-            - {name: ezplatform.field_type.indexable, alias: ezproductcategory}
-            - {name: ezplatform.field_type.indexable, alias: ezrangeoption}
-            - {name: ezplatform.field_type.indexable, alias: ezsubtreesubscription}
-            - {name: ezplatform.field_type.indexable, alias: ezcomcomments}
-            - {name: ezplatform.field_type.indexable, alias: ezsurvey}
-            - {name: ezplatform.field_type.indexable, alias: eztags}
-            - {name: ezplatform.field_type.indexable, alias: ezrecommendation}
+            - {name: ibexa.field_type.indexable, alias: ezuser}
+            - {name: ibexa.field_type.indexable, alias: ezenum}
+            - {name: ibexa.field_type.indexable, alias: ezidentifier}
+            - {name: ibexa.field_type.indexable, alias: ezinisetting}
+            - {name: ibexa.field_type.indexable, alias: ezmatrix}
+            - {name: ibexa.field_type.indexable, alias: ezmultioption}
+            - {name: ibexa.field_type.indexable, alias: ezmultioption2}
+            - {name: ibexa.field_type.indexable, alias: ezmultiprice}
+            - {name: ibexa.field_type.indexable, alias: ezoption}
+            - {name: ibexa.field_type.indexable, alias: ezpackage}
+            - {name: ibexa.field_type.indexable, alias: ezproductcategory}
+            - {name: ibexa.field_type.indexable, alias: ezrangeoption}
+            - {name: ibexa.field_type.indexable, alias: ezsubtreesubscription}
+            - {name: ibexa.field_type.indexable, alias: ezcomcomments}
+            - {name: ibexa.field_type.indexable, alias: ezsurvey}
+            - {name: ibexa.field_type.indexable, alias: eztags}
+            - {name: ibexa.field_type.indexable, alias: ezrecommendation}

--- a/src/lib/Resources/settings/limitations/language.yml
+++ b/src/lib/Resources/settings/limitations/language.yml
@@ -6,7 +6,7 @@ services:
     _instanceof:
         Ibexa\Core\Limitation\LanguageLimitation\VersionTargetEvaluator:
             tags:
-                - { name: ezplatform.limitation.language.version_target_evaluator }
+                - { name: ibexa.permissions.limitation_type.language_target_evaluator.version }
 
     Ibexa\Core\Limitation\LanguageLimitation\:
         resource: '../../../Limitation/LanguageLimitation/*'

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -198,7 +198,7 @@ services:
     # Permission-related
     Ibexa\Core\Repository\Permission\LimitationService:
         arguments:
-            $limitationTypes: !tagged_iterator { tag: ezpublish.limitationType, index_by: alias }
+            $limitationTypes: !tagged_iterator { tag: ibexa.permissions.limitation_type, index_by: alias }
 
     Ibexa\Core\Repository\Permission\PermissionResolver:
         arguments:
@@ -220,14 +220,14 @@ services:
 
     Ibexa\Core\Repository\Strategy\ContentValidator\ContentValidatorStrategy:
         arguments:
-            $contentValidators: !tagged_iterator ezplatform.spi.content.validator
+            $contentValidators: !tagged_iterator ibexa.repository.content.validator
 
     Ibexa\Core\Repository\Validator\ContentCreateStructValidator:
         arguments:
             $contentMapper: '@Ibexa\Core\Repository\Mapper\ContentMapper'
             $fieldTypeRegistry: '@Ibexa\Core\FieldType\FieldTypeRegistry'
         tags:
-            - ezplatform.spi.content.validator
+            - ibexa.repository.content.validator
 
     Ibexa\Core\Repository\Validator\ContentUpdateStructValidator:
         arguments:
@@ -235,13 +235,13 @@ services:
             $fieldTypeRegistry: '@Ibexa\Core\FieldType\FieldTypeRegistry'
             $contentLanguageHandler: '@ezpublish.spi.persistence.language_handler'
         tags:
-            - ezplatform.spi.content.validator
+            - ibexa.repository.content.validator
 
     Ibexa\Core\Repository\Validator\VersionValidator:
         arguments:
             $fieldTypeRegistry: '@Ibexa\Core\FieldType\FieldTypeRegistry'
         tags:
-            - ezplatform.spi.content.validator
+            - ibexa.repository.content.validator
 
     Ibexa\Contracts\Core\Repository\Validator\ContentValidator: '@Ibexa\Core\Repository\Strategy\ContentValidator\ContentValidatorStrategy'
 

--- a/src/lib/Resources/settings/roles.yml
+++ b/src/lib/Resources/settings/roles.yml
@@ -10,99 +10,99 @@ services:
         class: Ibexa\Core\Limitation\ContentTypeLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: Class}
+            - {name: ibexa.permissions.limitation_type, alias: Class}
 
     ezpublish.api.role.limitation_type.language:
         class: Ibexa\Core\Limitation\LanguageLimitationType
         arguments:
             $persistenceLanguageHandler: '@ezpublish.spi.persistence.language_handler'
             $persistenceContentHandler: '@ezpublish.spi.persistence.content_handler'
-            $versionTargetEvaluators: !tagged ezplatform.limitation.language.version_target_evaluator
+            $versionTargetEvaluators: !tagged ibexa.permissions.limitation_type.language_target_evaluator.version
         tags:
-            - {name: ezpublish.limitationType, alias: Language}
+            - {name: ibexa.permissions.limitation_type, alias: Language}
 
     ezpublish.api.role.limitation_type.location:
         class: Ibexa\Core\Limitation\LocationLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: Node}
+            - {name: ibexa.permissions.limitation_type, alias: Node}
 
     ezpublish.api.role.limitation_type.owner:
         class: Ibexa\Core\Limitation\OwnerLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: Owner}
+            - {name: ibexa.permissions.limitation_type, alias: Owner}
 
     ezpublish.api.role.limitation_type.parent_content_type:
         class: Ibexa\Core\Limitation\ParentContentTypeLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: ParentClass}
+            - {name: ibexa.permissions.limitation_type, alias: ParentClass}
 
     ezpublish.api.role.limitation_type.parent_depth:
         class: Ibexa\Core\Limitation\ParentDepthLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: ParentDepth}
+            - {name: ibexa.permissions.limitation_type, alias: ParentDepth}
 
     ezpublish.api.role.limitation_type.parent_owner:
         class: Ibexa\Core\Limitation\ParentOwnerLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: ParentOwner}
+            - {name: ibexa.permissions.limitation_type, alias: ParentOwner}
 
     ezpublish.api.role.limitation_type.parent_group:
         class: Ibexa\Core\Limitation\ParentUserGroupLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: ParentGroup}
+            - {name: ibexa.permissions.limitation_type, alias: ParentGroup}
 
     ezpublish.api.role.limitation_type.section:
         class: Ibexa\Core\Limitation\SectionLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: Section}
+            - {name: ibexa.permissions.limitation_type, alias: Section}
 
     ezpublish.api.role.limitation_type.new_section:
         class: Ibexa\Core\Limitation\NewSectionLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: NewSection}
+            - {name: ibexa.permissions.limitation_type, alias: NewSection}
 
     ezpublish.api.role.limitation_type.siteaccess:
         class: Ibexa\Core\Limitation\SiteAccessLimitationType
         arguments: ['@ezpublish.siteaccess_service']
         tags:
-            - {name: ezpublish.limitationType, alias: SiteAccess}
+            - {name: ibexa.permissions.limitation_type, alias: SiteAccess}
 
     ezpublish.api.role.limitation_type.state:
         class: Ibexa\Core\Limitation\ObjectStateLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: State}
+            - {name: ibexa.permissions.limitation_type, alias: State}
 
     ezpublish.api.role.limitation_type.new_state:
         class: Ibexa\Core\Limitation\NewObjectStateLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: NewState}
+            - {name: ibexa.permissions.limitation_type, alias: NewState}
 
     ezpublish.api.role.limitation_type.subtree:
         class: Ibexa\Core\Limitation\SubtreeLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: Subtree}
+            - {name: ibexa.permissions.limitation_type, alias: Subtree}
 
     ezpublish.api.role.limitation_type.user_group:
         class: Ibexa\Core\Limitation\UserGroupLimitationType
         arguments: ["@ezpublish.api.persistence_handler"]
         tags:
-            - {name: ezpublish.limitationType, alias: Group}
+            - {name: ibexa.permissions.limitation_type, alias: Group}
 
     ezpublish.api.role.limitation_type.status:
         class: Ibexa\Core\Limitation\StatusLimitationType
         tags:
-            - {name: ezpublish.limitationType, alias: Status}
+            - {name: ibexa.permissions.limitation_type, alias: Status}
 
     ## Non implemented Limitations
     # Configured to use "blocking" limitation (as they are not implemented) to avoid LimitationNotFoundException
@@ -111,20 +111,20 @@ services:
     ezpublish.api.role.limitation_type.function_list:
         class: Ibexa\Core\Limitation\BlockingLimitationType
         arguments: ['FunctionList']
-        tags: [{name: ezpublish.limitationType, alias: FunctionList}]
+        tags: [{name: ibexa.permissions.limitation_type, alias: FunctionList}]
 
     # Misc limitations used by ezcomments, not applicable to Platform replacement: EzCommentsBundle
     ezpublish.api.role.limitation_type.ezcomments.content_section:
         class: Ibexa\Core\Limitation\BlockingLimitationType
         arguments: ['ContentSection']
-        tags: [{name: ezpublish.limitationType, alias: ContentSection}]
+        tags: [{name: ibexa.permissions.limitation_type, alias: ContentSection}]
 
     ezpublish.api.role.limitation_type.ezcomments.comment_creator:
         class: Ibexa\Core\Limitation\BlockingLimitationType
         arguments: ['CommentCreator']
-        tags: [{name: ezpublish.limitationType, alias: CommentCreator}]
+        tags: [{name: ibexa.permissions.limitation_type, alias: CommentCreator}]
 
     ezpublish.api.role.limitation_type.ezcomments.anti_spam:
         class: Ibexa\Core\Limitation\BlockingLimitationType
         arguments: ['AntiSpam']
-        tags: [{name: ezpublish.limitationType, alias: AntiSpam}]
+        tags: [{name: ibexa.permissions.limitation_type, alias: AntiSpam}]

--- a/src/lib/Resources/settings/search_engines/common.yml
+++ b/src/lib/Resources/settings/search_engines/common.yml
@@ -24,7 +24,7 @@ parameters:
         ez_fulltext: 'fulltext'
 
 services:
-    # Note: services tagged with 'ezplatform.field_type.indexable'
+    # Note: services tagged with 'ibexa.field_type.indexable'
     # are registered to this one using compilation pass
     ezpublish.search.common.field_registry:
         class: Ibexa\Core\Search\Common\FieldRegistry
@@ -42,7 +42,7 @@ services:
             - "@ezpublish.spi.persistence.content_type_handler"
             - "@ezpublish.search.common.field_name_generator"
 
-    # Note: services tagged with 'ezpublish.search.common.field_value_mapper'
+    # Note: services tagged with 'ibexa.search.common.field_value.mapper'
     # are registered to this one using compilation pass
     ezpublish.search.common.field_value_mapper.aggregate:
         class: Ibexa\Core\Search\Common\FieldValueMapper\Aggregate

--- a/src/lib/Resources/settings/search_engines/field_value_mappers.yml
+++ b/src/lib/Resources/settings/search_engines/field_value_mappers.yml
@@ -2,72 +2,72 @@ services:
     ezpublish.search.common.field_value_mapper.boolean:
         class: Ibexa\Core\Search\Common\FieldValueMapper\BooleanMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.date:
         class: Ibexa\Core\Search\Common\FieldValueMapper\DateMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.document:
         class: Ibexa\Core\Search\Common\FieldValueMapper\DocumentMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.geo_location:
         class: Ibexa\Core\Search\Common\FieldValueMapper\GeoLocationMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.float:
         class: Ibexa\Core\Search\Common\FieldValueMapper\FloatMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.identifier:
         class: Ibexa\Core\Search\Common\FieldValueMapper\IdentifierMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.multiple_integer:
         class: Ibexa\Core\Search\Common\FieldValueMapper\MultipleIntegerMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.integer:
         class: Ibexa\Core\Search\Common\FieldValueMapper\IntegerMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.multiple_boolean:
         class: Ibexa\Core\Search\Common\FieldValueMapper\MultipleBooleanMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.multiple_identifier:
         class: Ibexa\Core\Search\Common\FieldValueMapper\MultipleIdentifierMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.multiple_string:
         class: Ibexa\Core\Search\Common\FieldValueMapper\MultipleStringMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.price:
         class: Ibexa\Core\Search\Common\FieldValueMapper\PriceMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     ezpublish.search.common.field_value_mapper.string:
         class: Ibexa\Core\Search\Common\FieldValueMapper\StringMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     Ibexa\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper:
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}
 
     Ibexa\Core\Search\Common\FieldValueMapper\MultipleRemoteIdentifierMapper:
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - {name: ibexa.search.common.field_value.mapper}

--- a/src/lib/Resources/settings/search_engines/legacy.yml
+++ b/src/lib/Resources/settings/search_engines/legacy.yml
@@ -68,7 +68,7 @@ services:
             $languageHandler: '@ezpublish.spi.persistence.language_handler'
             $mapper: '@ezpublish.search.legacy.fulltext_mapper'
         tags:
-            - {name: ezplatform.search_engine, alias: legacy}
+            - {name: ibexa.search.engine, alias: legacy}
         lazy: true
 
     ezpublish.spi.search.legacy.indexer:
@@ -79,7 +79,7 @@ services:
             $connection: '@ezpublish.persistence.connection'
             $searchHandler: "@ezpublish.spi.search.legacy"
         tags:
-            - {name: ezplatform.search_engine.indexer, alias: legacy}
+            - {name: ibexa.search.engine.indexer, alias: legacy}
         lazy: true
 
     Ibexa\Core\Search\Legacy\Content\IndexerGateway:

--- a/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -63,30 +63,30 @@ services:
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\CompositeCriterion:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_group_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeGroupId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier
@@ -95,16 +95,16 @@ services:
             $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
             $logger: '@?logger'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.date_metadata:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\DateMetadata
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\Field
@@ -114,8 +114,8 @@ services:
             $fieldValueConverter: '@ezpublish.search.legacy.gateway.criterion_field_value_converter'
             $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field_empty:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldEmpty
@@ -124,8 +124,8 @@ services:
             $fieldConverterRegistry: '@ezpublish.persistence.legacy.field_value_converter.registry'
             $fieldTypeService: '@ezpublish.api.service.field_type'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.full_text:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FullText
@@ -135,8 +135,8 @@ services:
             $languageMaskGenerator: '@ezpublish.persistence.legacy.language.mask_generator'
             $configuration: '%ezpublish.search.legacy.criterion_handler.full_text.configuration%'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.language_code:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LanguageCode
@@ -144,105 +144,105 @@ services:
         arguments:
             $maskGenerator: '@ezpublish.persistence.legacy.language.mask_generator'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.logical_and:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LogicalAnd
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.logical_not:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LogicalNot
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.logical_or:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LogicalOr
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.map_location_distance:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\MapLocationDistance
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.match_all:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\MatchAll
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.match_none:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\MatchNone
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.object_state_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ObjectStateId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.object_state_identifier:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ObjectStateIdentifier
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field_relation:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldRelation
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.remote_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\RemoteId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.section_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\SectionId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.section_identifier:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\SectionIdentifier
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_email:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
@@ -250,8 +250,8 @@ services:
         arguments:
             $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_login:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
@@ -259,34 +259,34 @@ services:
         arguments:
             $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.is_user_enabled:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\IsUserEnabled
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_metadata:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserMetadata
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.criterion.handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.is_user_based:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\IsUserBased
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     # Criterion field value handlers
 
-    # Note: services tagged with 'ezpublish.search.legacy.gateway.criterion_field_value_handler'
+    # Note: services tagged with 'ibexa.search.legacy.gateway.criterion_handler.field_value'
     # are registered to this one using compilation pass
     ezpublish.search.legacy.gateway.criterion_field_value_handler.registry:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\HandlerRegistry
@@ -303,15 +303,15 @@ services:
         arguments:
             $separator: ','
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezauthor}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezcountry}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezobjectrelationlist}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezauthor}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezcountry}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezobjectrelationlist}
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.keyword:
         parent: ezpublish.search.legacy.gateway.criterion_field_value_handler.collection.comma_separated
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Keyword
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezkeyword}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezkeyword}
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.collection.hypen_separated:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler
@@ -319,7 +319,7 @@ services:
         arguments:
             $separator: '-'
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezselection}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezselection}
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.composite:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler
@@ -329,13 +329,13 @@ services:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Simple
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezboolean}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezdate}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezdatetime}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezemail}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezinteger}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezobjectrelation}
-            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: eztime}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezboolean}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezdate}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezdatetime}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezemail}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezinteger}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: ezobjectrelation}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.field_value, alias: eztime}
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.default:
         alias: ezpublish.search.legacy.gateway.criterion_field_value_handler.composite

--- a/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_content.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_content.yml
@@ -9,25 +9,25 @@ services:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Gateway\CriterionHandler\Ancestor
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.location_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Gateway\CriterionHandler\LocationId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.location_remote_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Gateway\CriterionHandler\LocationRemoteId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.parent_location_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Gateway\CriterionHandler\ParentLocationId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
 
     # Needs to be before subtree, as permission_subtree extends it.
     # Only needed for Content Search on SQL engines where applying Permissions Subtree criterion on all possible
@@ -36,16 +36,16 @@ services:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Gateway\CriterionHandler\PermissionSubtree
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.subtree:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Gateway\CriterionHandler\Subtree
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.visibility:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Gateway\CriterionHandler\Visibility
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.content}

--- a/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_location.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_location.yml
@@ -9,52 +9,52 @@ services:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Ancestor
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.depth:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\Depth
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.location_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\LocationId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.is_main_location:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\IsMainLocation
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.parent_location_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\ParentLocationId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.priority:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\Priority
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.location_remote_id:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\LocationRemoteId
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.subtree:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Subtree
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.visibility:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Visibility
         tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ibexa.search.legacy.gateway.criterion_handler.location}

--- a/src/lib/Resources/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -8,30 +8,30 @@ services:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\ContentId
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.content_name:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\ContentName
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.date_modified:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\DateModified
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.date_published:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\DatePublished
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Field:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
@@ -39,72 +39,72 @@ services:
             $languageHandler: '@ezpublish.spi.persistence.language_handler'
             $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.map_location_distance:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\MapLocationDistance
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Field
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.section_identifier:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\SectionIdentifier
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.section_name:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\SectionName
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory:
         arguments:
             - '@ezpublish.persistence.connection'
-            - !tagged ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random
+            - !tagged ibexa.search.legacy.gateway.sort_clause_handler.gateway.random
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.random:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\AbstractRandom
         factory: ['@Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory', 'getGateway']
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.content}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Random\MySqlRandom:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.gateway.random}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Random\SqlLiteRandom:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.gateway.random}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Random\PgSqlRandom:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.gateway.random}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\ContentTypeName:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\UserLogin:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\DateTrashed:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     # BC
     ezpublish.search.legacy.gateway.sort_clause_handler.base: '@Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler'

--- a/src/lib/Resources/settings/search_engines/legacy/sort_clause_handlers_location.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/sort_clause_handlers_location.yml
@@ -9,37 +9,37 @@ services:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Id
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.depth:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Depth
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.path:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Path
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.is_main_location:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\IsMainLocation
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.priority:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Priority
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.trash.gateway.sort_clause.handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.visibility:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: Ibexa\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Visibility
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
+            - {name: ibexa.search.legacy.gateway.sort_clause_handler.location}

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -195,7 +195,7 @@ services:
         lazy: true
         arguments:
             $sharedPool: '@Ibexa\Core\Persistence\Cache\Adapter\TransactionalInMemoryCacheAdapter.inner'
-            $inMemoryPools: !tagged ez.spi.persistence.cache.inmemory
+            $inMemoryPools: !tagged ibexa.cache.persistence.inmemory
 
     ezpublish.cache_pool:
         public: true
@@ -223,7 +223,7 @@ services:
             - "%ezpublish.spi.persistence.cache.inmemory.ttl%"
             - "%ezpublish.spi.persistence.cache.inmemory.limit%"
             - "%ezpublish.spi.persistence.cache.inmemory.enable%"
-        tags: ['ez.spi.persistence.cache.inmemory']
+        tags: [ ibexa.cache.persistence.inmemory ]
 
     ezpublish.spi.persistence.cache.inmemory.content:
         public: false
@@ -232,7 +232,7 @@ services:
             - "%ezpublish.spi.persistence.cache.inmemory.content.ttl%"
             - "%ezpublish.spi.persistence.cache.inmemory.content.limit%"
             - "%ezpublish.spi.persistence.cache.inmemory.content.enable%"
-        tags: ['ez.spi.persistence.cache.inmemory']
+        tags: [ ibexa.cache.persistence.inmemory ]
 
     Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface:
         alias: Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGenerator

--- a/src/lib/Resources/settings/storage_engines/legacy.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy.yml
@@ -41,7 +41,7 @@ services:
             - "@ezpublish.spi.persistence.legacy.user_preference.handler"
             - "@ezpublish.spi.persistence.legacy.setting.handler"
         tags:
-            - {name: ezpublish.storageEngine, alias: legacy}
+            - {name: ibexa.storage, alias: legacy}
         lazy: true
         public: true # @todo should be private
 

--- a/src/lib/Resources/settings/storage_engines/legacy/field_value_converters.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/field_value_converters.yml
@@ -1,6 +1,6 @@
 services:
-    # Note: converter services tagged with 'ezplatform.field_type.legacy_storage.converter' are
-    # registered to this one using compilation pass and factory
+    # Note: converter services tagged with 'ibexa.field_type.storage.legacy.converter'
+    # are registered to this one using compilation pass and factory
     ezpublish.persistence.legacy.field_value_converter.registry:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry
         lazy: true
@@ -12,69 +12,69 @@ services:
     ezpublish.fieldType.ezauthor.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\AuthorConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezauthor}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezauthor}
 
     ezpublish.fieldType.ezbinaryfile.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\BinaryFileConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezbinaryfile}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezbinaryfile}
 
     ezpublish.fieldType.ezboolean.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\CheckboxConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezboolean}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezboolean}
 
     ezpublish.fieldType.ezcountry.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\CountryConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezcountry}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezcountry}
 
     ezpublish.fieldType.ezdatetime.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezdatetime}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezdatetime}
 
     ezpublish.fieldType.ezfloat.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\FloatConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezfloat}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezfloat}
 
     ezpublish.fieldType.ezinteger.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\IntegerConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezinteger}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezinteger}
 
     ezpublish.fieldType.ezkeyword.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\KeywordConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezkeyword}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezkeyword}
 
     ezpublish.fieldType.ezmedia.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\MediaConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezmedia}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezmedia}
 
     ezpublish.fieldType.ezselection.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter
         arguments:
             - '@ezpublish.api.service.language'
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezselection}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezselection}
 
     ezpublish.fieldType.ezstring.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezstring}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezstring}
 
     ezpublish.fieldType.eztext.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: eztext}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: eztext}
 
     ezpublish.fieldType.ezurl.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezurl}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezurl}
 
     ezpublish.fieldType.ezimage.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter
@@ -82,141 +82,141 @@ services:
             - "@ezpublish.fieldType.ezimage.io_service"
             - "@ezpublish.core.io.image_fieldtype.legacy_url_redecorator"
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezimage}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezimage}
 
     ezpublish.fieldType.ezisbn.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\ISBNConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezisbn}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezisbn}
 
     ezpublish.fieldType.ezgmaplocation.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\MapLocationConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezgmaplocation}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezgmaplocation}
 
     ezpublish.fieldType.ezemail.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\EmailAddressConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezemail}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezemail}
 
     ezpublish.fieldType.ezobjectrelation.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezobjectrelation}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezobjectrelation}
 
     ezpublish.fieldType.ezobjectrelationlist.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationListConverter
         arguments:
             $connection: '@ezpublish.persistence.connection'
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezobjectrelationlist}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezobjectrelationlist}
 
     ezpublish.fieldType.ezuser.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\UserConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezuser}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezuser}
 
     # Not implemented converters
     # Configured to use the Null converter which does not nothing
     ezpublish.fieldType.ezdate.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\DateConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezdate}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezdate}
 
     ezpublish.fieldType.ezenum.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezenum}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezenum}
 
     ezpublish.fieldType.ezidentifier.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezidentifier}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezidentifier}
 
     ezpublish.fieldType.ezinisetting.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezinisetting}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezinisetting}
 
     ezpublish.fieldType.ezmatrix.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezmatrix}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezmatrix}
 
     ezpublish.fieldType.ezmultioption.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezmultioption}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezmultioption}
 
     ezpublish.fieldType.ezmultioption2.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezmultioption2}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezmultioption2}
 
     ezpublish.fieldType.ezmultiprice.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezmultiprice}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezmultiprice}
 
     ezpublish.fieldType.ezoption.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezoption}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezoption}
 
     ezpublish.fieldType.ezpackage.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezpackage}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezpackage}
 
     ezpublish.fieldType.ezproductcategory.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezproductcategory}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezproductcategory}
 
     ezpublish.fieldType.ezrangeoption.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezrangeoption}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezrangeoption}
 
     ezpublish.fieldType.ezsubtreesubscription.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezsubtreesubscription}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezsubtreesubscription}
 
     ezpublish.fieldType.eztime.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\TimeConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: eztime}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: eztime}
 
     # not implemented converters from extensions
     ezpublish.fieldType.ezcomcomments.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezcomcomments}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezcomcomments}
 
     ezpublish.fieldType.ezpaex.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezpaex}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezpaex}
 
     ezpublish.fieldType.ezsurvey.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezsurvey}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezsurvey}
 
     ezpublish.fieldType.eztags.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: eztags}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: eztags}
 
     ezpublish.fieldType.ezrecommendation.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezrecommendation}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezrecommendation}
 
     Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageAssetConverter:
         tags:
-            - {name: ezplatform.field_type.legacy_storage.converter, alias: ezimageasset}
+            - {name: ibexa.field_type.storage.legacy.converter, alias: ezimageasset}
 
     ezpublish.fieldType.ezimageasset.converter:
         alias: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageAssetConverter

--- a/src/lib/Resources/settings/storage_engines/legacy/filter.yaml
+++ b/src/lib/Resources/settings/storage_engines/legacy/filter.yaml
@@ -33,11 +33,11 @@ services:
 
     Ibexa\Core\Persistence\Legacy\Filter\CriterionVisitor:
         arguments:
-            $criterionQueryBuilders: !tagged_iterator ezplatform.filter.criterion.query_builder
+            $criterionQueryBuilders: !tagged_iterator ibexa.filter.criterion.query.builder
 
     Ibexa\Core\Persistence\Legacy\Filter\SortClauseVisitor:
         arguments:
-            $sortClauseQueryBuilders: !tagged_iterator ezplatform.filter.sort_clause.query_builder
+            $sortClauseQueryBuilders: !tagged_iterator ibexa.filter.sort_clause.query.builder
 
     Ibexa\Core\Persistence\Legacy\Filter\Gateway\Content\Doctrine\DoctrineGateway:
         arguments:

--- a/src/lib/Resources/settings/storage_engines/legacy/shared_gateway.yaml
+++ b/src/lib/Resources/settings/storage_engines/legacy/shared_gateway.yaml
@@ -10,12 +10,12 @@ services:
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\DatabasePlatform\SqliteGateway:
         tags:
-            - { name: ezplatform.persistence.legacy.gateway.shared, platform: sqlite }
+            - { name: ibexa.storage.legacy.gateway.shared, platform: sqlite }
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\GatewayFactory:
         arguments:
             $fallbackGateway: '@Ibexa\Core\Persistence\Legacy\SharedGateway\DatabasePlatform\FallbackGateway'
-            $gateways: !tagged_iterator { tag: ezplatform.persistence.legacy.gateway.shared, index_by: platform }
+            $gateways: !tagged_iterator { tag: ibexa.storage.legacy.gateway.shared, index_by: platform }
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\Gateway:
         factory: ['@Ibexa\Core\Persistence\Legacy\SharedGateway\GatewayFactory', 'buildSharedGateway']

--- a/src/lib/Resources/settings/storage_engines/legacy/url_criterion_handlers.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/url_criterion_handlers.yml
@@ -6,58 +6,58 @@ services:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\LogicalAnd
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.logical_or:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\LogicalOr
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.logical_not:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\LogicalNot
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.match_all:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\MatchAll
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.match_none:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\MatchNone
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.validity:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\Validity
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.pattern:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\Pattern
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.visible_only:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\VisibleOnly
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.section_id:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\SectionId
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }
 
    ezpublish.persistence.legacy.url.criterion_handler.section_identifier:
        parent: ezpublish.persistence.legacy.url.criterion_handler.base
        class: Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\SectionIdentifier
        tags:
-           - { name: ezpublish.persistence.legacy.url.criterion_handler }
+           - { name: ibexa.storage.legacy.url.criterion.handler }

--- a/src/lib/Resources/settings/storage_engines/legacy/user.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/user.yml
@@ -40,9 +40,9 @@ services:
         parent: ezpublish.persistence.legacy.role.limitation.handler
         class: Ibexa\Core\Persistence\Legacy\User\Role\LimitationHandler\ObjectStateHandler
         tags:
-            - {name: ezpublish.persistence.legacy.role.limitation.handler}
+            - {name: ibexa.storage.legacy.role.limitation.handler}
 
-    # Note: services tagged with 'ezpublish.persistence.legacy.role.limitation.handler'
+    # Note: services tagged with 'ibexa.storage.legacy.role.limitation.handler'
     # are registered to this one using compilation pass
     ezpublish.persistence.legacy.role.limitation.converter:
         class: Ibexa\Core\Persistence\Legacy\User\Role\LimitationConverter

--- a/src/lib/Resources/settings/thumbnails.yml
+++ b/src/lib/Resources/settings/thumbnails.yml
@@ -10,7 +10,7 @@ services:
             $variationHandler: '@ezpublish.image_alias.imagine.cache.alias_generator_decorator'
             $variationName: 'medium'
         tags:
-            - { name: ezplatform.spi.field.thumbnail_strategy, priority: 0 }
+            - { name: ibexa.repository.thumbnail.strategy.field, priority: 0 }
 
     Ibexa\Core\FieldType\Image\ImageThumbnailProxyStrategy:
         decorates: Ibexa\Core\FieldType\Image\ImageThumbnailStrategy
@@ -25,19 +25,19 @@ services:
             $thumbnailStrategy: '@Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
             $contentService: '@ezpublish.api.service.content'
         tags:
-            - { name: ezplatform.spi.field.thumbnail_strategy, priority: 0 }
+            - { name: ibexa.repository.thumbnail.strategy.field, priority: 0 }
 
     Ibexa\Core\Repository\Strategy\ContentThumbnail\Field\ContentFieldStrategy:
         arguments:
-            $strategies: !tagged_iterator ezplatform.spi.field.thumbnail_strategy
+            $strategies: !tagged_iterator ibexa.repository.thumbnail.strategy.field
 
     Ibexa\Core\Repository\Strategy\ContentThumbnail\FirstMatchingFieldStrategy:
         arguments:
             $fieldTypeService: '@ezpublish.api.service.field_type'
             $contentFieldStrategy: '@Ibexa\Core\Repository\Strategy\ContentThumbnail\Field\ContentFieldStrategy'
         tags:
-            - { name: ezplatform.spi.content.thumbnail_strategy, priority: 0 }
+            - { name: ibexa.repository.thumbnail.strategy.content, priority: 0 }
 
     Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy:
         arguments:
-            $strategies: !tagged_iterator ezplatform.spi.content.thumbnail_strategy
+            $strategies: !tagged_iterator ibexa.repository.thumbnail.strategy.content

--- a/tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
@@ -45,11 +45,12 @@ class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
     {
         $resolverDef = new Definition();
         $serviceId = 'some_service_id';
-        if ($declaredPriority !== null) {
-            $resolverDef->addTag('ezpublish.config.resolver', ['priority' => $declaredPriority]);
-        } else {
-            $resolverDef->addTag('ezpublish.config.resolver');
-        }
+        $resolverDef->addTag(
+            'ibexa.site.config.resolver',
+            null !== $declaredPriority
+                ? ['priority' => $declaredPriority]
+                : []
+        );
 
         $this->setDefinition($serviceId, $resolverDef);
         $this->compile();

--- a/tests/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePassTest.php
@@ -36,7 +36,7 @@ class RegisterStorageEnginePassTest extends AbstractCompilerPassTestCase
     {
         $storageEngineDef = new Definition();
         $storageEngineIdentifier = 'i_am_a_storage_engine';
-        $storageEngineDef->addTag('ezpublish.storageEngine', ['alias' => $storageEngineIdentifier]);
+        $storageEngineDef->addTag('ibexa.storage', ['alias' => $storageEngineIdentifier]);
         $serviceId = 'storage_engine_service';
         $this->setDefinition($serviceId, $storageEngineDef);
 
@@ -55,7 +55,7 @@ class RegisterStorageEnginePassTest extends AbstractCompilerPassTestCase
         $storageEngineIdentifier = 'i_am_a_storage_engine';
 
         $this->container->setParameter('ezpublish.api.storage_engine.default', $storageEngineIdentifier);
-        $storageEngineDef->addTag('ezpublish.storageEngine', ['alias' => $storageEngineIdentifier]);
+        $storageEngineDef->addTag('ibexa.storage', ['alias' => $storageEngineIdentifier]);
         $serviceId = 'storage_engine_service';
         $this->setDefinition($serviceId, $storageEngineDef);
 
@@ -74,7 +74,7 @@ class RegisterStorageEnginePassTest extends AbstractCompilerPassTestCase
 
         $storageEngineDef = new Definition();
         $storageEngineIdentifier = 'i_am_a_storage_engine';
-        $storageEngineDef->addTag('ezpublish.storageEngine');
+        $storageEngineDef->addTag('ibexa.storage');
         $serviceId = 'storage_engine_service';
         $this->setDefinition($serviceId, $storageEngineDef);
 

--- a/tests/bundle/Core/DependencyInjection/Compiler/URLHandlerPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/URLHandlerPassTest.php
@@ -30,7 +30,7 @@ class URLHandlerPassTest extends AbstractCompilerPassTestCase
         $serviceId = 'service_id';
         $scheme = 'http';
         $definition = new Definition();
-        $definition->addTag('ezpublish.url_handler', ['scheme' => $scheme]);
+        $definition->addTag('ibexa.url_checker.handler', ['scheme' => $scheme]);
         $this->setDefinition($serviceId, $definition);
 
         $this->compile();
@@ -49,7 +49,7 @@ class URLHandlerPassTest extends AbstractCompilerPassTestCase
         $serviceId = 'service_id';
         $scheme = 'http';
         $definition = new Definition();
-        $definition->addTag('ezpublish.url_handler');
+        $definition->addTag('ibexa.url_checker.handler');
         $this->setDefinition($serviceId, $definition);
 
         $this->compile();

--- a/tests/bundle/Core/DependencyInjection/Compiler/ViewProvidersPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ViewProvidersPassTest.php
@@ -42,7 +42,7 @@ class ViewProvidersPassTest extends AbstractCompilerPassTestCase
         if ($declaredPriority !== null) {
             $attributes['priority'] = $declaredPriority;
         }
-        $def->addTag('ezpublish.view_provider', $attributes);
+        $def->addTag('ibexa.view.provider', $attributes);
         $serviceId = 'service_id';
         $this->setDefinition($serviceId, $def);
 

--- a/tests/bundle/Debug/DependencyInjection/Compiler/DataCollectorPassTest.php
+++ b/tests/bundle/Debug/DependencyInjection/Compiler/DataCollectorPassTest.php
@@ -31,7 +31,7 @@ class DataCollectorPassTest extends AbstractCompilerPassTestCase
         $toolbarTemplate = 'toolbar.html.twig';
         $definition = new Definition();
         $definition->addTag(
-            'ezpublish_data_collector',
+            'ibexa.debug.data_collector',
             ['panelTemplate' => $panelTemplate, 'toolbarTemplate' => $toolbarTemplate]
         );
 

--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -75,7 +75,7 @@ services:
     ezpublish.siteaccess.provider.chain:
         class: Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider
         arguments:
-            $providers: !tagged ezplatform.siteaccess.provider
+            $providers: !tagged ibexa.site_access.provider
 
     ezpublish.siteaccess.provider:
         alias: ezpublish.siteaccess.provider.chain

--- a/tests/integration/Core/Resources/settings/fieldtype_constraints_storage.yaml
+++ b/tests/integration/Core/Resources/settings/fieldtype_constraints_storage.yaml
@@ -1,7 +1,7 @@
 services:
     Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldType:
         tags:
-            - { name: ezplatform.field_type, alias: example }
+            - { name: ibexa.field_type, alias: example }
 
     Ibexa\Tests\Integration\Core\FieldType\FieldConstraintsStorage\Stub\ExampleFieldConstraintsStorage:
         public: true
@@ -11,4 +11,4 @@ services:
     ibexa.test.field_type.example.converter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
         tags:
-            - { name: ezplatform.field_type.legacy_storage.converter, alias: example }
+            - { name: ibexa.field_type.storage.legacy.converter, alias: example }

--- a/tests/integration/Core/Resources/settings/integration_legacy.yml
+++ b/tests/integration/Core/Resources/settings/integration_legacy.yml
@@ -23,7 +23,7 @@ services:
     # repeat part of DIC setup to avoid loading DoctrineSchemaBundle
     _instanceof:
         Ibexa\DoctrineSchema\Database\DbPlatform\DbPlatformInterface:
-            tags: ['doctrine.dbplatform']
+            tags: [ ibexa.doctrine.db.platform ]
 
     Symfony\Component\EventDispatcher\EventDispatcher:
         calls:
@@ -42,7 +42,7 @@ services:
     Ibexa\Tests\Core\Persistence\DatabaseConnectionFactory:
         autowire: true
         arguments:
-            $databasePlatforms: !tagged 'doctrine.dbplatform'
+            $databasePlatforms: !tagged ibexa.doctrine.db.platform
 
     # build ezpublish.api.storage_engine.legacy.connection for test purposes
     ezpublish.api.storage_engine.legacy.connection:

--- a/tests/lib/Base/Container/Compiler/Search/FieldTypeRegistryPassTest.php
+++ b/tests/lib/Base/Container/Compiler/Search/FieldTypeRegistryPassTest.php
@@ -36,7 +36,7 @@ class FieldTypeRegistryPassTest extends AbstractCompilerPassTestCase
         $fieldTypeIdentifier = 'field_type_identifier';
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezplatform.field_type.indexable', ['alias' => $fieldTypeIdentifier]);
+        $def->addTag('ibexa.field_type.indexable', ['alias' => $fieldTypeIdentifier]);
         $this->setDefinition($serviceId, $def);
 
         $this->compile();
@@ -55,7 +55,7 @@ class FieldTypeRegistryPassTest extends AbstractCompilerPassTestCase
         $fieldTypeIdentifier = 'field_type_identifier';
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezplatform.field_type.indexable');
+        $def->addTag('ibexa.field_type.indexable');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();

--- a/tests/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
+++ b/tests/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
@@ -34,7 +34,7 @@ class CriteriaConverterPassTest extends AbstractCompilerPassTestCase
 
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.legacy.gateway.criterion_handler.content');
+        $def->addTag('ibexa.search.legacy.gateway.criterion_handler.content');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();
@@ -55,7 +55,7 @@ class CriteriaConverterPassTest extends AbstractCompilerPassTestCase
 
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.legacy.gateway.criterion_handler.location');
+        $def->addTag('ibexa.search.legacy.gateway.criterion_handler.location');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();
@@ -76,7 +76,7 @@ class CriteriaConverterPassTest extends AbstractCompilerPassTestCase
 
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezplatform.trash.search.legacy.gateway.criterion_handler');
+        $def->addTag('ibexa.search.legacy.trash.gateway.criterion.handler');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();
@@ -105,9 +105,9 @@ class CriteriaConverterPassTest extends AbstractCompilerPassTestCase
 
         $commonServiceId = 'common_service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.legacy.gateway.criterion_handler.content');
-        $def->addTag('ezpublish.search.legacy.gateway.criterion_handler.location');
-        $def->addTag('ezplatform.trash.search.legacy.gateway.criterion_handler');
+        $def->addTag('ibexa.search.legacy.gateway.criterion_handler.content');
+        $def->addTag('ibexa.search.legacy.gateway.criterion_handler.location');
+        $def->addTag('ibexa.search.legacy.trash.gateway.criterion.handler');
         $this->setDefinition($commonServiceId, $def);
 
         $this->compile();

--- a/tests/lib/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPassTest.php
+++ b/tests/lib/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPassTest.php
@@ -40,7 +40,7 @@ class CriterionFieldValueHandlerRegistryPassTest extends AbstractCompilerPassTes
         $serviceId = 'service_id';
         $def = new Definition();
         $def->addTag(
-            'ezpublish.search.legacy.gateway.criterion_field_value_handler',
+            'ibexa.search.legacy.gateway.criterion_handler.field_value',
             ['alias' => $fieldTypeIdentifier]
         );
         $this->setDefinition($serviceId, $def);
@@ -61,7 +61,7 @@ class CriterionFieldValueHandlerRegistryPassTest extends AbstractCompilerPassTes
         $fieldTypeIdentifier = 'field_type_identifier';
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.legacy.gateway.criterion_field_value_handler');
+        $def->addTag('ibexa.search.legacy.gateway.criterion_handler.field_value');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();

--- a/tests/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPassTest.php
+++ b/tests/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPassTest.php
@@ -34,7 +34,7 @@ class SortClauseConverterPassTest extends AbstractCompilerPassTestCase
 
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.legacy.gateway.sort_clause_handler.content');
+        $def->addTag('ibexa.search.legacy.gateway.sort_clause_handler.content');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();
@@ -55,7 +55,7 @@ class SortClauseConverterPassTest extends AbstractCompilerPassTestCase
 
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.legacy.gateway.sort_clause_handler.location');
+        $def->addTag('ibexa.search.legacy.gateway.sort_clause_handler.location');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();
@@ -80,8 +80,8 @@ class SortClauseConverterPassTest extends AbstractCompilerPassTestCase
 
         $commonServiceId = 'common_service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.search.legacy.gateway.sort_clause_handler.content');
-        $def->addTag('ezpublish.search.legacy.gateway.sort_clause_handler.location');
+        $def->addTag('ibexa.search.legacy.gateway.sort_clause_handler.content');
+        $def->addTag('ibexa.search.legacy.gateway.sort_clause_handler.location');
         $this->setDefinition($commonServiceId, $def);
 
         $this->compile();

--- a/tests/lib/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPassTest.php
+++ b/tests/lib/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPassTest.php
@@ -38,7 +38,7 @@ class RoleLimitationConverterPassTest extends AbstractCompilerPassTestCase
     {
         $serviceId = 'service_id';
         $def = new Definition();
-        $def->addTag('ezpublish.persistence.legacy.role.limitation.handler');
+        $def->addTag('ibexa.storage.legacy.role.limitation.handler');
         $this->setDefinition($serviceId, $def);
 
         $this->compile();


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Asked for a review
