### PR TITLE
IBX-2120: FieldConstraintsStorage should be aware of content type status

### DIFF
--- a/src/contracts/FieldType/FieldConstraintsStorage.php
+++ b/src/contracts/FieldType/FieldConstraintsStorage.php
@@ -14,14 +14,17 @@ interface FieldConstraintsStorage
 {
     public function storeFieldConstraintsData(
         int $fieldDefinitionId,
+        int $status,
         FieldTypeConstraints $fieldTypeConstraints
     ): void;
 
     public function getFieldConstraintsData(
-        int $fieldDefinitionId
+        int $fieldDefinitionId,
+        int $status
     ): FieldTypeConstraints;
 
     public function deleteFieldConstraintsData(
-        int $fieldDefinitionId
+        int $fieldDefinitionId,
+        int $status
     ): void;
 }

--- a/src/contracts/FieldType/FieldConstraintsStorage.php
+++ b/src/contracts/FieldType/FieldConstraintsStorage.php
@@ -27,4 +27,6 @@ interface FieldConstraintsStorage
         int $fieldDefinitionId,
         int $status
     ): void;
+
+    public function publishFieldConstraintsData(int $fieldDefinitionId): void;
 }

--- a/src/lib/Persistence/Legacy/Content/Type/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Handler.php
@@ -629,6 +629,10 @@ class Handler implements BaseContentTypeHandler
         }
 
         $this->updateHandler->publishNewType($toType, Type::STATUS_DEFINED);
+
+        foreach ($toType->fieldDefinitions as $fieldDefinition) {
+            $this->storageDispatcher->publishFieldConstraintsData($fieldDefinition);
+        }
     }
 
     public function getSearchableFieldMap()

--- a/src/lib/Persistence/Legacy/Content/Type/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Handler.php
@@ -331,7 +331,7 @@ class Handler implements BaseContentTypeHandler
                 $storageFieldDef
             );
 
-            $this->storageDispatcher->storeFieldConstraintsData($fieldDef);
+            $this->storageDispatcher->storeFieldConstraintsData($fieldDef, $contentType->status);
         }
 
         return $contentType;
@@ -378,7 +378,7 @@ class Handler implements BaseContentTypeHandler
         }
 
         foreach ($fieldDefinitions as $fieldDefinition) {
-            $this->storageDispatcher->deleteFieldConstraintsData($fieldDefinition->fieldType, $fieldDefinition->id);
+            $this->storageDispatcher->deleteFieldConstraintsData($fieldDefinition->fieldType, $fieldDefinition->id, $status);
         }
 
         $this->contentTypeGateway->delete($contentTypeId, $status);
@@ -515,7 +515,7 @@ class Handler implements BaseContentTypeHandler
 
         $multilingualData = $this->mapper->extractMultilingualData($rows);
 
-        return $this->mapper->extractFieldFromRow(reset($rows), $multilingualData);
+        return $this->mapper->extractFieldFromRow(reset($rows), $multilingualData, $status);
     }
 
     /**
@@ -552,7 +552,7 @@ class Handler implements BaseContentTypeHandler
             $storageFieldDef
         );
 
-        $this->storageDispatcher->storeFieldConstraintsData($fieldDefinition);
+        $this->storageDispatcher->storeFieldConstraintsData($fieldDefinition, $status);
     }
 
     /**
@@ -574,7 +574,8 @@ class Handler implements BaseContentTypeHandler
     ): void {
         $this->storageDispatcher->deleteFieldConstraintsData(
             $fieldDefinition->fieldType,
-            $fieldDefinition->id
+            $fieldDefinition->id,
+            $status
         );
 
         $this->contentTypeGateway->deleteFieldDefinition(
@@ -600,7 +601,7 @@ class Handler implements BaseContentTypeHandler
         $storageFieldDef = new StorageFieldDefinition();
         $this->mapper->toStorageFieldDefinition($fieldDefinition, $storageFieldDef);
         $this->contentTypeGateway->updateFieldDefinition($contentTypeId, $status, $fieldDefinition, $storageFieldDef);
-        $this->storageDispatcher->storeFieldConstraintsData($fieldDefinition);
+        $this->storageDispatcher->storeFieldConstraintsData($fieldDefinition, $status);
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Type/Mapper.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Mapper.php
@@ -134,7 +134,7 @@ class Mapper
 
                 $multilingualData = $this->extractMultilingualData($fieldDataRows);
 
-                $types[$typeId]->fieldDefinitions[] = $fields[$fieldId] = $this->extractFieldFromRow($row, $multilingualData);
+                $types[$typeId]->fieldDefinitions[] = $fields[$fieldId] = $this->extractFieldFromRow($row, $multilingualData, $types[$typeId]->status);
             }
 
             $groupId = (int)$row['ezcontentclass_classgroup_group_id'];
@@ -219,7 +219,7 @@ class Mapper
      *
      * @return \Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition
      */
-    public function extractFieldFromRow(array $row, array $multilingualData = [])
+    public function extractFieldFromRow(array $row, array $multilingualData = [], int $status = Type::STATUS_DEFINED)
     {
         $storageFieldDef = $this->extractStorageFieldFromRow($row, $multilingualData);
 
@@ -249,7 +249,7 @@ class Mapper
         $mainLanguageCode = $this->maskGenerator->extractLanguageCodesFromMask((int)$row['ezcontentclass_initial_language_id']);
         $field->mainLanguageCode = array_shift($mainLanguageCode);
 
-        $this->toFieldDefinition($storageFieldDef, $field);
+        $this->toFieldDefinition($storageFieldDef, $field, $status);
 
         return $field;
     }
@@ -456,7 +456,8 @@ class Mapper
      */
     public function toFieldDefinition(
         StorageFieldDefinition $storageFieldDef,
-        FieldDefinition $fieldDef
+        FieldDefinition $fieldDef,
+        int $status
     ) {
         $converter = $this->converterRegistry->getConverter(
             $fieldDef->fieldType
@@ -466,7 +467,7 @@ class Mapper
             $fieldDef
         );
 
-        $this->storageDispatcher->loadFieldConstraintsData($fieldDef);
+        $this->storageDispatcher->loadFieldConstraintsData($fieldDef, $status);
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Type/Mapper.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Mapper.php
@@ -457,7 +457,7 @@ class Mapper
     public function toFieldDefinition(
         StorageFieldDefinition $storageFieldDef,
         FieldDefinition $fieldDef,
-        int $status
+        int $status = Type::STATUS_DEFINED
     ) {
         $converter = $this->converterRegistry->getConverter(
             $fieldDef->fieldType

--- a/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
@@ -36,7 +36,7 @@ final class StorageDispatcher implements StorageDispatcherInterface
         }
     }
 
-    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $status, int $fieldDefinitionId): void
+    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $fieldDefinitionId, int $status): void
     {
         if ($this->registry->hasStorage($fieldTypeIdentifier)) {
             $storage = $this->registry->getStorage($fieldTypeIdentifier);

--- a/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
@@ -19,6 +19,14 @@ final class StorageDispatcher implements StorageDispatcherInterface
         $this->registry = $registry;
     }
 
+    public function publishFieldConstraintsData(FieldDefinition $fieldDefinition): void
+    {
+        if ($this->registry->hasStorage($fieldDefinition->fieldType)) {
+            $storage = $this->registry->getStorage($fieldDefinition->fieldType);
+            $storage->publishFieldConstraintsData($fieldDefinition->id);
+        }
+    }
+
     public function storeFieldConstraintsData(FieldDefinition $fieldDefinition, int $status): void
     {
         if ($this->registry->hasStorage($fieldDefinition->fieldType)) {

--- a/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageDispatcher.php
@@ -19,28 +19,28 @@ final class StorageDispatcher implements StorageDispatcherInterface
         $this->registry = $registry;
     }
 
-    public function storeFieldConstraintsData(FieldDefinition $fieldDefinition): void
+    public function storeFieldConstraintsData(FieldDefinition $fieldDefinition, int $status): void
     {
         if ($this->registry->hasStorage($fieldDefinition->fieldType)) {
             $storage = $this->registry->getStorage($fieldDefinition->fieldType);
-            $storage->storeFieldConstraintsData($fieldDefinition->id, $fieldDefinition->fieldTypeConstraints);
+            $storage->storeFieldConstraintsData($fieldDefinition->id, $status, $fieldDefinition->fieldTypeConstraints);
         }
     }
 
-    public function loadFieldConstraintsData(FieldDefinition $fieldDefinition): void
+    public function loadFieldConstraintsData(FieldDefinition $fieldDefinition, int $status): void
     {
         if ($this->registry->hasStorage($fieldDefinition->fieldType)) {
             $storage = $this->registry->getStorage($fieldDefinition->fieldType);
 
-            $fieldDefinition->fieldTypeConstraints = $storage->getFieldConstraintsData($fieldDefinition->id);
+            $fieldDefinition->fieldTypeConstraints = $storage->getFieldConstraintsData($fieldDefinition->id, $status);
         }
     }
 
-    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $fieldDefinitionId): void
+    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $status, int $fieldDefinitionId): void
     {
         if ($this->registry->hasStorage($fieldTypeIdentifier)) {
             $storage = $this->registry->getStorage($fieldTypeIdentifier);
-            $storage->deleteFieldConstraintsData($fieldDefinitionId);
+            $storage->deleteFieldConstraintsData($fieldDefinitionId, $status);
         }
     }
 }

--- a/src/lib/Persistence/Legacy/Content/Type/StorageDispatcherInterface.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageDispatcherInterface.php
@@ -12,6 +12,8 @@ use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
 
 interface StorageDispatcherInterface
 {
+    public function publishFieldConstraintsData(FieldDefinition $fieldDefinition): void;
+
     public function storeFieldConstraintsData(FieldDefinition $fieldDefinition, int $status): void;
 
     public function loadFieldConstraintsData(FieldDefinition $fieldDefinition, int $status): void;

--- a/src/lib/Persistence/Legacy/Content/Type/StorageDispatcherInterface.php
+++ b/src/lib/Persistence/Legacy/Content/Type/StorageDispatcherInterface.php
@@ -12,9 +12,9 @@ use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
 
 interface StorageDispatcherInterface
 {
-    public function storeFieldConstraintsData(FieldDefinition $fieldDefinition): void;
+    public function storeFieldConstraintsData(FieldDefinition $fieldDefinition, int $status): void;
 
-    public function loadFieldConstraintsData(FieldDefinition $fieldDefinition): void;
+    public function loadFieldConstraintsData(FieldDefinition $fieldDefinition, int $status): void;
 
-    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $fieldDefinitionId): void;
+    public function deleteFieldConstraintsData(string $fieldTypeIdentifier, int $fieldDefinitionId, int $status): void;
 }

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/FieldConstraintsStorageTest.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/FieldConstraintsStorageTest.php
@@ -71,11 +71,9 @@ final class FieldConstraintsStorageTest extends BaseTest
 
         $contentTypeService->publishContentTypeDraft($contentType);
 
-        $actualFieldTypeConstraints = $this
-            ->getExampleFieldConstraintsStorage()
-            ->getFieldConstraintsDataIfAvailable(
-                $contentType->getFieldDefinition(self::EXAMPLE_FIELD_IDENTIFIER)->id
-            );
+        $storage = $this->getExampleFieldConstraintsStorage();
+
+        self::assertTrue($storage->isPublished($contentType->fieldDefinitions->get(self::EXAMPLE_FIELD_IDENTIFIER)->id));
 
         self::assertEquals(
             new FieldTypeConstraints(
@@ -84,7 +82,9 @@ final class FieldConstraintsStorageTest extends BaseTest
                     'validators' => self::EXAMPLE_VALIDATOR_CONFIGURATION,
                 ]
             ),
-            $actualFieldTypeConstraints
+            $storage->getFieldConstraintsDataIfAvailable(
+                $contentType->getFieldDefinition(self::EXAMPLE_FIELD_IDENTIFIER)->id
+            )
         );
 
         return $contentTypeService->loadContentTypeByIdentifier($contentType->identifier);

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
@@ -29,6 +29,7 @@ final class ExampleFieldConstraintsStorage implements FieldConstraintsStorage
 
     public function storeFieldConstraintsData(
         int $fieldDefinitionId,
+        int $status,
         FieldTypeConstraints $fieldTypeConstraints
     ): void {
         $this->fieldConstraints[$fieldDefinitionId] = $fieldTypeConstraints;
@@ -41,7 +42,8 @@ final class ExampleFieldConstraintsStorage implements FieldConstraintsStorage
     }
 
     public function getFieldConstraintsData(
-        int $fieldDefinitionId
+        int $fieldDefinitionId,
+        int $status
     ): FieldTypeConstraints {
         return $this->fieldConstraints[$fieldDefinitionId];
     }
@@ -52,7 +54,7 @@ final class ExampleFieldConstraintsStorage implements FieldConstraintsStorage
         return $this->fieldConstraints[$fieldDefinitionId] ?? null;
     }
 
-    public function deleteFieldConstraintsData(int $fieldDefinitionId): void
+    public function deleteFieldConstraintsData(int $fieldDefinitionId, int $status): void
     {
         unset($this->fieldConstraints[$fieldDefinitionId]);
     }

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
@@ -27,6 +27,11 @@ final class ExampleFieldConstraintsStorage implements FieldConstraintsStorage
         $this->fieldConstraints = $fieldConstraints;
     }
 
+    public function publishFieldConstraintsData(int $fieldDefinitionId): void
+    {
+        // TODO: Implementation
+    }
+
     public function storeFieldConstraintsData(
         int $fieldDefinitionId,
         int $status,

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldConstraintsStorage.php
@@ -19,17 +19,21 @@ final class ExampleFieldConstraintsStorage implements FieldConstraintsStorage
     /** @var \Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints[] */
     private array $fieldConstraints;
 
+    /** @var int[] */
+    private array $published = [];
+
     /**
      * @param \Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints[]
      */
     public function __construct(array $fieldConstraints = [])
     {
         $this->fieldConstraints = $fieldConstraints;
+        $this->published = [];
     }
 
     public function publishFieldConstraintsData(int $fieldDefinitionId): void
     {
-        // TODO: Implementation
+        $this->published[] = $fieldDefinitionId;
     }
 
     public function storeFieldConstraintsData(
@@ -44,6 +48,11 @@ final class ExampleFieldConstraintsStorage implements FieldConstraintsStorage
         int $fieldDefinitionId
     ): bool {
         return isset($this->fieldConstraints[$fieldDefinitionId]);
+    }
+
+    public function isPublished(int $fieldDefinitionId): bool
+    {
+        return in_array($fieldDefinitionId, $this->published, true);
     }
 
     public function getFieldConstraintsData(

--- a/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Core\Persistence\Legacy\Content\Type;
 
 use Ibexa\Contracts\Core\FieldType\FieldConstraintsStorage;
 use Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints;
+use Ibexa\Contracts\Core\Persistence\Content\Type as ContentType;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcher;
 use Ibexa\Core\Persistence\Legacy\Content\Type\StorageRegistryInterface;
@@ -22,13 +23,14 @@ final class StorageDispatcherTest extends TestCase
 
     public function testStoreFieldConstraintsData(): void
     {
+        $status = ContentType::STATUS_DEFINED;
         $constraints = $this->createMock(FieldTypeConstraints::class);
 
         $storage = $this->createMock(FieldConstraintsStorage::class);
         $storage
             ->expects($this->once())
             ->method('storeFieldConstraintsData')
-            ->with(self::EXAMPLE_FIELD_DEFINITION_ID, $constraints);
+            ->with(self::EXAMPLE_FIELD_DEFINITION_ID, $status, $constraints);
 
         $fieldDefinition = new FieldDefinition();
         $fieldDefinition->fieldTypeConstraints = $constraints;
@@ -38,11 +40,13 @@ final class StorageDispatcherTest extends TestCase
         $registry = $this->createStorageRegistryMockWithExternalStorage($storage);
 
         $dispatcher = new StorageDispatcher($registry);
-        $dispatcher->storeFieldConstraintsData($fieldDefinition);
+        $dispatcher->storeFieldConstraintsData($fieldDefinition, $status);
     }
 
     public function testStoreFieldConstraintsDataForNonSupportedFieldType(): void
     {
+        $status = ContentType::STATUS_DEFINED;
+
         $fieldDefinition = new FieldDefinition();
         $fieldDefinition->id = self::EXAMPLE_FIELD_DEFINITION_ID;
         $fieldDefinition->fieldType = self::EXAMPLE_FIELD_TYPE_IDENTIFIER;
@@ -50,7 +54,7 @@ final class StorageDispatcherTest extends TestCase
         $registry = $this->createStorageRegistryMockWithoutExternalStorage();
 
         $dispatcher = new StorageDispatcher($registry);
-        $dispatcher->storeFieldConstraintsData($fieldDefinition);
+        $dispatcher->storeFieldConstraintsData($fieldDefinition, $status);
     }
 
     public function testLoadFieldConstraintsData(): void
@@ -71,7 +75,7 @@ final class StorageDispatcherTest extends TestCase
         $registry = $this->createStorageRegistryMockWithExternalStorage($storage);
 
         $dispatcher = new StorageDispatcher($registry);
-        $dispatcher->loadFieldConstraintsData($fieldDefinition);
+        $dispatcher->loadFieldConstraintsData($fieldDefinition, ContentType::STATUS_DEFINED);
 
         self::assertSame(
             $constraints,
@@ -91,7 +95,7 @@ final class StorageDispatcherTest extends TestCase
         $registry = $this->createStorageRegistryMockWithoutExternalStorage();
 
         $dispatcher = new StorageDispatcher($registry);
-        $dispatcher->loadFieldConstraintsData($fieldDefinition);
+        $dispatcher->loadFieldConstraintsData($fieldDefinition, ContentType::STATUS_DEFINED);
 
         self::assertSame(
             $constraints,
@@ -112,7 +116,8 @@ final class StorageDispatcherTest extends TestCase
         $dispatcher = new StorageDispatcher($registry);
         $dispatcher->deleteFieldConstraintsData(
             self::EXAMPLE_FIELD_TYPE_IDENTIFIER,
-            self::EXAMPLE_FIELD_DEFINITION_ID
+            ContentType::STATUS_DEFINED,
+            self::EXAMPLE_FIELD_DEFINITION_ID,
         );
     }
 
@@ -123,7 +128,8 @@ final class StorageDispatcherTest extends TestCase
         $dispatcher = new StorageDispatcher($registry);
         $dispatcher->deleteFieldConstraintsData(
             self::EXAMPLE_FIELD_TYPE_IDENTIFIER,
-            self::EXAMPLE_FIELD_DEFINITION_ID
+            ContentType::STATUS_DEFINED,
+            self::EXAMPLE_FIELD_DEFINITION_ID,
         );
     }
 

--- a/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
@@ -116,8 +116,8 @@ final class StorageDispatcherTest extends TestCase
         $dispatcher = new StorageDispatcher($registry);
         $dispatcher->deleteFieldConstraintsData(
             self::EXAMPLE_FIELD_TYPE_IDENTIFIER,
-            ContentType::STATUS_DEFINED,
             self::EXAMPLE_FIELD_DEFINITION_ID,
+            ContentType::STATUS_DEFINED,
         );
     }
 
@@ -128,8 +128,8 @@ final class StorageDispatcherTest extends TestCase
         $dispatcher = new StorageDispatcher($registry);
         $dispatcher->deleteFieldConstraintsData(
             self::EXAMPLE_FIELD_TYPE_IDENTIFIER,
-            ContentType::STATUS_DEFINED,
             self::EXAMPLE_FIELD_DEFINITION_ID,
+            ContentType::STATUS_DEFINED,
         );
     }
 

--- a/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/StorageDispatcherTest.php
@@ -21,6 +21,24 @@ final class StorageDispatcherTest extends TestCase
     private const EXAMPLE_FIELD_DEFINITION_ID = 1;
     private const EXAMPLE_FIELD_TYPE_IDENTIFIER = 'example_ft';
 
+    public function testPublishFieldConstraintsData(): void
+    {
+        $storage = $this->createMock(FieldConstraintsStorage::class);
+        $storage
+            ->expects($this->once())
+            ->method('publishFieldConstraintsData')
+            ->with(self::EXAMPLE_FIELD_DEFINITION_ID);
+
+        $fieldDefinition = new FieldDefinition();
+        $fieldDefinition->id = self::EXAMPLE_FIELD_DEFINITION_ID;
+        $fieldDefinition->fieldType = self::EXAMPLE_FIELD_TYPE_IDENTIFIER;
+
+        $registry = $this->createStorageRegistryMockWithExternalStorage($storage);
+
+        $dispatcher = new StorageDispatcher($registry);
+        $dispatcher->publishFieldConstraintsData($fieldDefinition);
+    }
+
     public function testStoreFieldConstraintsData(): void
     {
         $status = ContentType::STATUS_DEFINED;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2120](https://issues.ibexa.co/browse/IBX-2120)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes/no

FieldConstraintsStorage is not able to distinct between published/draft version of content type.

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [x] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
