### PR TITLE
IBX-1696: Rebranded Container parameters and Config Resolver namespaces

### DIFF
--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -63,7 +63,7 @@ class DebugConfigResolverCommand extends Command implements BackwardCompatibleCo
             'namespace',
             null,
             InputOption::VALUE_REQUIRED,
-            'Set a different namespace than the default "ezsettings" used by SiteAccess settings.'
+            'Set a different namespace than the default "ibexa.site_access.config" used by SiteAccess settings.'
         );
         $this->setHelp(
             <<<EOM
@@ -72,7 +72,7 @@ Outputs a given config resolver parameter, more commonly known as a SiteAccess s
 By default it will give value depending on the global <comment>--siteaccess[=SITEACCESS]</comment> (default SiteAccess is used if not set).
 
 However, you can also manually set <comment>--scope[=NAME]</comment> yourself if you don't want to affect the SiteAccess
-set by the system. You can also override the namespace to get something other than the default "ezsettings" namespace by using
+set by the system. You can also override the namespace to get something other than the default "ibexa.site_access.config" namespace by using
 the <comment>--namespace[=NS]</comment> option.
 
 NOTE: To see *all* compiled SiteAccess settings, use: <comment>debug:config ibexa [system.default]</comment>

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
@@ -37,7 +37,7 @@ class ChainRoutingPass implements CompilerPassInterface
             $defaultRouter->addMethodCall('setConfigResolver', [new Reference('ibexa.config.resolver')]);
             $defaultRouter->addMethodCall(
                 'setNonSiteAccessAwareRoutes',
-                ['%ezpublish.default_router.non_siteaccess_aware_routes%']
+                ['%ibexa.default_router.non_site_access_aware_routes%']
             );
             $defaultRouter->addMethodCall(
                 'setSiteAccessRouter',

--- a/src/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -13,8 +13,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Configures session handler based on `ezplatform.session.handler_id`
- * and `ezplatform.session.save_path`.
+ * Configures session handler based on `ibexa.session.handler_id`
+ * and `ibexa.session.save_path`.
  *
  * This ensures parameters have the highest priority and the configuration
  * will be respected with default framework.yaml file.
@@ -25,12 +25,12 @@ final class SessionConfigurationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $handlerId = $container->hasParameter('ezplatform.session.handler_id')
-            ? $container->getParameter('ezplatform.session.handler_id')
+        $handlerId = $container->hasParameter('ibexa.session.handler_id')
+            ? $container->getParameter('ibexa.session.handler_id')
             : null;
 
-        $savePath = $container->hasParameter('ezplatform.session.save_path')
-            ? $container->getParameter('ezplatform.session.save_path')
+        $savePath = $container->hasParameter('ibexa.session.save_path')
+            ? $container->getParameter('ibexa.session.save_path')
             : null;
 
         if (null !== $handlerId) {

--- a/src/bundle/Core/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
@@ -27,7 +27,7 @@ class SlugConverterConfigurationPass implements CompilerPassInterface
         $slugConverterDefinition = $container->getDefinition(\Ibexa\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter::class);
 
         $parameterConfiguration = $slugConverterDefinition->getArgument(1);
-        $semanticConfiguration = $container->getParameter('ezpublish.url_alias.slug_converter');
+        $semanticConfiguration = $container->getParameter('ibexa.url_alias.slug_converter');
 
         $mergedConfiguration = $parameterConfiguration;
 

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * It will check the different scopes available for a given namespace to find the appropriate parameter.
  * To work, the dynamic setting must comply internally to the following name format : "<namespace>.<scope>.parameter.name".
  *
- * - <namespace> is the namespace for your dynamic setting. Defaults to "ezsettings", but can be anything.
+ * - <namespace> is the namespace for your dynamic setting. Defaults to "ibexa.site_access.config", but can be anything.
  * - <scope> is basically the siteaccess name you want your parameter value to apply to.
  *   Can also be "global" for a global override.
  *   Another scope is used internally: "default". This is the generic fallback.
@@ -273,8 +273,8 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
         $serviceName = '??';
         $firstService = '??';
         $commandName = null;
-        $resettableServiceIds = $container->getParameter('ezpublish.config_resolver.resettable_services');
-        $updatableServices = $container->getParameter('ezpublish.config_resolver.updateable_services');
+        $resettableServiceIds = $container->getParameter('ibexa.config_resolver.resettable_services');
+        $updatableServices = $container->getParameter('ibexa.config_resolver.updateable_services');
 
         // Lookup trace to find last service being loaded as possible blame for eager loading
         // Abort if one of the earlier services is detected to be "safe", aka updatable

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Common.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Common.php
@@ -177,7 +177,7 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
 
         // session_name setting is deprecated in favor of session.name
         $container = $contextualizer->getContainer();
-        $sessionOptions = $container->hasParameter("ezsettings.$currentScope.session") ? $container->getParameter("ezsettings.$currentScope.session") : [];
+        $sessionOptions = $container->hasParameter("ibexa.site_access.config.$currentScope.session") ? $container->getParameter("ibexa.site_access.config.$currentScope.session") : [];
         if (isset($sessionOptions['name'])) {
             $contextualizer->setContextualParameter('session_name', $currentScope, $sessionOptions['name']);
         }

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/IO.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/IO.php
@@ -102,10 +102,10 @@ class IO extends AbstractParser
     private function addComplexParametersDependencies($parameter, $scope, ContainerBuilder $container)
     {
         // The complex setting exists in this scope, we don't need to do anything
-        if ($container->hasParameter("ezsettings.$scope.$parameter")) {
+        if ($container->hasParameter("ibexa.site_access.config.$scope.$parameter")) {
             return;
         }
-        $parameterValue = $container->getParameter("ezsettings.default.$parameter");
+        $parameterValue = $container->getParameter("ibexa.site_access.config.default.$parameter");
 
         // not complex in this scope
         if (!$this->complexSettingParser->containsDynamicSettings($parameterValue)) {
@@ -121,12 +121,12 @@ class IO extends AbstractParser
             }
             $dynamicParameterId = sprintf(
                 '%s.%s.%s',
-                $dynamicParameterParts['namespace'] ?: 'ezsettings',
+                $dynamicParameterParts['namespace'] ?: 'ibexa.site_access.config',
                 $scope,
                 $dynamicParameterParts['param']
             );
             if ($container->hasParameter($dynamicParameterId)) {
-                $container->setParameter("ezsettings.$scope.$parameter", $parameterValue);
+                $container->setParameter("ibexa.site_access.config.$scope.$parameter", $parameterValue);
                 break;
             }
         }

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Languages.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Languages.php
@@ -41,16 +41,16 @@ class Languages extends AbstractParser
         $contextualizer->mapConfigArray('translation_siteaccesses', $config, ContextualizerInterface::UNIQUE);
 
         $container = $contextualizer->getContainer();
-        if ($container->hasParameter('ezpublish.siteaccesses_by_language')) {
-            $this->siteAccessesByLanguages = $container->getParameter('ezpublish.siteaccesses_by_language');
+        if ($container->hasParameter('ibexa.site_access.by_language')) {
+            $this->siteAccessesByLanguages = $container->getParameter('ibexa.site_access.by_language');
         }
     }
 
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
     {
         $container = $contextualizer->getContainer();
-        if ($container->hasParameter("ezsettings.$currentScope.languages")) {
-            $languages = $container->getParameter("ezsettings.$currentScope.languages");
+        if ($container->hasParameter("ibexa.site_access.config.$currentScope.languages")) {
+            $languages = $container->getParameter("ibexa.site_access.config.$currentScope.languages");
             $mainLanguage = array_shift($languages);
             if ($mainLanguage) {
                 $this->siteAccessesByLanguages[$mainLanguage][] = $currentScope;
@@ -61,7 +61,7 @@ class Languages extends AbstractParser
     public function postMap(array $config, ContextualizerInterface $contextualizer)
     {
         $contextualizer->getContainer()->setParameter(
-            'ezpublish.siteaccesses_by_language',
+            'ibexa.site_access.by_language',
             $this->siteAccessesByLanguages
         );
     }

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Repository/FieldGroups.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Repository/FieldGroups.php
@@ -24,7 +24,7 @@ final class FieldGroups implements RepositoryConfigParserInterface
                         ->end()
                     ->end()
                     ->scalarNode('default')
-                        ->defaultValue('%ezsettings.default.content.field_groups.default%')
+                        ->defaultValue('%ibexa.site_access.config.default.content.field_groups.default%')
                     ->end()
                 ->end()
             ->end();

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Repository/Search.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Repository/Search.php
@@ -19,7 +19,7 @@ final class Search implements RepositoryConfigParserInterface
             ->arrayNode('search')
                 ->children()
                     ->scalarNode('engine')
-                        ->defaultValue('%ezpublish.api.search_engine.default%')
+                        ->defaultValue('%ibexa.api.search_engine.default%')
                         ->info('The search engine to use')
                     ->end()
                     ->scalarNode('connection')

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Repository/Storage.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Repository/Storage.php
@@ -19,7 +19,7 @@ final class Storage implements RepositoryConfigParserInterface
             ->arrayNode('storage')
                 ->children()
                     ->scalarNode('engine')
-                        ->defaultValue('%ezpublish.api.storage_engine.default%')
+                        ->defaultValue('%ibexa.api.storage_engine.default%')
                         ->info('The storage engine to use')
                     ->end()
                     ->scalarNode('connection')

--- a/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
@@ -186,7 +186,7 @@ interface ContextualizerInterface
     /**
      * Injects namespace for internal settings.
      * Registered internal settings always have the format <namespace>.<scope>.<parameter_name>
-     * e.g. ezsettings.default.session.
+     * e.g. ibexa.site_access.config.default.session.
      *
      * @param string $namespace
      */

--- a/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParserInterface.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParserInterface.php
@@ -14,7 +14,7 @@ namespace Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware;
  * Supported syntax for dynamic settings: $<paramName>[;<namespace>[;<scope>]]$
  *
  * The following will work :
- * $my_param$ (using default namespace, e.g. ezsettings, with current scope).
+ * $my_param$ (using default namespace, e.g. ibexa.site_access.config, with current scope).
  * $my_param;foo$ (using "foo" as namespace, in current scope).
  * $my_param;foo;some_siteaccess$ (using "foo" as namespace, forcing "some_siteaccess scope").
  *

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -145,7 +145,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         $this->handleUrlWildcards($config, $container, $loader);
 
         // Map settings
-        $processor = new ConfigurationProcessor($container, 'ezsettings');
+        $processor = new ConfigurationProcessor($container, 'ibexa.site_access.config');
         $processor->mapConfig($config, $this->getMainConfigParser());
 
         if ($this->suggestionCollector->hasSuggestions()) {
@@ -255,11 +255,11 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
         foreach ($config['repositories'] as $name => &$repository) {
             if (empty($repository['fields_groups']['list'])) {
-                $repository['fields_groups']['list'] = $container->getParameter('ezsettings.default.content.field_groups.list');
+                $repository['fields_groups']['list'] = $container->getParameter('ibexa.site_access.config.default.content.field_groups.list');
             }
         }
 
-        $container->setParameter('ezpublish.repositories', $config['repositories']);
+        $container->setParameter('ibexa.repositories', $config['repositories']);
     }
 
     private function registerSiteAccessConfiguration(array $config, ContainerBuilder $container)
@@ -272,13 +272,13 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
             $config['siteaccess']['match'] = null;
         }
 
-        $container->setParameter('ezpublish.siteaccess.list', $config['siteaccess']['list']);
+        $container->setParameter('ibexa.site_access.list', $config['siteaccess']['list']);
         ConfigurationProcessor::setAvailableSiteAccesses($config['siteaccess']['list']);
-        $container->setParameter('ezpublish.siteaccess.default', $config['siteaccess']['default_siteaccess']);
-        $container->setParameter('ezpublish.siteaccess.match_config', $config['siteaccess']['match']);
+        $container->setParameter('ibexa.site_access.default', $config['siteaccess']['default_siteaccess']);
+        $container->setParameter('ibexa.site_access.match_config', $config['siteaccess']['match']);
 
         // Register siteaccess groups + reverse
-        $container->setParameter('ezpublish.siteaccess.groups', $config['siteaccess']['groups']);
+        $container->setParameter('ibexa.site_access.groups', $config['siteaccess']['groups']);
         ConfigurationProcessor::setAvailableSiteAccessGroups($config['siteaccess']['groups']);
         $groupsBySiteaccess = [];
         foreach ($config['siteaccess']['groups'] as $groupName => $groupMembers) {
@@ -290,23 +290,23 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
                 $groupsBySiteaccess[$member][] = $groupName;
             }
         }
-        $container->setParameter('ezpublish.siteaccess.groups_by_siteaccess', $groupsBySiteaccess);
+        $container->setParameter('ibexa.site_access.groups_by_site_access', $groupsBySiteaccess);
         ConfigurationProcessor::setGroupsBySiteAccess($groupsBySiteaccess);
     }
 
     private function registerImageMagickConfiguration(array $config, ContainerBuilder $container)
     {
         if (isset($config['imagemagick'])) {
-            $container->setParameter('ezpublish.image.imagemagick.enabled', $config['imagemagick']['enabled']);
+            $container->setParameter('ibexa.image.imagemagick.enabled', $config['imagemagick']['enabled']);
             if ($config['imagemagick']['enabled']) {
-                $container->setParameter('ezpublish.image.imagemagick.executable_path', dirname($config['imagemagick']['path']));
-                $container->setParameter('ezpublish.image.imagemagick.executable', basename($config['imagemagick']['path']));
+                $container->setParameter('ibexa.image.imagemagick.executable_path', dirname($config['imagemagick']['path']));
+                $container->setParameter('ibexa.image.imagemagick.executable', basename($config['imagemagick']['path']));
             }
         }
 
         $filters = isset($config['imagemagick']['filters']) ? $config['imagemagick']['filters'] : [];
-        $filters = $filters + $container->getParameter('ezpublish.image.imagemagick.filters');
-        $container->setParameter('ezpublish.image.imagemagick.filters', $filters);
+        $filters = $filters + $container->getParameter('ibexa.image.imagemagick.filters');
+        $container->setParameter('ibexa.image.imagemagick.filters', $filters);
     }
 
     private function registerOrmConfiguration(array $config, ContainerBuilder $container): void
@@ -334,9 +334,9 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
         if (isset($config['router']['default_router']['non_siteaccess_aware_routes'])) {
             $container->setParameter(
-                'ezpublish.default_router.non_siteaccess_aware_routes',
+                'ibexa.default_router.non_site_access_aware_routes',
                 array_merge(
-                    $container->getParameter('ezpublish.default_router.non_siteaccess_aware_routes'),
+                    $container->getParameter('ibexa.default_router.non_site_access_aware_routes'),
                     $config['router']['default_router']['non_siteaccess_aware_routes']
                 )
             );
@@ -435,7 +435,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
             // resolves ENV variable at compile time, needed by ezplatform-http-cache to setup purge driver
             $purgeType = $container->resolveEnvPlaceholders($config['http_cache']['purge_type'], true);
 
-            $container->setParameter('ezpublish.http_cache.purge_type', $purgeType);
+            $container->setParameter('ibexa.http_cache.purge_type', $purgeType);
         }
     }
 
@@ -450,8 +450,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
     {
         $loader->load('locale.yml');
         $container->setParameter(
-            'ezpublish.locale.conversion_map',
-            $config['locale_conversion'] + $container->getParameter('ezpublish.locale.conversion_map')
+            'ibexa.locale.conversion_map',
+            $config['locale_conversion'] + $container->getParameter('ibexa.locale.conversion_map')
         );
     }
 
@@ -487,7 +487,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
             }
         }
 
-        $container->setParameter('image_alias.placeholder_providers', $providers);
+        $container->setParameter('ibexa.io.images.alias.placeholder_provider', $providers);
     }
 
     private function handleUrlChecker($config, ContainerBuilder $container, FileLoader $loader)
@@ -590,7 +590,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
             $config['url_alias'] = ['slug_converter' => []];
         }
 
-        $container->setParameter('ezpublish.url_alias.slug_converter', $config['url_alias']['slug_converter']);
+        $container->setParameter('ibexa.url_alias.slug_converter', $config['url_alias']['slug_converter']);
     }
 
     /**
@@ -669,7 +669,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
      */
     private function registerUrlWildcardsConfiguration(array $config, ContainerBuilder $container): void
     {
-        $container->setParameter('ezpublish.url_wildcards.enabled', $config['url_wildcards']['enabled'] ?? false);
+        $container->setParameter('ibexa.url_wildcards.enabled', $config['url_wildcards']['enabled'] ?? false);
     }
 
     /**
@@ -681,7 +681,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
      */
     private function handleUrlWildcards(array $config, ContainerBuilder $container, Loader\YamlFileLoader $loader)
     {
-        if ($container->getParameter('ezpublish.url_wildcards.enabled')) {
+        if ($container->getParameter('ibexa.url_wildcards.enabled')) {
             $loader->load('url_wildcard.yml');
         }
     }
@@ -719,7 +719,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('search_engine', '%env(SEARCH_ENGINE)%');
 
         // Session save path as used by symfony session handlers (eg. used for dsn with redis)
-        $container->setParameter('ezplatform.session.save_path', '%kernel.project_dir%/var/sessions/%kernel.environment%');
+        $container->setParameter('ibexa.session.save_path', '%kernel.project_dir%/var/sessions/%kernel.environment%');
 
         // Predefined pools are located in config/packages/cache_pool/
         // You can add your own cache pool to the folder mentioned above.
@@ -736,7 +736,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
         // Identifier used to generate the CSRF token. Commenting this line will result in authentication
         // issues both in AdminUI and REST calls
-        $container->setParameter('ezpublish_rest.csrf_token_intention', 'authenticate');
+        $container->setParameter('ibexa.rest.csrf_token_intention', 'authenticate');
 
         // Varnish invalidation/purge token (for use on platform.sh, eZ Platform Cloud and other places you can't use IP for ACL)
         $container->setParameter('varnish_invalidate_token', '%env(resolve:default::HTTPCACHE_VARNISH_INVALIDATE_TOKEN)%');
@@ -745,8 +745,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         // These are defined at compile time, and hence can't be set at runtime using env()
         // config/env/generic.php takes care about letting you set them by env variables
 
-        // Session handler, by default set to file based (instead of ~) in order to be able to use %ezplatform.session.save_path%
-        $container->setParameter('ezplatform.session.handler_id', 'session.handler.native_file');
+        // Session handler, by default set to file based (instead of ~) in order to be able to use %ibexa.session.save_path%
+        $container->setParameter('ibexa.session.handler_id', 'session.handler.native_file');
 
         // Purge type used by HttpCache system ("local", "varnish"/"http", and on ee also "fastly")
         $container->setParameter('purge_type', '%env(HTTPCACHE_PURGE_TYPE)%');
@@ -754,10 +754,10 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('solr_dsn', '%env(SOLR_DSN)%');
         $container->setParameter('solr_core', '%env(SOLR_CORE)%');
 
-        $container->setParameter('siso_search.solr.host', '%env(SISO_SEARCH_SOLR_HOST)%');
-        $container->setParameter('siso_search.solr.port', '%env(SISO_SEARCH_SOLR_PORT)%');
-        $container->setParameter('siso_search.solr.core', '%env(SISO_SEARCH_SOLR_CORE)%');
-        $container->setParameter('siso_search.solr.path', '%env(SISO_SEARCH_SOLR_PATH)%');
+        $container->setParameter('ibexa.commerce.search.solr.host', '%env(SISO_SEARCH_SOLR_HOST)%');
+        $container->setParameter('ibexa.commerce.search.solr.port', '%env(SISO_SEARCH_SOLR_PORT)%');
+        $container->setParameter('ibexa.commerce.search.solr.core', '%env(SISO_SEARCH_SOLR_CORE)%');
+        $container->setParameter('ibexa.commerce.search.solr.path', '%env(SISO_SEARCH_SOLR_PATH)%');
 
         $projectDir = $container->getParameter('kernel.project_dir');
 
@@ -790,7 +790,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
         if ($purgeType = $_SERVER['HTTPCACHE_PURGE_TYPE'] ?? false) {
             $container->setParameter('purge_type', $purgeType);
-            $container->setParameter('ezpublish.http_cache.purge_type', $purgeType);
+            $container->setParameter('ibexa.http_cache.purge_type', $purgeType);
         }
 
         if ($value = $_SERVER['MAILER_TRANSPORT'] ?? false) {
@@ -802,11 +802,11 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         }
 
         if ($value = $_SERVER['SESSION_HANDLER_ID'] ?? false) {
-            $container->setParameter('ezplatform.session.handler_id', $value);
+            $container->setParameter('ibexa.session.handler_id', $value);
         }
 
         if ($value = $_SERVER['SESSION_SAVE_PATH'] ?? false) {
-            $container->setParameter('ezplatform.session.save_path', $value);
+            $container->setParameter('ibexa.session.save_path', $value);
         }
     }
 
@@ -914,8 +914,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
                     continue;
                 }
 
-                $container->setParameter('ezplatform.session.handler_id', NativeSessionHandler::class);
-                $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+                $container->setParameter('ibexa.session.handler_id', NativeSessionHandler::class);
+                $container->setParameter('ibexa.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
             }
         } elseif (isset($relationships['rediscache'])) {
             foreach ($relationships['rediscache'] as $endpoint) {
@@ -923,8 +923,8 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
                     continue;
                 }
 
-                $container->setParameter('ezplatform.session.handler_id', NativeSessionHandler::class);
-                $container->setParameter('ezplatform.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
+                $container->setParameter('ibexa.session.handler_id', NativeSessionHandler::class);
+                $container->setParameter('ibexa.session.save_path', sprintf('%s:%d', $endpoint['host'], $endpoint['port']));
             }
         }
 
@@ -949,9 +949,9 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
                     // To set solr_core parameter we assume path is in form like: "solr/collection1"
                     $container->setParameter('solr_core', substr($endpoint['path'], 5));
 
-                    $container->setParameter('siso_search.solr.host', $endpoint['host']);
-                    $container->setParameter('siso_search.solr.port', $endpoint['port']);
-                    $container->setParameter('siso_search.solr.core', $endpoint['rel']);
+                    $container->setParameter('ibexa.commerce.search.solr.host', $endpoint['host']);
+                    $container->setParameter('ibexa.commerce.search.solr.port', $endpoint['port']);
+                    $container->setParameter('ibexa.commerce.search.solr.core', $endpoint['rel']);
                 }
             }
         }
@@ -998,7 +998,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
                 $purgeServer = str_replace($domain, $credentials . '@' . $domain, $purgeServer);
             }
 
-            $container->setParameter('ezpublish.http_cache.purge_type', 'varnish');
+            $container->setParameter('ibexa.http_cache.purge_type', 'varnish');
             $container->setParameter('purge_type', 'varnish');
             $container->setParameter('purge_server', $purgeServer);
         }

--- a/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
+++ b/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
@@ -15,8 +15,8 @@ class PoliciesConfigBuilder extends ContainerConfigBuilder
     {
         $previousPolicyMap = [];
 
-        if ($this->containerBuilder->hasParameter('ezpublish.api.role.policy_map')) {
-            $previousPolicyMap = $this->containerBuilder->getParameter('ezpublish.api.role.policy_map');
+        if ($this->containerBuilder->hasParameter('ibexa.api.role.policy_map')) {
+            $previousPolicyMap = $this->containerBuilder->getParameter('ibexa.api.role.policy_map');
         }
 
         // We receive limitations as values, but we want them as keys to be used by isset().
@@ -33,7 +33,7 @@ class PoliciesConfigBuilder extends ContainerConfigBuilder
         }
 
         $this->containerBuilder->setParameter(
-            'ezpublish.api.role.policy_map',
+            'ibexa.api.role.policy_map',
             $previousPolicyMap
         );
     }

--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -3,110 +3,110 @@ parameters:
     webroot_dir: "%kernel.project_dir%/public"
 
     ###
-    # ezsettings namespace, default scope
+    # ibexa.site_access.config namespace, default scope
     ###
 
     # Content/Location view
-    ezsettings.default.location_view: {}
-    ezsettings.default.content_view: {}
-    ezsettings.default.block_view: {}
+    ibexa.site_access.config.default.location_view: {}
+    ibexa.site_access.config.default.content_view: {}
+    ibexa.site_access.config.default.block_view: {}
 
     # Default Twig variables
-    ezsettings.default.twig_variables: {}
+    ibexa.site_access.config.default.twig_variables: {}
 
     # Default view templates
-    ezplatform.default_view_templates.content.full: '@@IbexaCore/default/content/full.html.twig'
-    ezplatform.default_view_templates.content.line: '@@IbexaCore/default/content/line.html.twig'
-    ezplatform.default_view_templates.content.text_linked: '@@IbexaCore/default/content/text_linked.html.twig'
-    ezplatform.default_view_templates.content.embed: '@@IbexaCore/default/content/embed.html.twig'
-    ezplatform.default_view_templates.content.embed_inline: '@@IbexaCore/default/content/embed_inline.html.twig'
-    ezplatform.default_view_templates.content.embed_image: '@@IbexaCore/default/content/embed_image.html.twig'
-    ezplatform.default_view_templates.content.asset_image: '@@IbexaCore/default/content/asset_image.html.twig'
-    ezplatform.default_view_templates.block: '@@IbexaCore/default/block/block.html.twig'
+    ibexa.default_view_templates.content.full: '@@IbexaCore/default/content/full.html.twig'
+    ibexa.default_view_templates.content.line: '@@IbexaCore/default/content/line.html.twig'
+    ibexa.default_view_templates.content.text_linked: '@@IbexaCore/default/content/text_linked.html.twig'
+    ibexa.default_view_templates.content.embed: '@@IbexaCore/default/content/embed.html.twig'
+    ibexa.default_view_templates.content.embed_inline: '@@IbexaCore/default/content/embed_inline.html.twig'
+    ibexa.default_view_templates.content.embed_image: '@@IbexaCore/default/content/embed_image.html.twig'
+    ibexa.default_view_templates.content.asset_image: '@@IbexaCore/default/content/asset_image.html.twig'
+    ibexa.default_view_templates.block: '@@IbexaCore/default/block/block.html.twig'
 
     # Default templates
-    ezplatform.default_templates.pagelayout: '@@IbexaCore/pagelayout.html.twig'
-    ezplatform.default_templates.field_templates: '@@IbexaCore/content_fields.html.twig'
-    ezplatform.default_templates.fielddefinition_settings_templates: '@@IbexaCore/fielddefinition_settings.html.twig'
+    ibexa.default_templates.pagelayout: '@@IbexaCore/pagelayout.html.twig'
+    ibexa.default_templates.field_templates: '@@IbexaCore/content_fields.html.twig'
+    ibexa.default_templates.fielddefinition_settings_templates: '@@IbexaCore/fielddefinition_settings.html.twig'
 
     # Image Asset mappings
-    ezsettings.default.fieldtypes.ezimageasset.mappings:
+    ibexa.site_access.config.default.fieldtypes.ezimageasset.mappings:
         content_type_identifier: image
         content_field_identifier: image
         name_field_identifier: name
         parent_location_id: 51
 
-    ezsettings.default.pagelayout: '%ezplatform.default_templates.pagelayout%'
-    ezsettings.default.page_layout: '%ezplatform.default_templates.pagelayout%'
+    ibexa.site_access.config.default.pagelayout: '%ibexa.default_templates.pagelayout%'
+    ibexa.site_access.config.default.page_layout: '%ibexa.default_templates.pagelayout%'
 
     # List of content type identifiers to display as image when embedded
-    ezplatform.content_view.image_embed_content_types_identifiers: ['image']
+    ibexa.content_view.image_embed_content_types_identifiers: ['image']
 
-    ezsettings.default.content_view_defaults:
+    ibexa.site_access.config.default.content_view_defaults:
         full:
             default:
-                template: "%ezplatform.default_view_templates.content.full%"
+                template: '%ibexa.default_view_templates.content.full%'
                 match: []
         line:
             default:
-                template: "%ezplatform.default_view_templates.content.line%"
+                template: '%ibexa.default_view_templates.content.line%'
                 match: []
         text_linked:
             default:
-                template: "%ezplatform.default_view_templates.content.text_linked%"
+                template: '%ibexa.default_view_templates.content.text_linked%'
                 match: []
         embed:
             image:
-                template: '%ezplatform.default_view_templates.content.embed_image%'
+                template: '%ibexa.default_view_templates.content.embed_image%'
                 match:
-                    Identifier\ContentType: '%ezplatform.content_view.image_embed_content_types_identifiers%'
+                    Identifier\ContentType: '%ibexa.content_view.image_embed_content_types_identifiers%'
             default:
-                template: "%ezplatform.default_view_templates.content.embed%"
+                template: '%ibexa.default_view_templates.content.embed%'
                 match: []
         embed-inline:
             default:
-                template: "%ezplatform.default_view_templates.content.embed_inline%"
+                template: '%ibexa.default_view_templates.content.embed_inline%'
                 match: []
         asset_image:
             default:
-                template: '%ezplatform.default_view_templates.content.asset_image%'
+                template: '%ibexa.default_view_templates.content.asset_image%'
                 match: []
 
-    ezsettings.default.block_view_defaults:
+    ibexa.site_access.config.default.block_view_defaults:
         block:
             default:
-                template: "%ezplatform.default_view_templates.block%"
+                template: '%ibexa.default_view_templates.block%'
                 match: []
 
     # Common settings
-    ezpublish.repositories: {}
-    ezsettings.default.repository: ~
-    ezpublish.session_name.default: "eZSESSID{siteaccess_hash}"
-    ezsettings.default.session_name: "%ezpublish.session_name.default%"    # Using "{siteaccess_hash}" in session name makes it unique per siteaccess
-    ezsettings.default.session: { name: "%ezpublish.session_name.default%" } # Session options that will override options from framework
-    ezsettings.default.url_alias_router: true                       # Use UrlAliasRouter by default
-    ezsettings.default.index_page: ~                    # The page to show when accessing IndexPage (/)
-    ezsettings.default.default_page: ~                  # The default page to show, e.g. after user login this will be used for default redirection
-    ezsettings.default.languages: []
-    ezsettings.default.translation_siteaccesses: []
-    ezsettings.default.related_siteaccesses: []
-    ezsettings.default.cache_service_name: "cache.app"       # The cache pool serive name to use for a siteaccess / siteaccess-group
-    ezsettings.default.var_dir: "var"                   # The root directory where all log files, cache files and other stored files are created
-    ezsettings.default.storage_dir: "storage"           # Where to place new files for storage, it's relative to var directory
-    ezsettings.default.binary_dir: "original"
-    ezsettings.default.anonymous_user_id: 10            # The ID of the user to be used for everyone who is not logged in
-    ezsettings.default.api_keys: { google_maps: ~ }     # Google Maps APIs v3 key (https://developers.google.com/maps/documentation/javascript/get-api-key)
+    ibexa.repositories: {}
+    ibexa.site_access.config.default.repository: ~
+    ibexa.session_name.default: "eZSESSID{siteaccess_hash}"
+    ibexa.site_access.config.default.session_name: '%ibexa.session_name.default%'    # Using "{siteaccess_hash}" in session name makes it unique per siteaccess
+    ibexa.site_access.config.default.session: { name: '%ibexa.session_name.default%' } # Session options that will override options from framework
+    ibexa.site_access.config.default.url_alias_router: true                       # Use UrlAliasRouter by default
+    ibexa.site_access.config.default.index_page: ~                    # The page to show when accessing IndexPage (/)
+    ibexa.site_access.config.default.default_page: ~                  # The default page to show, e.g. after user login this will be used for default redirection
+    ibexa.site_access.config.default.languages: []
+    ibexa.site_access.config.default.translation_siteaccesses: []
+    ibexa.site_access.config.default.related_siteaccesses: []
+    ibexa.site_access.config.default.cache_service_name: "cache.app"       # The cache pool serive name to use for a siteaccess / siteaccess-group
+    ibexa.site_access.config.default.var_dir: "var"                   # The root directory where all log files, cache files and other stored files are created
+    ibexa.site_access.config.default.storage_dir: "storage"           # Where to place new files for storage, it's relative to var directory
+    ibexa.site_access.config.default.binary_dir: "original"
+    ibexa.site_access.config.default.anonymous_user_id: 10            # The ID of the user to be used for everyone who is not logged in
+    ibexa.site_access.config.default.api_keys: { google_maps: ~ }     # Google Maps APIs v3 key (https://developers.google.com/maps/documentation/javascript/get-api-key)
 
     # IO
-    ezsettings.default.io.metadata_handler: "default"
-    ezsettings.default.io.binarydata_handler: "default"
-    ezsettings.default.io.url_prefix: "$var_dir$/$storage_dir$"
-    ezsettings.default.io.legacy_url_prefix: "$var_dir$/$storage_dir$"
-    ezsettings.default.io.root_dir: "%webroot_dir%/$var_dir$/$storage_dir$"
-    ezsettings.default.io.permissions.files: 0644
-    ezsettings.default.io.permissions.directories: 0755
+    ibexa.site_access.config.default.io.metadata_handler: "default"
+    ibexa.site_access.config.default.io.binarydata_handler: "default"
+    ibexa.site_access.config.default.io.url_prefix: "$var_dir$/$storage_dir$"
+    ibexa.site_access.config.default.io.legacy_url_prefix: "$var_dir$/$storage_dir$"
+    ibexa.site_access.config.default.io.root_dir: "%webroot_dir%/$var_dir$/$storage_dir$"
+    ibexa.site_access.config.default.io.permissions.files: 0644
+    ibexa.site_access.config.default.io.permissions.directories: 0755
     # Blacklist against storing certain file types, validation will be refused for these
-    ezsettings.default.io.file_storage.file_type_blacklist:
+    ibexa.site_access.config.default.io.file_storage.file_type_blacklist:
         - php
         - php3
         - phar
@@ -126,50 +126,50 @@ parameters:
         - swf
 
     # Content settings
-    ezsettings.default.content.view_cache: true         # Whether to use content view cache or not (Etag/Last-Modified based)
-    ezsettings.default.content.ttl_cache: true          # Whether to use TTL Cache for content (i.e. Max-Age response header)
-    ezsettings.default.content.default_ttl: 60          # Default TTL cache value for content
-    ezsettings.default.content.tree_root.location_id: 2 # Root locationId for routing and link generation. Useful for multisite apps with one repository.
-    ezsettings.default.content.tree_root.excluded_uri_prefixes: [] # URI prefixes that are allowed to be outside the content tree
-    ezsettings.default.content.field_groups.list: ['content', 'metadata']
-    ezsettings.default.content.field_groups.default: 'content'
+    ibexa.site_access.config.default.content.view_cache: true         # Whether to use content view cache or not (Etag/Last-Modified based)
+    ibexa.site_access.config.default.content.ttl_cache: true          # Whether to use TTL Cache for content (i.e. Max-Age response header)
+    ibexa.site_access.config.default.content.default_ttl: 60          # Default TTL cache value for content
+    ibexa.site_access.config.default.content.tree_root.location_id: 2 # Root locationId for routing and link generation. Useful for multisite apps with one repository.
+    ibexa.site_access.config.default.content.tree_root.excluded_uri_prefixes: [] # URI prefixes that are allowed to be outside the content tree
+    ibexa.site_access.config.default.content.field_groups.list: ['content', 'metadata']
+    ibexa.site_access.config.default.content.field_groups.default: 'content'
 
     # URL Wilcards
-    ezsettings.default.url_wildcards.enabled: '%ezpublish.url_wildcards.enabled%'
+    ibexa.site_access.config.default.url_wildcards.enabled: '%ibexa.url_wildcards.enabled%'
 
     # FieldType settings
 
     # Cache settings
     # Server(s) URL(s) that will be used for purging HTTP cache with BAN requests.
-    ezsettings.default.http_cache.purge_servers: []
+    ibexa.site_access.config.default.http_cache.purge_servers: []
 
     # Treemenu settings (admin interface)
-    ezsettings.default.treemenu.http_cache: true        # Whether to use HttpCache or not for admin tree menu
-    ezsettings.default.treemenu.ttl_cache: 86400        # If HttpCache is used, cache time to live in seconds
+    ibexa.site_access.config.default.treemenu.http_cache: true        # Whether to use HttpCache or not for admin tree menu
+    ibexa.site_access.config.default.treemenu.ttl_cache: 86400        # If HttpCache is used, cache time to live in seconds
 
     # Templates to use while rendering fields
-    ezsettings.default.field_templates:
-        - {template: '%ezplatform.default_templates.field_templates%', priority: 0}
+    ibexa.site_access.config.default.field_templates:
+        - {template: '%ibexa.default_templates.field_templates%', priority: 0}
 
     # Templates for Field edition. Follows the same structure than for field_templates
-    ezsettings.default.field_edit_templates: []
+    ibexa.site_access.config.default.field_edit_templates: []
 
     # Templates to use while rendering field definition settings
-    ezsettings.default.fielddefinition_settings_templates:
-        - {template: '%ezplatform.default_templates.fielddefinition_settings_templates%', priority: 0}
+    ibexa.site_access.config.default.fielddefinition_settings_templates:
+        - {template: '%ibexa.default_templates.fielddefinition_settings_templates%', priority: 0}
 
     # Templates for FieldDefinition edition. Follows the same structure than for field_templates
-    ezsettings.default.fielddefinition_edit_templates: []
+    ibexa.site_access.config.default.fielddefinition_edit_templates: []
 
     # Security settings
-    ezsettings.default.security.login_template: "@@IbexaCore/Security/login.html.twig"
-    ezsettings.default.security.base_layout: "%ezsettings.default.page_layout%"
+    ibexa.site_access.config.default.security.login_template: "@@IbexaCore/Security/login.html.twig"
+    ibexa.site_access.config.default.security.base_layout: "%ibexa.site_access.config.default.page_layout%"
 
     # Image settings
-    ezsettings.default.image.temporary_dir: imagetmp
-    ezsettings.default.image.published_images_dir: images
-    ezsettings.default.image.versioned_images_dir: images-versioned
-    ezsettings.default.image_variations:
+    ibexa.site_access.config.default.image.temporary_dir: imagetmp
+    ibexa.site_access.config.default.image.published_images_dir: images
+    ibexa.site_access.config.default.image.versioned_images_dir: images-versioned
+    ibexa.site_access.config.default.image_variations:
         reference:
             reference: ~
             filters:
@@ -193,12 +193,12 @@ parameters:
 
     # ImageMagick
     # TODO: Deprecated. Move this to ezpublish_legacy.
-    ezpublish.image.imagemagick.enabled: false
-    ezpublish.image.imagemagick.executable_path:
-    ezpublish.image.imagemagick.executable: convert
-    ezsettings.default.imagemagick.pre_parameters:
-    ezsettings.default.imagemagick.post_parameters:
-    ezpublish.image.imagemagick.filters:
+    ibexa.image.imagemagick.enabled: false
+    ibexa.image.imagemagick.executable_path:
+    ibexa.image.imagemagick.executable: convert
+    ibexa.site_access.config.default.imagemagick.pre_parameters:
+    ibexa.site_access.config.default.imagemagick.post_parameters:
+    ibexa.image.imagemagick.filters:
         geometry/scale: "-geometry {1}x{2}"
         geometry/scalewidth: "-geometry {1}"
         geometry/scaleheight: "-geometry x{1}"
@@ -220,40 +220,40 @@ parameters:
         resize: "-resize {1}"
         optimize: "-strip"
 
-    ezsettings.default.image_host: ''
+    ibexa.site_access.config.default.image_host: ''
 
-    ezsettings.default.url_handler.http.options:
+    ibexa.site_access.config.default.url_handler.http.options:
         timeout: 10
         connection_timeout: 5
         batch_size: 25
         ignore_certificate: false
-    ezsettings.default.url_handler.https.options:
+    ibexa.site_access.config.default.url_handler.https.options:
         timeout: 10
         connection_timeout: 5
         batch_size: 25
         ignore_certificate: false
-    ezsettings.default.url_handler.mailto.options: {}
+    ibexa.site_access.config.default.url_handler.mailto.options: {}
 
     ###
     # Internal settings
     ###
-    ezpublish.siteaccess.list: []
-    ezpublish.siteaccess.groups: {}
-    ezpublish.siteaccess.groups_by_siteaccess: {}
-    ezpublish.siteaccess.default: ~
+    ibexa.site_access.list: []
+    ibexa.site_access.groups: {}
+    ibexa.site_access.groups_by_site_access: {}
+    ibexa.site_access.default: ~
     # SiteAccesses relation map. 2 dimensions array.
     # First dimension is indexed by repository identifier.
     # Second dimension is indexed by root location Id.
-    ezpublish.siteaccess.relation_map: {}
+    ibexa.site_access.relation_map: {}
     # SiteAccesses, indexed by language.
-    ezpublish.siteaccesses_by_language: {}
+    ibexa.site_access.by_language: {}
 
     ##
     # Siteaccess aware Entity Manager
     ##
     ibexa.orm.entity_mappings: []
 
-    ibexa.platform.io.nfs.adapter.config:
+    ibexa.io.nfs.adapter.config:
         root: './'
         path: '$var_dir$/$storage_dir$/'
         writeFlags: ~

--- a/src/bundle/Core/Resources/config/feature_contexts.yml
+++ b/src/bundle/Core/Resources/config/feature_contexts.yml
@@ -8,8 +8,8 @@ services:
         public: true
         arguments:
             $configResolver: '@ibexa.config.resolver'
-            $siteaccessList: '%ezpublish.siteaccess.list%'
-            $defaultSiteaccess: '%ezpublish.siteaccess.default%'
+            $siteaccessList: '%ibexa.site_access.list%'
+            $defaultSiteaccess: '%ibexa.site_access.default%'
 
     Ibexa\Bundle\Core\Features\Context\YamlConfigurationContext:
         public: true

--- a/src/bundle/Core/Resources/config/helpers.yml
+++ b/src/bundle/Core/Resources/config/helpers.yml
@@ -1,7 +1,7 @@
 parameters:
     # Helpers
-    ezpublish.config_resolver.resettable_services: []
-    ezpublish.config_resolver.updateable_services: []
+    ibexa.config_resolver.resettable_services: []
+    ibexa.config_resolver.updateable_services: []
 
 services:
     # Helpers
@@ -10,7 +10,7 @@ services:
         arguments:
             - '@ibexa.config.resolver'
             - '@ibexa.api.service.content'
-            - "%ezpublish.siteaccesses_by_language%"
+            - '%ibexa.site_access.by_language%'
             - "@?logger"
 
     Ibexa\Core\Helper\FieldHelper:

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -100,7 +100,7 @@ services:
         arguments:
             - '@ibexa.config.resolver'
             - '@Ibexa\Bundle\Core\Imagine\PlaceholderProviderRegistry'
-            - '%image_alias.placeholder_providers%'
+            - '%ibexa.io.images.alias.placeholder_provider%'
 
     Ibexa\Bundle\Core\Imagine\PlaceholderAliasGenerator:
         class: 'Ibexa\Bundle\Core\Imagine\PlaceholderAliasGenerator'

--- a/src/bundle/Core/Resources/config/locale.yml
+++ b/src/bundle/Core/Resources/config/locale.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezpublish.locale.conversion_map:
+    ibexa.locale.conversion_map:
         alb-AL: sq_AL
         ara-SA: ar_SA
         bos-BA: bs_BA
@@ -56,7 +56,7 @@ parameters:
         ukr-UA: uk_UA
         vie-VN: vi_VN
 
-    ezpublish.locale.browser_map:
+    ibexa.locale.browser_map:
         au: ['eng-AU']
         be: ['fre-BE', 'dut-BE', 'ger-BE']
         br: ['por-BR']
@@ -101,7 +101,7 @@ parameters:
 services:
     Ibexa\Core\MVC\Symfony\Locale\LocaleConverter:
         class: Ibexa\Core\MVC\Symfony\Locale\LocaleConverter
-        arguments: ["%ezpublish.locale.conversion_map%", "@logger"]
+        arguments: ['%ibexa.locale.conversion_map%', "@logger"]
         public: true
 
     Ibexa\Core\MVC\Symfony\Locale\LocaleConverterInterface:
@@ -120,7 +120,7 @@ services:
     Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider:
         autowire: true
         arguments:
-            $languageCodesMap: '%ezpublish.locale.browser_map%'
+            $languageCodesMap: '%ibexa.locale.browser_map%'
             $localeFallback: '%locale_fallback%'
 
     Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface: '@Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider'

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -1,12 +1,12 @@
 parameters:
-    ezpublish.kernel.root_dir: "%kernel.project_dir%/vendor/ibexa/core"
+    ibexa.kernel.root_dir: "%kernel.project_dir%/vendor/ibexa/core"
 
     # API
-    ezplatform.kernel.proxy_cache_dir: '%kernel.cache_dir%/repository/proxy'
+    ibexa.kernel.proxy_cache_dir: '%kernel.cache_dir%/repository/proxy'
 
     # Using legacy storage engine for data compatibility with 4.x
-    ezpublish.api.storage_engine.default: legacy
-    ezpublish.api.search_engine.default: legacy
+    ibexa.api.storage_engine.default: legacy
+    ibexa.api.search_engine.default: legacy
 
 services:
     # API
@@ -15,7 +15,7 @@ services:
         arguments:
             - '@ibexa.config.resolver'
             - Ibexa\Core\Repository\Repository
-            - "%ezpublish.api.role.policy_map%"
+            - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
             - "@?logger"
         calls:

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -1,7 +1,7 @@
 parameters:
-    ezpublish.default_router.non_siteaccess_aware_routes: ['_assetic_', '_wdt', '_profiler', '_configurator_', 'ibexa.user_hash']
+    ibexa.default_router.non_site_access_aware_routes: ['_assetic_', '_wdt', '_profiler', '_configurator_', 'ibexa.user_hash']
     # characters that may require encoding in the urlalias generator
-    ezpublish.urlalias_generator.charmap:
+    ibexa.urlalias_generator.charmap:
         "\"" : "%22"
         "'" : "%27"
         "<" : "%3C"
@@ -56,7 +56,7 @@ services:
             - '@ibexa.api.repository'
             - "@router.default"
             - '@ibexa.config.resolver'
-            - "%ezpublish.urlalias_generator.charmap%"
+            - '%ibexa.urlalias_generator.charmap%'
         parent: Ibexa\Core\MVC\Symfony\Routing\Generator
 
     Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistry: ~
@@ -71,8 +71,8 @@ services:
     Ibexa\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider:
         class: Ibexa\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider
         arguments:
-            - "%ezpublish.siteaccess.list%"
-            - "%ezpublish.siteaccess.groups_by_siteaccess%"
+            - '%ibexa.site_access.list%'
+            - '%ibexa.site_access.groups_by_site_access%'
         tags:
             - { name: ibexa.site_access.provider, priority: 10 }
 
@@ -100,8 +100,8 @@ services:
         arguments:
             - '@Ibexa\Bundle\Core\SiteAccess\MatcherBuilder'
             - "@logger"
-            - "%ezpublish.siteaccess.default%"
-            - "%ezpublish.siteaccess.match_config%"
+            - '%ibexa.site_access.default%'
+            - '%ibexa.site_access.match_config%'
             - '@ibexa.siteaccess.provider'
             - 'Ibexa\Core\MVC\Symfony\SiteAccess'
             - "%kernel.debug%"
@@ -124,7 +124,7 @@ services:
         arguments:
             - '@ibexa.config.resolver'
             - "@router"
-            - "%ezpublish.siteaccess.default%"
+            - '%ibexa.site_access.default%'
             - "@?logger"
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -2,22 +2,22 @@ imports:
     - { resource: commands.yml }
 
 parameters:
-    ezpublish.siteaccess.default.name: default
-    ezpublish.config.default_scope: ezsettings
+    ibexa.site_access.default.name: default
+    ibexa.config.default_scope: ibexa.site_access.config
 
     # Param converters
-    ezpublish.param_converter.content.priority: -2
-    ezpublish.param_converter.location.priority: -2
+    ibexa.param_converter.content.priority: -2
+    ibexa.param_converter.location.priority: -2
 
 services:
     # Siteaccess is injected in the container at runtime
     Ibexa\Core\MVC\Symfony\SiteAccess:
         class: Ibexa\Core\MVC\Symfony\SiteAccess
-        arguments: ["%ezpublish.siteaccess.default.name%", 'uninitialized']
+        arguments: ['%ibexa.site_access.default.name%', 'uninitialized']
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver:
         arguments:
-            - '%ezpublish.config.default_scope%'
+            - '%ibexa.config.default_scope%'
         calls:
             - [setContainer, ['@service_container']]
         lazy: true
@@ -27,8 +27,8 @@ services:
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\SiteAccessGroupConfigResolver:
         arguments:
             - '@ibexa.siteaccess.provider'
-            - '%ezpublish.config.default_scope%'
-            - '%ezpublish.siteaccess.groups%'
+            - '%ibexa.config.default_scope%'
+            - '%ibexa.site_access.groups%'
         calls:
             - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
             - [setContainer, ['@service_container']]
@@ -39,7 +39,7 @@ services:
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\StaticSiteAccessConfigResolver:
         arguments:
             - '@ibexa.siteaccess.provider'
-            - '%ezpublish.config.default_scope%'
+            - '%ibexa.config.default_scope%'
         calls:
             - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
             - [setContainer, ['@service_container']]
@@ -49,7 +49,7 @@ services:
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver:
         arguments:
-            - '%ezpublish.config.default_scope%'
+            - '%ibexa.config.default_scope%'
         calls:
             - [setContainer, ['@service_container']]
         lazy: true
@@ -72,7 +72,7 @@ services:
     Ibexa\Bundle\Core\EventListener\ConsoleCommandListener:
         class: Ibexa\Bundle\Core\EventListener\ConsoleCommandListener
         arguments:
-            - "%ezpublish.siteaccess.default%"
+            - '%ibexa.site_access.default%'
             - '@ibexa.siteaccess.provider'
             - "@event_dispatcher"
             - "%kernel.debug%"
@@ -185,14 +185,14 @@ services:
         arguments:
             - '@ibexa.siteaccessaware.service.content'
         tags:
-            - { name: request.param_converter, priority: "%ezpublish.param_converter.content.priority%", converter: ez_content_converter }
+            - { name: request.param_converter, priority: '%ibexa.param_converter.content.priority%', converter: ez_content_converter }
 
     Ibexa\Bundle\Core\Converter\LocationParamConverter:
         class: Ibexa\Bundle\Core\Converter\LocationParamConverter
         arguments:
             - '@ibexa.siteaccessaware.service.location'
         tags:
-            - { name: request.param_converter, priority: "%ezpublish.param_converter.location.priority%", converter: ez_location_converter }
+            - { name: request.param_converter, priority: '%ibexa.param_converter.location.priority%', converter: ez_location_converter }
 
     Ibexa\Bundle\Core\EventListener\ExceptionListener:
         class: Ibexa\Bundle\Core\EventListener\ExceptionListener

--- a/src/bundle/Core/Resources/config/session.yml
+++ b/src/bundle/Core/Resources/config/session.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezpublish.session.attribute_bag.storage_key: "_ezpublish"
+    ibexa.session.attribute_bag.storage_key: "_ezpublish"
 
 services:
     Ibexa\Bundle\Core\EventListener\SessionSetDynamicNameListener:
@@ -17,4 +17,4 @@ services:
     # @deprecated To be removed in 7.0 kernel, see 594b083d94f1cff7008fb0d7d54f40d0ce0a2ace
     session.attribute_bag:
         class: Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag
-        arguments: ["%ezpublish.session.attribute_bag.storage_key%"]
+        arguments: ['%ibexa.session.attribute_bag.storage_key%']

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -4,7 +4,7 @@ services:
         class: Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider
         arguments:
             - '@ibexa.config.resolver'
-            - "%ezpublish.repositories%"
+            - '%ibexa.repositories%'
 
     Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory:
         class: Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory

--- a/src/bundle/Core/Resources/config/templating.yml
+++ b/src/bundle/Core/Resources/config/templating.yml
@@ -1,10 +1,10 @@
 parameters:
     # @todo drop once core dependencies stop relying on those parameters
 
-    ezpublish.content_view.viewbase_layout: "@@IbexaCore/viewbase_layout.html.twig"
-    ezpublish.content_view.content_block_name: "content"
+    ibexa.content_view.viewbase_layout: "@@IbexaCore/viewbase_layout.html.twig"
+    ibexa.content_view.content_block_name: "content"
 
-    ezpublish.twig.extension.filesize.suffixes: ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB']
+    ibexa.twig.extension.filesize.suffixes: ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB']
 
 services:
     Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\ContentExtension:
@@ -24,7 +24,7 @@ services:
           - "@event_dispatcher"
           - '@ibexa.siteaccessaware.repository'
           - '@ibexa.config.resolver'
-          - "%ezpublish.content_view.viewbase_layout%"
+          - '%ibexa.content_view.viewbase_layout%'
           - '@Ibexa\Core\MVC\Symfony\View\Configurator\ViewProvider'
           - "@?logger"
 
@@ -110,7 +110,7 @@ services:
 
     Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\FileSizeExtension:
         class: Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\FileSizeExtension
-        arguments: ["@translator", "%ezpublish.twig.extension.filesize.suffixes%", '@ibexa.config.resolver', '@Ibexa\Core\MVC\Symfony\Locale\LocaleConverter' ]
+        arguments: ["@translator", '%ibexa.twig.extension.filesize.suffixes%', '@ibexa.config.resolver', '@Ibexa\Core\MVC\Symfony\Locale\LocaleConverter' ]
         tags:
             - {name: twig.extension}
 
@@ -129,7 +129,7 @@ services:
         arguments:
             $twig: '@twig'
             $resourceProvider: '@Ibexa\Core\MVC\Symfony\Templating\Twig\ResourceProvider'
-            $baseTemplate: '%ezpublish.content_view.viewbase_layout%'
+            $baseTemplate: '%ibexa.content_view.viewbase_layout%'
 
     ibexa.templating.field_block_renderer:
         alias: Ibexa\Core\MVC\Symfony\Templating\Twig\FieldBlockRenderer
@@ -270,7 +270,7 @@ services:
     Ibexa\Core\MVC\Symfony\View\ParametersInjector\ViewbaseLayout:
         class: Ibexa\Core\MVC\Symfony\View\ParametersInjector\ViewbaseLayout
         arguments:
-            - "%ezpublish.content_view.viewbase_layout%"
+            - '%ibexa.content_view.viewbase_layout%'
             - '@ibexa.config.resolver'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Core/SiteAccess/Config/ComplexConfigProcessor.php
+++ b/src/bundle/Core/SiteAccess/Config/ComplexConfigProcessor.php
@@ -17,7 +17,7 @@ use function str_replace;
 
 final class ComplexConfigProcessor implements ConfigProcessor
 {
-    private const DEFAULT_NAMESPACE = 'ezsettings';
+    private const DEFAULT_NAMESPACE = 'ibexa.site_access.config';
 
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
     private $configResolver;

--- a/src/bundle/Debug/Resources/views/Profiler/persistence/panel.html.twig
+++ b/src/bundle/Debug/Resources/views/Profiler/persistence/panel.html.twig
@@ -81,5 +81,5 @@
     </table>
 
 {% else %}
-    <p class="text-small text-muted">NOTE: Call logging is by default only enabled in debug mode as <code>ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging: "%kernel.debug%"</code>, enable debug or change the setting in order to see calls made and trace for where the calls comes from.</p>
+    <p class="text-small text-muted">NOTE: Call logging is by default only enabled in debug mode as <code>ibexa.spi.persistence.cache.persistenceLogger.enableCallLogging: "%kernel.debug%"</code>, enable debug or change the setting in order to see calls made and trace for where the calls comes from.</p>
 {% endif %}

--- a/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
+++ b/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
@@ -43,8 +43,8 @@ class IOConfigurationPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $ioMetadataHandlers = $container->hasParameter('ez_io.metadata_handlers') ?
-            $container->getParameter('ez_io.metadata_handlers') :
+        $ioMetadataHandlers = $container->hasParameter('ibexa.io.metadata_handlers') ?
+            $container->getParameter('ibexa.io.metadata_handlers') :
             [];
         $this->processHandlers(
             $container,
@@ -54,8 +54,8 @@ class IOConfigurationPass implements CompilerPassInterface
             'ibexa.core.io.metadata_handler.flysystem.default'
         );
 
-        $ioBinarydataHandlers = $container->hasParameter('ez_io.binarydata_handlers') ?
-            $container->getParameter('ez_io.binarydata_handlers') :
+        $ioBinarydataHandlers = $container->hasParameter('ibexa.io.binarydata_handlers') ?
+            $container->getParameter('ibexa.io.binarydata_handlers') :
             [];
         $this->processHandlers(
             $container,

--- a/src/bundle/IO/DependencyInjection/IbexaIOExtension.php
+++ b/src/bundle/IO/DependencyInjection/IbexaIOExtension.php
@@ -115,7 +115,7 @@ class IbexaIOExtension extends Extension
                 $handlers[$name] = $handlerConfig;
             }
         }
-        $container->setParameter("ez_io.{$key}", $handlers);
+        $container->setParameter("ibexa.io.{$key}", $handlers);
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)

--- a/src/bundle/IO/Resources/config/default_settings.yml
+++ b/src/bundle/IO/Resources/config/default_settings.yml
@@ -1,4 +1,4 @@
 parameters:
     # User configured IO handlers
-    ez_io.metadata_handlers: {}
-    ez_io.binarydata_handlers: {}
+    ibexa.io.metadata_handlers: {}
+    ibexa.io.binarydata_handlers: {}

--- a/src/bundle/IO/Resources/config/io.yml
+++ b/src/bundle/IO/Resources/config/io.yml
@@ -2,8 +2,8 @@ services:
     Ibexa\Bundle\IO\Command\MigrateFilesCommand:
         class: Ibexa\Bundle\IO\Command\MigrateFilesCommand
         arguments:
-            - "%ez_io.metadata_handlers%"
-            - "%ez_io.binarydata_handlers%"
+            - '%ibexa.io.metadata_handlers%'
+            - '%ibexa.io.binarydata_handlers%'
             - '@Ibexa\Bundle\IO\Migration\FileListerRegistry\ConfigurableRegistry'
             - '@Ibexa\Bundle\IO\Migration\FileMigrator\FileMigrator'
         tags:
@@ -24,7 +24,7 @@ services:
         parent: Ibexa\Bundle\IO\Migration\MigrationHandler
         arguments:
             - '@ibexa.core.io.migration.file_lister.file_iterator.binary_file_iterator'
-            - "%ezsettings.default.binary_dir%"
+            - "%ibexa.site_access.config.default.binary_dir%"
         tags:
             - { name: "ibexa.io.migration.file_lister", identifier: "binary_file" }
         lazy: true
@@ -34,7 +34,7 @@ services:
         parent: Ibexa\Bundle\IO\Migration\MigrationHandler
         arguments:
             - '@ibexa.core.io.migration.file_lister.file_iterator.media_file_iterator'
-            - "%ezsettings.default.binary_dir%"
+            - "%ibexa.site_access.config.default.binary_dir%"
         tags:
             - { name: "ibexa.io.migration.file_lister", identifier: "media_file" }
         lazy: true
@@ -46,7 +46,7 @@ services:
             - '@Ibexa\Bundle\Core\Imagine\VariationPurger\LegacyStorageImageFileList'
             - '@ibexa.image_alias.variation_path_generator'
             - "@liip_imagine.filter.configuration"
-            - "%ezsettings.default.image.published_images_dir%"
+            - "%ibexa.site_access.config.default.image.published_images_dir%"
         tags:
             - { name: "ibexa.io.migration.file_lister", identifier: "image_file" }
         lazy: true
@@ -106,7 +106,7 @@ services:
     Ibexa\Bundle\IO\Flysystem\Adapter\SiteAccessAwareLocalAdapter:
         arguments:
             $configProcessor: '@Ibexa\Contracts\Core\SiteAccess\ConfigProcessor'
-            $config: '%ibexa.platform.io.nfs.adapter.config%'
+            $config: '%ibexa.io.nfs.adapter.config%'
 
     ibexa.io.nfs.adapter.site_access_aware:
         alias: Ibexa\Bundle\IO\Flysystem\Adapter\SiteAccessAwareLocalAdapter

--- a/src/contracts/Test/Repository/SetupFactory/Legacy.php
+++ b/src/contracts/Test/Repository/SetupFactory/Legacy.php
@@ -307,13 +307,13 @@ class Legacy extends SetupFactory
             $this->externalBuildContainer($containerBuilder);
 
             $containerBuilder->setParameter(
-                'legacy_dsn',
+                'ibexa.persistence.legacy.dsn',
                 self::$dsn
             );
 
             $containerBuilder->setParameter(
-                'io_root_dir',
-                self::$ioRootDir . '/' . $containerBuilder->getParameter('storage_dir')
+                'ibexa.io.dir.root',
+                self::$ioRootDir . '/' . $containerBuilder->getParameter('ibexa.io.dir.storage')
             );
 
             $containerBuilder->addCompilerPass(new Compiler\Search\FieldRegistryPass());

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -72,12 +72,12 @@ class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
         foreach ($saList as $sa) {
             $siteAccessName = $sa->name;
 
-            $repository = $this->configResolver->getParameter('repository', 'ezsettings', $siteAccessName);
+            $repository = $this->configResolver->getParameter('repository', 'ibexa.site_access.config', $siteAccessName);
             if (!isset($saRelationMap[$repository])) {
                 $saRelationMap[$repository] = [];
             }
 
-            $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', 'ezsettings', $siteAccessName);
+            $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', 'ibexa.site_access.config', $siteAccessName);
             if (!isset($saRelationMap[$repository][$rootLocationId])) {
                 $saRelationMap[$repository][$rootLocationId] = [];
             }
@@ -86,8 +86,8 @@ class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
         }
 
         $siteAccessName = $siteAccess->name;
-        $repository = $this->configResolver->getParameter('repository', 'ezsettings', $siteAccessName);
-        $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', 'ezsettings', $siteAccessName);
+        $repository = $this->configResolver->getParameter('repository', 'ibexa.site_access.config', $siteAccessName);
+        $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', 'ibexa.site_access.config', $siteAccessName);
 
         return $saRelationMap[$repository][$rootLocationId];
     }

--- a/src/lib/Resources/settings/fieldtype_services.yml
+++ b/src/lib/Resources/settings/fieldtype_services.yml
@@ -19,13 +19,13 @@ services:
     ibexa.field_type.ezimage.io_service.published:
         parent: ibexa.core.io.service
         calls:
-            - [ setPrefix, [ "%image_storage_prefix%" ] ]
+            - [ setPrefix, [ '%ibexa.io.images.storage.prefix%' ] ]
 
     # Used to manipulate images with a legacy 'images-versioned' path
     ibexa.field_type.ezimage.io_service.draft:
         parent: ibexa.core.io.service
         calls:
-            - [ setPrefix, [ "%image_draft_storage_prefix%" ] ]
+            - [ setPrefix, [ '%ibexa.io.images.storage.prefix.draft%' ] ]
 
     Ibexa\Core\FieldType\Image\PathGenerator\LegacyPathGenerator:
         class: Ibexa\Core\FieldType\Image\PathGenerator\LegacyPathGenerator
@@ -37,7 +37,7 @@ services:
     ibexa.field_type.ezbinaryfile.io_service:
         parent: ibexa.core.io.service
         calls:
-            - [ setPrefix, [ "%binaryfile_storage_prefix%" ] ]
+            - [ setPrefix, [ '%ibexa.io.binary_file.storage.prefix%' ] ]
 
     Ibexa\Core\FieldType\BinaryBase\PathGenerator\LegacyPathGenerator:
         class: Ibexa\Core\FieldType\BinaryBase\PathGenerator\LegacyPathGenerator

--- a/src/lib/Resources/settings/fieldtypes.yml
+++ b/src/lib/Resources/settings/fieldtypes.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezpublish.fieldType.ezcountry.data:
+    ibexa.field_type.country.data:
         AF: {Name: "Afghanistan", Alpha2: "AF", Alpha3: "AFG", IDC: "93"}
         AX: {Name: "Åland", Alpha2: "AX", Alpha3: "ALA", IDC: "358"}
         AL: {Name: "Albania", Alpha2: "AL", Alpha3: "ALB", IDC: "355"}
@@ -279,7 +279,7 @@ services:
 
     Ibexa\Core\FieldType\Country\Type:
         class: Ibexa\Core\FieldType\Country\Type
-        arguments: ["%ezpublish.fieldType.ezcountry.data%"]
+        arguments: ['%ibexa.field_type.country.data%']
         parent: Ibexa\Core\FieldType\FieldType
         tags:
             - {name: ibexa.field_type, alias: ezcountry}

--- a/src/lib/Resources/settings/indexable_fieldtypes.yml
+++ b/src/lib/Resources/settings/indexable_fieldtypes.yml
@@ -24,7 +24,7 @@ services:
     Ibexa\Core\FieldType\Country\SearchField:
         class: Ibexa\Core\FieldType\Country\SearchField
         arguments:
-            - "%ezpublish.fieldType.ezcountry.data%"
+            - '%ibexa.field_type.country.data%'
         tags:
             - {name: ibexa.field_type.indexable, alias: ezcountry}
 

--- a/src/lib/Resources/settings/io.yml
+++ b/src/lib/Resources/settings/io.yml
@@ -46,7 +46,7 @@ services:
     Ibexa\Core\IO\Adapter\LocalAdapter:
         class: League\Flysystem\Adapter\Local
         arguments:
-            - "%io_root_dir%"
+            - '%ibexa.io.dir.root%'
 
     ibexa.core.io.default_url_decorator:
         alias: Ibexa\Core\IO\UrlDecorator\AbsolutePrefix

--- a/src/lib/Resources/settings/policies.yml
+++ b/src/lib/Resources/settings/policies.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezpublish.api.role.policy_map:
+    ibexa.api.role.policy_map:
         content:
             read: { Class: true, Section: true, Owner: true, Group: true, Node: true, Subtree: true, State: true }
             diff: { Class: true, Section: true, Owner: true, Node: true, Subtree: true }

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezplatform.kernel.proxy_cache_dir: 'var/cache/repository/proxy'
+    ibexa.kernel.proxy_cache_dir: 'var/cache/repository/proxy'
 
     # intentionally defined class parameter to be used by the Repository Factory
 services:
@@ -7,7 +7,7 @@ services:
         class: Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory
         arguments:
             - Ibexa\Core\Repository\Repository
-            - "%ezpublish.api.role.policy_map%"
+            - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
         calls:
             - [setContainer, ["@service_container"]]
@@ -141,7 +141,7 @@ services:
     # Domain mappers and proxies
     Ibexa\Core\Repository\ProxyFactory\ProxyGenerator:
         arguments:
-            $proxyCacheDir: '%ezplatform.kernel.proxy_cache_dir%'
+            $proxyCacheDir: '%ibexa.kernel.proxy_cache_dir%'
 
     Ibexa\Core\Repository\ProxyFactory\ProxyGeneratorInterface:
         alias: 'Ibexa\Core\Repository\ProxyFactory\ProxyGenerator'
@@ -204,7 +204,7 @@ services:
             $limitationService: '@Ibexa\Core\Repository\Permission\LimitationService'
             $userHandler: '@Ibexa\Contracts\Core\Persistence\User\Handler'
             $configResolver: '@ibexa.config.resolver'
-            $policyMap: '%ezpublish.api.role.policy_map%'
+            $policyMap: '%ibexa.api.role.policy_map%'
 
     Ibexa\Core\Repository\Permission\PermissionCriterionResolver:
         arguments:

--- a/src/lib/Resources/settings/repository/siteaccessaware.yml
+++ b/src/lib/Resources/settings/repository/siteaccessaware.yml
@@ -1,8 +1,8 @@
 parameters:
     languages: []
-    storage_dir: var/ezdemo_site/storage
-    legacy_url_prefix: var/ezdemo_site/storage
-    url_prefix: var/ezdemo_site/storage
+    ibexa.io.dir.storage: var/ezdemo_site/storage
+    ibexa.legacy.url_prefix: var/ezdemo_site/storage
+    ibexa.url_prefix: var/ezdemo_site/storage
 
 services:
     Ibexa\Core\Repository\SiteAccessAware\Repository:
@@ -110,6 +110,6 @@ services:
 
     Ibexa\Core\Repository\SiteAccessAware\Config\IOConfigResolver:
         arguments:
-            - '%storage_dir%'
-            - '%legacy_url_prefix%'
-            - '%url_prefix%'
+            - '%ibexa.io.dir.storage%'
+            - '%ibexa.legacy.url_prefix%'
+            - '%ibexa.url_prefix%'

--- a/src/lib/Resources/settings/roles.yml
+++ b/src/lib/Resources/settings/roles.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: limitations/language.yml }
 
 parameters:
-    ezpublish.api.role.policy_map: {}
+    ibexa.api.role.policy_map: {}
 
 services:
     ## Implemented Limitations

--- a/src/lib/Resources/settings/search_engines/common.yml
+++ b/src/lib/Resources/settings/search_engines/common.yml
@@ -2,7 +2,7 @@ imports:
     - {resource: search_engines/field_value_mappers.yml}
 
 parameters:
-    ezpublish.search.common.field_name_generator.map:
+    ibexa.search.common.field_name_generator.map:
         ez_integer: 'i'
         ez_minteger: 'mi'
         ez_id: 'id'
@@ -33,7 +33,7 @@ services:
     Ibexa\Core\Search\Common\FieldNameGenerator:
         class: Ibexa\Core\Search\Common\FieldNameGenerator
         arguments:
-            - "%ezpublish.search.common.field_name_generator.map%"
+            - '%ibexa.search.common.field_name_generator.map%'
 
     Ibexa\Core\Search\Common\FieldNameResolver:
         class: Ibexa\Core\Search\Common\FieldNameResolver

--- a/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -1,6 +1,6 @@
 parameters:
     # Full text search configuration options.
-    ezpublish.search.legacy.criterion_handler.full_text.configuration:
+    ibexa.search.legacy.criterion_handler.full_text.configuration:
         stopWordThresholdFactor: 0.66
         enableWildcards: true
         commands:
@@ -133,7 +133,7 @@ services:
         arguments:
             $processor: '@Ibexa\Core\Persistence\TransformationProcessor\PreprocessedBased'
             $languageMaskGenerator: '@Ibexa\Core\Persistence\Legacy\Content\Language\MaskGenerator'
-            $configuration: '%ezpublish.search.legacy.criterion_handler.full_text.configuration%'
+            $configuration: '%ibexa.search.legacy.criterion_handler.full_text.configuration%'
         tags:
             - {name: ibexa.search.legacy.gateway.criterion_handler.content}
             - {name: ibexa.search.legacy.gateway.criterion_handler.location}

--- a/src/lib/Resources/settings/search_engines/legacy/indexer.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/indexer.yml
@@ -6,7 +6,7 @@ services:
             $transformationProcessor: '@Ibexa\Core\Persistence\TransformationProcessor\PreprocessedBased'
             $searchIndex: '@Ibexa\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex'
             $languageMaskGenerator: '@Ibexa\Core\Persistence\Legacy\Content\Language\MaskGenerator'
-            $fullTextSearchConfiguration: '%ezpublish.search.legacy.criterion_handler.full_text.configuration%'
+            $fullTextSearchConfiguration: '%ibexa.search.legacy.criterion_handler.full_text.configuration%'
 
     Ibexa\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex:
         arguments:

--- a/src/lib/Resources/settings/settings.yml
+++ b/src/lib/Resources/settings/settings.yml
@@ -1,15 +1,15 @@
 parameters:
-    legacy_dsn: sqlite://:memory:
+    ibexa.persistence.legacy.dsn: sqlite://:memory:
     anonymous_user_id: 10
     kernel.debug: false
     languages: []
-    image_storage_prefix: images
-    image_draft_storage_prefix: images-versioned
-    binaryfile_storage_prefix: original
-    storage_dir: var/ezdemo_site/storage
-    io_root_dir: "%storage_dir%"
-    ezpublish.siteaccess.list: [test]
-    ezsettings.default.anonymous_user_id: 10
+    ibexa.io.images.storage.prefix: images
+    ibexa.io.images.storage.prefix.draft: images-versioned
+    ibexa.io.binary_file.storage.prefix: original
+    ibexa.io.dir.storage: var/ezdemo_site/storage
+    ibexa.io.dir.root: '%ibexa.io.dir.storage%'
+    ibexa.site_access.list: [test]
+    ibexa.site_access.config.default.anonymous_user_id: 10
 
 services:
     ibexa.api.persistence_handler:

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -1,15 +1,15 @@
 parameters:
     # Make sure logging is only enabled for debug by default
-    ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging: "%kernel.debug%"
+    ibexa.spi.persistence.cache.persistenceLogger.enableCallLogging: "%kernel.debug%"
     # Global in-memory settings, for meta data
-    ezpublish.spi.persistence.cache.inmemory.ttl: 3000
-    ezpublish.spi.persistence.cache.inmemory.limit: 100
-    ezpublish.spi.persistence.cache.inmemory.enable: true
+    ibexa.spi.persistence.cache.inmemory.ttl: 3000
+    ibexa.spi.persistence.cache.inmemory.limit: 100
+    ibexa.spi.persistence.cache.inmemory.enable: true
     # Global in-memory settings, for content in-memory cache
     ## WARNING: TTL on purpose low to avoid getting outdated data in prod! For dev config you can safely increase by x3
-    ezpublish.spi.persistence.cache.inmemory.content.ttl: 300
-    ezpublish.spi.persistence.cache.inmemory.content.limit: 100
-    ezpublish.spi.persistence.cache.inmemory.content.enable: true
+    ibexa.spi.persistence.cache.inmemory.content.ttl: 300
+    ibexa.spi.persistence.cache.inmemory.content.limit: 100
+    ibexa.spi.persistence.cache.inmemory.content.enable: true
     ibexa.core.persistence.cache.tag_prefix: 'ibx-'
     ibexa.core.persistence.cache.tag_patterns:
         by_group: 'bg-%s'
@@ -213,25 +213,25 @@ services:
     Ibexa\Core\Persistence\Cache\PersistenceLogger:
         class: Ibexa\Core\Persistence\Cache\PersistenceLogger
         arguments:
-            - "%ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging%"
+            - '%ibexa.spi.persistence.cache.persistenceLogger.enableCallLogging%'
 
     # In-Memory cache pools
     ibexa.spi.persistence.cache.inmemory:
         public: false
         class: Ibexa\Core\Persistence\Cache\InMemory\InMemoryCache
         arguments:
-            - "%ezpublish.spi.persistence.cache.inmemory.ttl%"
-            - "%ezpublish.spi.persistence.cache.inmemory.limit%"
-            - "%ezpublish.spi.persistence.cache.inmemory.enable%"
+            - '%ibexa.spi.persistence.cache.inmemory.ttl%'
+            - '%ibexa.spi.persistence.cache.inmemory.limit%'
+            - '%ibexa.spi.persistence.cache.inmemory.enable%'
         tags: [ ibexa.cache.persistence.inmemory ]
 
     ibexa.spi.persistence.cache.inmemory.content:
         public: false
         class: Ibexa\Core\Persistence\Cache\InMemory\InMemoryCache
         arguments:
-            - "%ezpublish.spi.persistence.cache.inmemory.content.ttl%"
-            - "%ezpublish.spi.persistence.cache.inmemory.content.limit%"
-            - "%ezpublish.spi.persistence.cache.inmemory.content.enable%"
+            - '%ibexa.spi.persistence.cache.inmemory.content.ttl%'
+            - '%ibexa.spi.persistence.cache.inmemory.content.limit%'
+            - '%ibexa.spi.persistence.cache.inmemory.content.enable%'
         tags: [ ibexa.cache.persistence.inmemory ]
 
     Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface:

--- a/src/lib/Resources/settings/storage_engines/common.yml
+++ b/src/lib/Resources/settings/storage_engines/common.yml
@@ -2,25 +2,25 @@ parameters:
     # Using definition files:
 
     # Transformation rules resources
-    ezpublish.api.storage_engine.transformation_rules.resources:
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/ascii.tr"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/basic.tr"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/cyrillic.tr"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/greek.tr"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/hebrew.tr"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/latin.tr"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/search.tr"
+    ibexa.api.storage_engine.transformation_rules.resources:
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/ascii.tr"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/basic.tr"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/cyrillic.tr"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/greek.tr"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/hebrew.tr"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/latin.tr"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/search.tr"
 
     # Using preprocessed files:
 
-    ezpublish.api.storage_engine.preprocessed_transformation_rules.resources:
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/ascii.tr.result"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/basic.tr.result"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/cyrillic.tr.result"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/greek.tr.result"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/hebrew.tr.result"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/latin.tr.result"
-        - "%ezpublish.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/search.tr.result"
+    ibexa.api.storage_engine.preprocessed_transformation_rules.resources:
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/ascii.tr.result"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/basic.tr.result"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/cyrillic.tr.result"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/greek.tr.result"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/hebrew.tr.result"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/latin.tr.result"
+        - "%ibexa.kernel.root_dir%/tests/lib/Persistence/TransformationProcessor/_fixtures/transformations/search.tr.result"
 
 services:
     Ibexa\Core\Persistence\FieldTypeRegistry:
@@ -52,11 +52,11 @@ services:
             #
             # - '@Ibexa\Core\Persistence\TransformationProcessor\DefinitionBased\Parser'
             # - '@Ibexa\Core\Persistence\TransformationProcessor\PcreCompiler'
-            # - "%ezpublish.api.storage_engine.transformation_rules.resources%"
+            # - '%ibexa.api.storage_engine.transformation_rules.resources%'
 
             # Using preprocessed files:
             - '@Ibexa\Core\Persistence\TransformationProcessor\PcreCompiler'
-            - "%ezpublish.api.storage_engine.preprocessed_transformation_rules.resources%"
+            - '%ibexa.api.storage_engine.preprocessed_transformation_rules.resources%'
 
     ibexa.persistence.connection:
         public: true # @todo should be private

--- a/tests/bundle/Core/ConfigResolverTest.php
+++ b/tests/bundle/Core/ConfigResolverTest.php
@@ -34,7 +34,7 @@ class ConfigResolverTest extends TestCase
      *
      * @return \Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver
      */
-    private function getResolver($defaultNS = 'ezsettings', $undefinedStrategy = ConfigResolver::UNDEFINED_STRATEGY_EXCEPTION, array $groupsBySiteAccess = [])
+    private function getResolver($defaultNS = 'ibexa.site_access.config', $undefinedStrategy = ConfigResolver::UNDEFINED_STRATEGY_EXCEPTION, array $groupsBySiteAccess = [])
     {
         $configResolver = new ConfigResolver(
             null,
@@ -51,7 +51,7 @@ class ConfigResolverTest extends TestCase
     public function testGetSetUndefinedStrategy()
     {
         $strategy = ConfigResolver::UNDEFINED_STRATEGY_NULL;
-        $defaultNS = 'ezsettings';
+        $defaultNS = 'ibexa.site_access.config';
         $resolver = $this->getResolver($defaultNS, $strategy);
 
         $this->assertSame($strategy, $resolver->getUndefinedStrategy());
@@ -67,13 +67,13 @@ class ConfigResolverTest extends TestCase
     {
         $this->expectException(ParameterNotFoundException::class);
 
-        $resolver = $this->getResolver('ezsettings', ConfigResolver::UNDEFINED_STRATEGY_EXCEPTION);
+        $resolver = $this->getResolver('ibexa.site_access.config', ConfigResolver::UNDEFINED_STRATEGY_EXCEPTION);
         $resolver->getParameter('foo');
     }
 
     public function testGetParameterFailedNull()
     {
-        $resolver = $this->getResolver('ezsettings', ConfigResolver::UNDEFINED_STRATEGY_NULL);
+        $resolver = $this->getResolver('ibexa.site_access.config', ConfigResolver::UNDEFINED_STRATEGY_NULL);
         $this->assertNull($resolver->getParameter('foo'));
     }
 
@@ -109,7 +109,7 @@ class ConfigResolverTest extends TestCase
      */
     public function testGetParameterGlobalScope($paramName, $expectedValue)
     {
-        $globalScopeParameter = "ezsettings.global.$paramName";
+        $globalScopeParameter = "ibexa.site_access.config.global.$paramName";
         $this->containerMock
             ->expects($this->once())
             ->method('hasParameter')
@@ -129,13 +129,13 @@ class ConfigResolverTest extends TestCase
      */
     public function testGetParameterRelativeScope($paramName, $expectedValue)
     {
-        $relativeScopeParameter = "ezsettings.{$this->siteAccess->name}.$paramName";
+        $relativeScopeParameter = "ibexa.site_access.config.{$this->siteAccess->name}.$paramName";
         $this->containerMock
             ->expects($this->exactly(2))
             ->method('hasParameter')
             ->with(
                 $this->logicalOr(
-                    "ezsettings.global.$paramName",
+                    "ibexa.site_access.config.global.$paramName",
                     $relativeScopeParameter
                 )
             )
@@ -156,13 +156,13 @@ class ConfigResolverTest extends TestCase
     public function testGetParameterSpecificScope($paramName, $expectedValue)
     {
         $scope = 'some_siteaccess';
-        $relativeScopeParameter = "ezsettings.$scope.$paramName";
+        $relativeScopeParameter = "ibexa.site_access.config.$scope.$paramName";
         $this->containerMock
             ->expects($this->exactly(2))
             ->method('hasParameter')
             ->with(
                 $this->logicalOr(
-                    "ezsettings.global.$paramName",
+                    "ibexa.site_access.config.global.$paramName",
                     $relativeScopeParameter
                 )
             )
@@ -176,7 +176,7 @@ class ConfigResolverTest extends TestCase
 
         $this->assertSame(
             $expectedValue,
-            $this->getResolver()->getParameter($paramName, 'ezsettings', $scope)
+            $this->getResolver()->getParameter($paramName, 'ibexa.site_access.config', $scope)
         );
     }
 
@@ -185,14 +185,14 @@ class ConfigResolverTest extends TestCase
      */
     public function testGetParameterDefaultScope($paramName, $expectedValue)
     {
-        $defaultScopeParameter = "ezsettings.default.$paramName";
-        $relativeScopeParameter = "ezsettings.{$this->siteAccess->name}.$paramName";
+        $defaultScopeParameter = "ibexa.site_access.config.default.$paramName";
+        $relativeScopeParameter = "ibexa.site_access.config.{$this->siteAccess->name}.$paramName";
         $this->containerMock
             ->expects($this->exactly(3))
             ->method('hasParameter')
             ->with(
                 $this->logicalOr(
-                    "ezsettings.global.$paramName",
+                    "ibexa.site_access.config.global.$paramName",
                     $relativeScopeParameter,
                     $defaultScopeParameter
                 )
@@ -230,7 +230,7 @@ class ConfigResolverTest extends TestCase
         $paramName = 'foo.bar';
         $groupName = 'my_group';
         $configResolver = $this->getResolver(
-            'ezsettings',
+            'ibexa.site_access.config',
             ConfigResolver::UNDEFINED_STRATEGY_EXCEPTION,
             [$this->siteAccess->name => [$groupName]]
         );
@@ -240,10 +240,10 @@ class ConfigResolverTest extends TestCase
             ->will(
                 $this->returnValueMap(
                     [
-                        ["ezsettings.default.$paramName", $defaultMatch],
-                        ["ezsettings.$groupName.$paramName", $groupMatch],
-                        ["ezsettings.{$this->siteAccess->name}.$paramName", $scopeMatch],
-                        ["ezsettings.global.$paramName", $globalMatch],
+                        ["ibexa.site_access.config.default.$paramName", $defaultMatch],
+                        ["ibexa.site_access.config.$groupName.$paramName", $groupMatch],
+                        ["ibexa.site_access.config.{$this->siteAccess->name}.$paramName", $scopeMatch],
+                        ["ibexa.site_access.config.global.$paramName", $globalMatch],
                     ]
                 )
             );
@@ -261,7 +261,7 @@ class ConfigResolverTest extends TestCase
         $scope = 'another_siteaccess';
         $groupName = 'my_group';
         $configResolver = $this->getResolver(
-            'ezsettings',
+            'ibexa.site_access.config',
             ConfigResolver::UNDEFINED_STRATEGY_EXCEPTION,
             [
                 $this->siteAccess->name => ['some_group'],

--- a/tests/bundle/Core/DependencyInjection/Compiler/ChainRoutingPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ChainRoutingPassTest.php
@@ -102,7 +102,7 @@ class ChainRoutingPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'router.default',
             'setNonSiteAccessAwareRoutes',
-            ['%ezpublish.default_router.non_siteaccess_aware_routes%']
+            ['%ibexa.default_router.non_site_access_aware_routes%']
         );
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'router.default',

--- a/tests/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePassTest.php
@@ -19,7 +19,7 @@ class RegisterStorageEnginePassTest extends AbstractCompilerPassTestCase
     {
         parent::setUp();
         $this->setDefinition(StorageEngineFactory::class, new Definition());
-        $this->container->setParameter('ezpublish.api.storage_engine.default', 'default_storage_engine');
+        $this->container->setParameter('ibexa.api.storage_engine.default', 'default_storage_engine');
     }
 
     /**
@@ -55,7 +55,7 @@ class RegisterStorageEnginePassTest extends AbstractCompilerPassTestCase
         $storageEngineDef = new Definition();
         $storageEngineIdentifier = 'i_am_a_storage_engine';
 
-        $this->container->setParameter('ezpublish.api.storage_engine.default', $storageEngineIdentifier);
+        $this->container->setParameter('ibexa.api.storage_engine.default', $storageEngineIdentifier);
         $storageEngineDef->addTag('ibexa.storage', ['alias' => $storageEngineIdentifier]);
         $serviceId = 'storage_engine_service';
         $this->setDefinition($serviceId, $storageEngineDef);

--- a/tests/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPassTest.php
@@ -85,8 +85,8 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
 
     private function doCompile(): void
     {
-        $this->container->setParameter('ezplatform.session.handler_id', 'my_handler');
-        $this->container->setParameter('ezplatform.session.save_path', 'my_save_path');
+        $this->container->setParameter('ibexa.session.handler_id', 'my_handler');
+        $this->container->setParameter('ibexa.session.save_path', 'my_save_path');
 
         $this->compile();
 
@@ -103,7 +103,7 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
         $definition->setArguments([$dsn]);
 
         $this->container->setDefinition('session.abstract_handler', $definition);
-        $this->container->setParameter('ezplatform.session.handler_id', $dsn);
+        $this->container->setParameter('ibexa.session.handler_id', $dsn);
         $this->container->setDefinition(
             'session.storage.native',
             (new Definition())->setArguments([null, null, null])
@@ -120,8 +120,8 @@ class SessionConfigurationPassTest extends AbstractCompilerPassTestCase
 
     public function testCompileWithNullValues(): void
     {
-        $this->container->setParameter('ezplatform.session.handler_id', null);
-        $this->container->setParameter('ezplatform.session.save_path', null);
+        $this->container->setParameter('ibexa.session.handler_id', null);
+        $this->container->setParameter('ibexa.session.save_path', null);
 
         $this->compile();
 

--- a/tests/bundle/Core/DependencyInjection/Compiler/SlugConverterConfigurationPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/SlugConverterConfigurationPassTest.php
@@ -45,7 +45,7 @@ class SlugConverterConfigurationPassTest extends AbstractCompilerPassTestCase
 
         $this->setDefinition(\Ibexa\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter::class, $definition);
 
-        $this->setParameter('ezpublish.url_alias.slug_converter', [
+        $this->setParameter('ibexa.url_alias.slug_converter', [
             'transformation' => 'urlalias',
             'separator' => 'underscore',
             'transformation_groups' => [

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
@@ -27,7 +27,7 @@ class ChainConfigResolverTest extends TestCase
     private const SECOND_SA_NAME = 'second_sa';
     private const SA_GROUP = 'sa_group';
 
-    private const DEFAULT_NAMESPACE = 'ezsettings';
+    private const DEFAULT_NAMESPACE = 'ibexa.site_access.config';
 
     private const SCOPE_DEFAULT = 'default';
     private const SCOPE_GLOBAL = 'global';
@@ -115,7 +115,7 @@ class ChainConfigResolverTest extends TestCase
              ->method('hasParameter')
              ->with(
                  $this->logicalOr(
-                     "ezsettings.global.$paramName",
+                     "ibexa.site_access.config.global.$paramName",
                      $specificScopeParameter
                  )
              )
@@ -172,10 +172,10 @@ class ChainConfigResolverTest extends TestCase
              ->method('hasParameter')
              ->willReturnMap(
                  [
-                     ["ezsettings.default.$paramName", $defaultMatch],
-                     ["ezsettings.$groupName.$paramName", $groupMatch],
-                     ["ezsettings.{$this->siteAccess->name}.$paramName", $scopeMatch],
-                     ["ezsettings.global.$paramName", $globalMatch],
+                     ["ibexa.site_access.config.default.$paramName", $defaultMatch],
+                     ["ibexa.site_access.config.$groupName.$paramName", $groupMatch],
+                     ["ibexa.site_access.config.{$this->siteAccess->name}.$paramName", $scopeMatch],
+                     ["ibexa.site_access.config.global.$paramName", $globalMatch],
                  ]
              );
 

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTest.php
@@ -20,7 +20,7 @@ abstract class ConfigResolverTest extends TestCase
     protected const UNDEFINED_SA_NAME = 'undefined_sa';
     protected const SA_GROUP = 'sa_group';
 
-    protected const DEFAULT_NAMESPACE = 'ezsettings';
+    protected const DEFAULT_NAMESPACE = 'ibexa.site_access.config';
 
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     protected $siteAccess;
@@ -35,7 +35,7 @@ abstract class ConfigResolverTest extends TestCase
         $this->containerMock = $this->createMock(ContainerInterface::class);
     }
 
-    abstract protected function getResolver(string $defaultNamespace = 'ezsettings'): ConfigResolverInterface;
+    abstract protected function getResolver(string $defaultNamespace = 'ibexa.site_access.config'): ConfigResolverInterface;
 
     abstract protected function getScope(): string;
 

--- a/tests/bundle/Core/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
@@ -48,7 +48,7 @@ abstract class AbstractParserTestCase extends AbstractExtensionTestCase
     {
         $chainConfigResolver = $this->getConfigResolver();
         $assertMethod = $assertSame ? 'assertSame' : 'assertEquals';
-        $this->$assertMethod($expectedValue, $chainConfigResolver->getParameter($parameterName, 'ezsettings', $scope));
+        $this->$assertMethod($expectedValue, $chainConfigResolver->getParameter($parameterName, 'ibexa.site_access.config', $scope));
     }
 
     protected function getConfigResolver(): ConfigResolverInterface

--- a/tests/bundle/Core/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -117,7 +117,7 @@ class CommonTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue('var_dir', 'var', 'ezdemo_site');
         $this->assertConfigResolverParameterValue('storage_dir', 'storage', 'ezdemo_site');
         $this->assertConfigResolverParameterValue('binary_dir', 'original', 'ezdemo_site');
-        $this->assertConfigResolverParameterValue('session_name', '%ezpublish.session_name.default%', 'ezdemo_site');
+        $this->assertConfigResolverParameterValue('session_name', '%ibexa.session_name.default%', 'ezdemo_site');
         $this->assertConfigResolverParameterValue('http_cache.purge_servers', [], 'ezdemo_site');
         $this->assertConfigResolverParameterValue('anonymous_user_id', 10, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('index_page', null, 'ezdemo_site');
@@ -211,7 +211,7 @@ class CommonTest extends AbstractParserTestCase
         $this->load();
         $this->assertConfigResolverParameterValue(
             'security.base_layout',
-            '%ezsettings.default.page_layout%',
+            '%ibexa.site_access.config.default.page_layout%',
             'ezdemo_site'
         );
         $this->assertConfigResolverParameterValue(

--- a/tests/bundle/Core/DependencyInjection/Configuration/Parser/IOTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Parser/IOTest.php
@@ -18,9 +18,9 @@ class IOTest extends AbstractParserTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->container->setParameter('ezsettings.default.var_dir', 'var'); // PS: Does not seem to take effect
-        $this->container->setParameter('ezsettings.default.storage_dir', 'storage');
-        $this->container->setParameter('ezsettings.ezdemo_site.var_dir', 'var/ezdemo_site');
+        $this->container->setParameter('ibexa.site_access.config.default.var_dir', 'var'); // PS: Does not seem to take effect
+        $this->container->setParameter('ibexa.site_access.config.default.storage_dir', 'storage');
+        $this->container->setParameter('ibexa.site_access.config.ezdemo_site.var_dir', 'var/ezdemo_site');
     }
 
     protected function getContainerExtensions(): array

--- a/tests/bundle/Core/DependencyInjection/Configuration/Parser/ImageTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Parser/ImageTest.php
@@ -60,7 +60,7 @@ class ImageTest extends AbstractParserTestCase
             }
         }
 
-        $expected = $expectedParsedVariations['ezdemo_group'] + $this->container->getParameter('ezsettings.default.image_variations');
+        $expected = $expectedParsedVariations['ezdemo_group'] + $this->container->getParameter('ibexa.site_access.config.default.image_variations');
         $this->assertConfigResolverParameterValue('image_variations', $expected, 'ezdemo_site', false);
         $this->assertConfigResolverParameterValue('image_variations', $expected, 'ezdemo_site_admin', false);
         $this->assertConfigResolverParameterValue(

--- a/tests/bundle/Core/DependencyInjection/Configuration/Parser/LanguagesTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Parser/LanguagesTest.php
@@ -51,7 +51,7 @@ class LanguagesTest extends AbstractParserTestCase
                 'fre-FR' => ['fre', 'fre2'],
                 'pol-PL' => [self::EMPTY_SA_GROUP],
             ],
-            $this->container->getParameter('ezpublish.siteaccesses_by_language')
+            $this->container->getParameter('ibexa.site_access.by_language')
         );
         // languages for ezdemo_site_admin will take default value (empty array)
         $this->assertConfigResolverParameterValue('languages', [], 'ezdemo_site_admin');
@@ -76,7 +76,7 @@ class LanguagesTest extends AbstractParserTestCase
             [
                 'eng-US' => ['ezdemo_frontend_group', 'ezdemo_site', 'fre'],
             ],
-            $this->container->getParameter('ezpublish.siteaccesses_by_language')
+            $this->container->getParameter('ibexa.site_access.by_language')
         );
         // languages for ezdemo_site_admin will take default value (empty array)
         $this->assertConfigResolverParameterValue('languages', [], 'ezdemo_site_admin');

--- a/tests/bundle/Core/DependencyInjection/Configuration/Parser/TemplatesTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Parser/TemplatesTest.php
@@ -41,7 +41,7 @@ class TemplatesTest extends AbstractParserTestCase
             'field_templates',
             array_merge(
                 // Adding default kernel value.
-                [['template' => '%ezplatform.default_templates.field_templates%', 'priority' => 0]],
+                [['template' => '%ibexa.default_templates.field_templates%', 'priority' => 0]],
                 $groupFieldTemplates,
                 $demoSiteFieldTemplates
             ),
@@ -52,7 +52,7 @@ class TemplatesTest extends AbstractParserTestCase
             'field_templates',
             array_merge(
                 // Adding default kernel value.
-                [['template' => '%ezplatform.default_templates.field_templates%', 'priority' => 0]],
+                [['template' => '%ibexa.default_templates.field_templates%', 'priority' => 0]],
                 $groupFieldTemplates
             ),
             'fre',
@@ -60,7 +60,7 @@ class TemplatesTest extends AbstractParserTestCase
         );
         $this->assertConfigResolverParameterValue(
             'field_templates',
-            [['template' => '%ezplatform.default_templates.field_templates%', 'priority' => 0]],
+            [['template' => '%ibexa.default_templates.field_templates%', 'priority' => 0]],
             'ezdemo_site_admin',
             false
         );
@@ -116,7 +116,7 @@ class TemplatesTest extends AbstractParserTestCase
             'fielddefinition_settings_templates',
             array_merge(
                 // Adding default kernel value.
-                [['template' => '%ezplatform.default_templates.fielddefinition_settings_templates%', 'priority' => 0]],
+                [['template' => '%ibexa.default_templates.fielddefinition_settings_templates%', 'priority' => 0]],
                 $groupFieldTemplates,
                 $demoSiteFieldTemplates
             ),
@@ -127,7 +127,7 @@ class TemplatesTest extends AbstractParserTestCase
             'fielddefinition_settings_templates',
             array_merge(
                 // Adding default kernel value.
-                [['template' => '%ezplatform.default_templates.fielddefinition_settings_templates%', 'priority' => 0]],
+                [['template' => '%ibexa.default_templates.fielddefinition_settings_templates%', 'priority' => 0]],
                 $groupFieldTemplates
             ),
             'fre',
@@ -135,7 +135,7 @@ class TemplatesTest extends AbstractParserTestCase
         );
         $this->assertConfigResolverParameterValue(
             'fielddefinition_settings_templates',
-            [['template' => '%ezplatform.default_templates.fielddefinition_settings_templates%', 'priority' => 0]],
+            [['template' => '%ibexa.default_templates.fielddefinition_settings_templates%', 'priority' => 0]],
             'ezdemo_site_admin',
             false
         );

--- a/tests/bundle/Core/DependencyInjection/Configuration/Suggestion/Formatter/YamlSuggestionFormatterTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Suggestion/Formatter/YamlSuggestionFormatterTest.php
@@ -17,9 +17,9 @@ class YamlSuggestionFormatterTest extends TestCase
         $message = <<<EOT
 Database configuration has changed for eZ Content repository.
 Please define:
- - An entry in ezpublish.repositories
+ - An entry in ibexa.repositories
  - A Doctrine connection (You may check configuration reference for Doctrine "config:dump-reference doctrine" console command.)
- - A reference to configured repository in ezpublish.system.foo.repository
+ - A reference to configured repository in ibexa.system.foo.repository
 EOT;
         $suggestion = new ConfigSuggestion($message);
         $suggestion->setMandatory(true);
@@ -54,9 +54,9 @@ EOT;
         $expectedMessage = <<<EOT
 Database configuration has changed for eZ Content repository.
 Please define:
- - An entry in ezpublish.repositories
+ - An entry in ibexa.repositories
  - A Doctrine connection (You may check configuration reference for Doctrine "config:dump-reference doctrine" console command.)
- - A reference to configured repository in ezpublish.system.foo.repository
+ - A reference to configured repository in ibexa.system.foo.repository
 
 
 Example:

--- a/tests/bundle/Core/DependencyInjection/IbexaCoreExtensionTest.php
+++ b/tests/bundle/Core/DependencyInjection/IbexaCoreExtensionTest.php
@@ -89,22 +89,22 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
     {
         $this->load($this->siteaccessConfig);
         $this->assertContainerBuilderHasParameter(
-            'ezpublish.siteaccess.list',
+            'ibexa.site_access.list',
             $this->siteaccessConfig['siteaccess']['list']
         );
         $this->assertContainerBuilderHasParameter(
-            'ezpublish.siteaccess.default',
+            'ibexa.site_access.default',
             $this->siteaccessConfig['siteaccess']['default_siteaccess']
         );
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.groups', $this->siteaccessConfig['siteaccess']['groups']);
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.groups', $this->siteaccessConfig['siteaccess']['groups']);
 
         $expectedMatchingConfig = [];
         foreach ($this->siteaccessConfig['siteaccess']['match'] as $key => $val) {
             // Value is expected to always be an array (transformed by semantic configuration parser).
             $expectedMatchingConfig[$key] = is_array($val) ? $val : ['value' => $val];
         }
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.match_config', $expectedMatchingConfig);
-        $this->assertContainerBuilderHasParameter('ezsettings.empty_group.var_dir', 'foo');
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.match_config', $expectedMatchingConfig);
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.config.empty_group.var_dir', 'foo');
 
         $groupsBySiteaccess = [];
         foreach ($this->siteaccessConfig['siteaccess']['groups'] as $groupName => $groupMembers) {
@@ -121,11 +121,11 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
     public function testSiteAccessNoConfiguration()
     {
         $this->load();
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.list', ['setup']);
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.default', 'setup');
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.groups', []);
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.groups_by_siteaccess', []);
-        $this->assertContainerBuilderHasParameter('ezpublish.siteaccess.match_config', null);
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.list', ['setup']);
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.default', 'setup');
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.groups', []);
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.groups_by_site_access', []);
+        $this->assertContainerBuilderHasParameter('ibexa.site_access.match_config', null);
     }
 
     public function testImageMagickConfigurationBasic()
@@ -142,9 +142,9 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 ],
             ]
         );
-        $this->assertContainerBuilderHasParameter('ezpublish.image.imagemagick.enabled', true);
-        $this->assertContainerBuilderHasParameter('ezpublish.image.imagemagick.executable_path', dirname($_ENV['imagemagickConvertPath']));
-        $this->assertContainerBuilderHasParameter('ezpublish.image.imagemagick.executable', basename($_ENV['imagemagickConvertPath']));
+        $this->assertContainerBuilderHasParameter('ibexa.image.imagemagick.enabled', true);
+        $this->assertContainerBuilderHasParameter('ibexa.image.imagemagick.executable_path', dirname($_ENV['imagemagickConvertPath']));
+        $this->assertContainerBuilderHasParameter('ibexa.image.imagemagick.executable', basename($_ENV['imagemagickConvertPath']));
     }
 
     public function testImageMagickConfigurationFilters()
@@ -166,8 +166,8 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 ],
             ]
         );
-        $this->assertTrue($this->container->hasParameter('ezpublish.image.imagemagick.filters'));
-        $filters = $this->container->getParameter('ezpublish.image.imagemagick.filters');
+        $this->assertTrue($this->container->hasParameter('ibexa.image.imagemagick.filters'));
+        $filters = $this->container->getParameter('ibexa.image.imagemagick.filters');
         $this->assertArrayHasKey('foobar', $filters);
         $this->assertSame($customFilters['foobar'], $filters['foobar']);
         $this->assertArrayHasKey('wow', $filters);
@@ -206,7 +206,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 'options' => [],
                 'verify_binary_data_availability' => false,
             ],
-        ], $this->container->getParameter('image_alias.placeholder_providers'));
+        ], $this->container->getParameter('ibexa.io.images.alias.placeholder_provider'));
     }
 
     public function testRoutingConfiguration()
@@ -214,8 +214,8 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
         $this->load();
         $this->assertContainerBuilderHasAlias('router', ChainRouter::class);
 
-        $this->assertTrue($this->container->hasParameter('ezpublish.default_router.non_siteaccess_aware_routes'));
-        $nonSiteaccessAwareRoutes = $this->container->getParameter('ezpublish.default_router.non_siteaccess_aware_routes');
+        $this->assertTrue($this->container->hasParameter('ibexa.default_router.non_site_access_aware_routes'));
+        $nonSiteaccessAwareRoutes = $this->container->getParameter('ibexa.default_router.non_site_access_aware_routes');
         // See ezpublish_minimal_no_siteaccess.yml fixture
         $this->assertContains('foo_route', $nonSiteaccessAwareRoutes);
         $this->assertContains('my_prefix_', $nonSiteaccessAwareRoutes);
@@ -231,7 +231,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
     {
         $this->load($customCacheConfig);
 
-        $this->assertContainerBuilderHasParameter('ezpublish.http_cache.purge_type', $expectedPurgeType);
+        $this->assertContainerBuilderHasParameter('ibexa.http_cache.purge_type', $expectedPurgeType);
     }
 
     public function cacheConfigurationProvider()
@@ -281,13 +281,13 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
             ]
         );
 
-        $this->assertContainerBuilderHasParameter('ezpublish.http_cache.purge_type', 'foobar');
+        $this->assertContainerBuilderHasParameter('ibexa.http_cache.purge_type', 'foobar');
     }
 
     public function testLocaleConfiguration()
     {
         $this->load(['locale_conversion' => ['foo' => 'bar']]);
-        $conversionMap = $this->container->getParameter('ezpublish.locale.conversion_map');
+        $conversionMap = $this->container->getParameter('ibexa.locale.conversion_map');
         $this->assertArrayHasKey('foo', $conversionMap);
         $this->assertSame('bar', $conversionMap['foo']);
     }
@@ -306,7 +306,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -324,7 +324,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -333,13 +333,13 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
             ],
         ];
         $this->load(['repositories' => $repositories]);
-        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+        $this->assertTrue($this->container->hasParameter('ibexa.repositories'));
 
         foreach ($repositories as &$repositoryConfig) {
             $repositoryConfig['storage']['config'] = [];
             $repositoryConfig['search']['config'] = [];
         }
-        $this->assertSame($repositories, $this->container->getParameter('ezpublish.repositories'));
+        $this->assertSame($repositories, $this->container->getParameter('ibexa.repositories'));
     }
 
     /**
@@ -348,9 +348,9 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
     public function testRepositoriesConfigurationFieldGroups($repositories, $expectedRepositories)
     {
         $this->load(['repositories' => $repositories]);
-        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+        $this->assertTrue($this->container->hasParameter('ibexa.repositories'));
 
-        $repositoriesPar = $this->container->getParameter('ezpublish.repositories');
+        $repositoriesPar = $this->container->getParameter('ibexa.repositories');
         $this->assertEquals(count($repositories), count($repositoriesPar));
 
         foreach ($repositoriesPar as $key => $repo) {
@@ -369,7 +369,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 ['main' => [
                         'fields_groups' => [
                             'list' => ['content', 'metadata'],
-                            'default' => '%ezsettings.default.content.field_groups.default%',
+                            'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                         ],
                     ],
                 ],
@@ -412,7 +412,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                     'anotherone' => [
                         'fields_groups' => [
                             'list' => ['content', 'metadata'],
-                            'default' => '%ezsettings.default.content.field_groups.default%',
+                            'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                         ],
                     ],
                 ],
@@ -435,7 +435,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                     'foo' => [
                         'fields_groups' => [
                             'list' => ['bar', 'baz', 'john'],
-                            'default' => '%ezsettings.default.content.field_groups.default%',
+                            'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                         ],
                     ],
                     'bar' => [
@@ -488,18 +488,18 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
         $expectedRepositories = [
             'main' => [
                 'storage' => [
-                    'engine' => '%ezpublish.api.storage_engine.default%',
+                    'engine' => '%ibexa.api.storage_engine.default%',
                     'connection' => null,
                     'config' => [],
                 ],
                 'search' => [
-                    'engine' => '%ezpublish.api.search_engine.default%',
+                    'engine' => '%ibexa.api.search_engine.default%',
                     'connection' => null,
                     'config' => [],
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -508,11 +508,11 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
             ],
         ];
         $this->load(['repositories' => $repositories]);
-        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+        $this->assertTrue($this->container->hasParameter('ibexa.repositories'));
 
         $this->assertSame(
             $expectedRepositories,
-            $this->container->getParameter('ezpublish.repositories')
+            $this->container->getParameter('ibexa.repositories')
         );
     }
 
@@ -534,13 +534,13 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => [],
                 ],
                 'storage' => [
-                    'engine' => '%ezpublish.api.storage_engine.default%',
+                    'engine' => '%ibexa.api.storage_engine.default%',
                     'connection' => null,
                     'config' => [],
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -549,11 +549,11 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
             ],
         ];
         $this->load(['repositories' => $repositories]);
-        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+        $this->assertTrue($this->container->hasParameter('ibexa.repositories'));
 
         $this->assertSame(
             $expectedRepositories,
-            $this->container->getParameter('ezpublish.repositories')
+            $this->container->getParameter('ibexa.repositories')
         );
     }
 
@@ -575,13 +575,13 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => [],
                 ],
                 'search' => [
-                    'engine' => '%ezpublish.api.search_engine.default%',
+                    'engine' => '%ibexa.api.search_engine.default%',
                     'connection' => null,
                     'config' => [],
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -590,11 +590,11 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
             ],
         ];
         $this->load(['repositories' => $repositories]);
-        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+        $this->assertTrue($this->container->hasParameter('ibexa.repositories'));
 
         $this->assertSame(
             $expectedRepositories,
-            $this->container->getParameter('ezpublish.repositories')
+            $this->container->getParameter('ibexa.repositories')
         );
     }
 
@@ -632,7 +632,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -652,7 +652,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -661,11 +661,11 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
             ],
         ];
         $this->load(['repositories' => $repositories]);
-        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+        $this->assertTrue($this->container->hasParameter('ibexa.repositories'));
 
         $this->assertSame(
             $expectedRepositories,
-            $this->container->getParameter('ezpublish.repositories')
+            $this->container->getParameter('ibexa.repositories')
         );
     }
 
@@ -685,13 +685,13 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => [],
                 ],
                 'search' => [
-                    'engine' => '%ezpublish.api.search_engine.default%',
+                    'engine' => '%ibexa.api.search_engine.default%',
                     'connection' => null,
                     'config' => [],
                 ],
                 'fields_groups' => [
                     'list' => ['content', 'metadata'],
-                    'default' => '%ezsettings.default.content.field_groups.default%',
+                    'default' => '%ibexa.site_access.config.default.content.field_groups.default%',
                 ],
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -700,19 +700,19 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
             ],
         ];
         $this->load(['repositories' => $repositories]);
-        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+        $this->assertTrue($this->container->hasParameter('ibexa.repositories'));
 
         $this->assertSame(
             $expectedRepositories,
-            $this->container->getParameter('ezpublish.repositories')
+            $this->container->getParameter('ibexa.repositories')
         );
     }
 
     public function testRegisteredPolicies()
     {
         $this->load();
-        $this->assertContainerBuilderHasParameter('ezpublish.api.role.policy_map');
-        $previousPolicyMap = $this->container->getParameter('ezpublish.api.role.policy_map');
+        $this->assertContainerBuilderHasParameter('ibexa.api.role.policy_map');
+        $previousPolicyMap = $this->container->getParameter('ibexa.api.role.policy_map');
 
         $policies1 = [
             'custom_module' => [
@@ -755,9 +755,9 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
         ];
 
         $this->load();
-        $this->assertContainerBuilderHasParameter('ezpublish.api.role.policy_map');
+        $this->assertContainerBuilderHasParameter('ibexa.api.role.policy_map');
         $expectedPolicies = array_merge_recursive($expectedPolicies, $previousPolicyMap);
-        self::assertEquals($expectedPolicies, $this->container->getParameter('ezpublish.api.role.policy_map'));
+        self::assertEquals($expectedPolicies, $this->container->getParameter('ibexa.api.role.policy_map'));
     }
 
     public function testUrlAliasConfiguration()
@@ -787,7 +787,7 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
                 'slug_converter' => $configuration,
             ],
         ]);
-        $parsedConfig = $this->container->getParameter('ezpublish.url_alias.slug_converter');
+        $parsedConfig = $this->container->getParameter('ibexa.url_alias.slug_converter');
         $this->assertSame(
             $configuration,
             $parsedConfig

--- a/tests/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
+++ b/tests/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
@@ -27,7 +27,7 @@ class PoliciesConfigBuilderTest extends TestCase
         $configBuilder->addConfig($config1);
         $configBuilder->addConfig($config2);
 
-        self::assertSame($expected, $containerBuilder->getParameter('ezpublish.api.role.policy_map'));
+        self::assertSame($expected, $containerBuilder->getParameter('ibexa.api.role.policy_map'));
     }
 
     public function testAddResource()

--- a/tests/bundle/Core/Resources/config/framework.yaml
+++ b/tests/bundle/Core/Resources/config/framework.yaml
@@ -1,5 +1,5 @@
 parameters:
-    io_root_dir: ''
+    ibexa.io.dir.root: ''
     kernel.secret: 'foobar'
 
 framework:

--- a/tests/bundle/Core/SiteAccess/Config/IOConfigResolverTest.php
+++ b/tests/bundle/Core/SiteAccess/Config/IOConfigResolverTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class IOConfigResolverTest extends TestCase
 {
-    private const DEFAULT_NAMESPACE = 'ezsettings';
+    private const DEFAULT_NAMESPACE = 'ibexa.site_access.config';
 
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $configResolver;
@@ -39,18 +39,18 @@ class IOConfigResolverTest extends TestCase
     {
         $this->siteAccessService
             ->method('getCurrent')
-            ->willReturn(new SiteAccess('ezdemo_site'));
+            ->willReturn(new SiteAccess('demo_site'));
 
         $this->configResolver
             ->method('hasParameter')
-            ->with('io.url_prefix', null, 'ezdemo_site')
+            ->with('io.url_prefix', null, 'demo_site')
             ->willReturn(true);
         $this->configResolver
             ->method('getParameter')
             ->willReturnMap([
-                ['io.url_prefix', null, 'ezdemo_site', '$var_dir$/ezdemo_site/$storage_dir$'],
-                ['var_dir', self::DEFAULT_NAMESPACE, 'ezdemo_site', 'var'],
-                ['storage_dir', self::DEFAULT_NAMESPACE, 'ezdemo_site', 'storage'],
+                ['io.url_prefix', null, 'demo_site', '$var_dir$/demo_site/$storage_dir$'],
+                ['var_dir', self::DEFAULT_NAMESPACE, 'demo_site', 'var'],
+                ['storage_dir', self::DEFAULT_NAMESPACE, 'demo_site', 'storage'],
             ]);
 
         $complexConfigProcessor = new ComplexConfigProcessor(
@@ -62,25 +62,25 @@ class IOConfigResolverTest extends TestCase
             $complexConfigProcessor
         );
 
-        $this->assertEquals('var/ezdemo_site/storage', $ioConfigResolver->getUrlPrefix());
+        $this->assertEquals('var/demo_site/storage', $ioConfigResolver->getUrlPrefix());
     }
 
     public function testGetLegacyUrlPrefix(): void
     {
         $this->siteAccessService
             ->method('getCurrent')
-            ->willReturn(new SiteAccess('ezdemo_site'));
+            ->willReturn(new SiteAccess('demo_site'));
 
         $this->configResolver
             ->method('hasParameter')
-            ->with('io.legacy_url_prefix', null, 'ezdemo_site')
+            ->with('io.legacy_url_prefix', null, 'demo_site')
             ->willReturn(true);
         $this->configResolver
             ->method('getParameter')
             ->willReturnMap([
-                ['io.legacy_url_prefix', null, 'ezdemo_site', '$var_dir$/ezdemo_site/$storage_dir$'],
-                ['var_dir', self::DEFAULT_NAMESPACE, 'ezdemo_site', 'var'],
-                ['storage_dir', self::DEFAULT_NAMESPACE, 'ezdemo_site', 'legacy_storage'],
+                ['io.legacy_url_prefix', null, 'demo_site', '$var_dir$/demo_site/$storage_dir$'],
+                ['var_dir', self::DEFAULT_NAMESPACE, 'demo_site', 'var'],
+                ['storage_dir', self::DEFAULT_NAMESPACE, 'demo_site', 'legacy_storage'],
             ]);
 
         $complexConfigProcessor = new ComplexConfigProcessor(
@@ -92,25 +92,25 @@ class IOConfigResolverTest extends TestCase
             $complexConfigProcessor
         );
 
-        $this->assertEquals('var/ezdemo_site/legacy_storage', $ioConfigResolver->getLegacyUrlPrefix());
+        $this->assertEquals('var/demo_site/legacy_storage', $ioConfigResolver->getLegacyUrlPrefix());
     }
 
     public function testGetRootDir(): void
     {
         $this->siteAccessService
             ->method('getCurrent')
-            ->willReturn(new SiteAccess('ezdemo_site'));
+            ->willReturn(new SiteAccess('demo_site'));
 
         $this->configResolver
             ->method('hasParameter')
-            ->with('io.root_dir', null, 'ezdemo_site')
+            ->with('io.root_dir', null, 'demo_site')
             ->willReturn(true);
         $this->configResolver
             ->method('getParameter')
             ->willReturnMap([
-                ['io.root_dir', null, 'ezdemo_site', '/path/to/ezpublish/web/$var_dir$/ezdemo_site/$storage_dir$'],
-                ['var_dir', self::DEFAULT_NAMESPACE, 'ezdemo_site', 'var'],
-                ['storage_dir', self::DEFAULT_NAMESPACE, 'ezdemo_site', 'legacy_storage'],
+                ['io.root_dir', null, 'demo_site', '/path/to/ibexa/web/$var_dir$/demo_site/$storage_dir$'],
+                ['var_dir', self::DEFAULT_NAMESPACE, 'demo_site', 'var'],
+                ['storage_dir', self::DEFAULT_NAMESPACE, 'demo_site', 'legacy_storage'],
             ]);
 
         $complexConfigProcessor = new ComplexConfigProcessor(
@@ -122,7 +122,7 @@ class IOConfigResolverTest extends TestCase
             $complexConfigProcessor
         );
 
-        $this->assertEquals('/path/to/ezpublish/web/var/ezdemo_site/legacy_storage', $ioConfigResolver->getRootDir());
+        $this->assertEquals('/path/to/ibexa/web/var/demo_site/legacy_storage', $ioConfigResolver->getRootDir());
     }
 }
 

--- a/tests/bundle/IO/DependencyInjection/Compiler/IOConfigurationPassTest.php
+++ b/tests/bundle/IO/DependencyInjection/Compiler/IOConfigurationPassTest.php
@@ -25,8 +25,8 @@ class IOConfigurationPassTest extends AbstractCompilerPassTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->container->setParameter('ez_io.metadata_handlers', []);
-        $this->container->setParameter('ez_io.binarydata_handlers', []);
+        $this->container->setParameter('ibexa.io.metadata_handlers', []);
+        $this->container->setParameter('ibexa.io.binarydata_handlers', []);
 
         $this->container->setDefinition('ibexa.core.io.binarydata_handler.registry', new Definition());
         $this->container->setDefinition('ibexa.core.io.metadata_handler.registry', new Definition());
@@ -74,7 +74,7 @@ class IOConfigurationPassTest extends AbstractCompilerPassTestCase
     public function testBinarydataHandler()
     {
         $this->container->setParameter(
-            'ez_io.binarydata_handlers',
+            'ibexa.io.binarydata_handlers',
             ['my_handler' => ['name' => 'my_handler', 'type' => 'test_handler']]
         );
 
@@ -94,7 +94,7 @@ class IOConfigurationPassTest extends AbstractCompilerPassTestCase
     public function testMetadataHandler()
     {
         $this->container->setParameter(
-            'ez_io.metadata_handlers',
+            'ibexa.io.metadata_handlers',
             ['my_handler' => ['name' => 'my_handler', 'type' => 'test_handler']]
         );
 
@@ -117,7 +117,7 @@ class IOConfigurationPassTest extends AbstractCompilerPassTestCase
         $this->expectExceptionMessage('Unknown handler');
 
         $this->container->setParameter(
-            'ez_io.metadata_handlers',
+            'ibexa.io.metadata_handlers',
             ['test' => ['type' => 'unknown']]
         );
 
@@ -130,7 +130,7 @@ class IOConfigurationPassTest extends AbstractCompilerPassTestCase
         $this->expectExceptionMessage('Unknown handler');
 
         $this->container->setParameter(
-            'ez_io.binarydata_handlers',
+            'ibexa.io.binarydata_handlers',
             ['test' => ['type' => 'unknown']]
         );
 

--- a/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
+++ b/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
@@ -34,8 +34,8 @@ class IbexaIOExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->assertContainerBuilderHasParameter('ez_io.metadata_handlers', []);
-        $this->assertContainerBuilderHasParameter('ez_io.binarydata_handlers', []);
+        $this->assertContainerBuilderHasParameter('ibexa.io.metadata_handlers', []);
+        $this->assertContainerBuilderHasParameter('ibexa.io.binarydata_handlers', []);
     }
 
     public function testParametersWithMetadataHandler()
@@ -47,9 +47,9 @@ class IbexaIOExtensionTest extends AbstractExtensionTestCase
         ];
         $this->load($config);
 
-        $this->assertContainerBuilderHasParameter('ez_io.binarydata_handlers', []);
+        $this->assertContainerBuilderHasParameter('ibexa.io.binarydata_handlers', []);
         $this->assertContainerBuilderHasParameter(
-            'ez_io.metadata_handlers',
+            'ibexa.io.metadata_handlers',
             ['my_metadata_handler' => ['name' => 'my_metadata_handler', 'type' => 'flysystem', 'adapter' => 'my_adapter']]
         );
     }
@@ -63,9 +63,9 @@ class IbexaIOExtensionTest extends AbstractExtensionTestCase
         ];
         $this->load($config);
 
-        $this->assertContainerBuilderHasParameter('ez_io.metadata_handlers', []);
+        $this->assertContainerBuilderHasParameter('ibexa.io.metadata_handlers', []);
         $this->assertContainerBuilderHasParameter(
-            'ez_io.binarydata_handlers',
+            'ibexa.io.binarydata_handlers',
             ['my_binarydata_handler' => ['name' => 'my_binarydata_handler', 'type' => 'flysystem', 'adapter' => 'my_adapter']]
         );
     }

--- a/tests/integration/Core/LegacyTestContainerBuilder.php
+++ b/tests/integration/Core/LegacyTestContainerBuilder.php
@@ -49,7 +49,7 @@ final class LegacyTestContainerBuilder extends ContainerBuilder
             $this->configureRedis();
         }
 
-        $this->setParameter('ezpublish.kernel.root_dir', $installDir);
+        $this->setParameter('ibexa.kernel.root_dir', $installDir);
 
         $this->registerCompilerPasses();
     }

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -3262,7 +3262,7 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
-     * Test for the copyContent() method with ezsettings.default.content.retain_owner_on_copy set to false
+     * Test for the copyContent() method with ibexa.site_access.config.default.content.retain_owner_on_copy set to false
      * See settings/test/integration_legacy.yml for service override.
      *
      * @covers \Ibexa\Contracts\Core\Repository\ContentService::copyContent()

--- a/tests/integration/Core/Repository/FieldType/BinaryFileIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/BinaryFileIntegrationTest.php
@@ -29,7 +29,7 @@ class BinaryFileIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @var string
      */
-    protected static $storagePrefixConfigKey = 'binaryfile_storage_prefix';
+    protected static $storagePrefixConfigKey = 'ibexa.io.binary_file.storage.prefix';
 
     protected function getStoragePrefix()
     {

--- a/tests/integration/Core/Repository/FieldType/FileSearchBaseIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/FileSearchBaseIntegrationTest.php
@@ -43,7 +43,7 @@ abstract class FileSearchBaseIntegrationTest extends SearchBaseIntegrationTest
     /**
      * Storage dir settings key.
      */
-    protected static $storageDirConfigKey = 'storage_dir';
+    protected static $storageDirConfigKey = 'ibexa.io.dir.storage';
 
     /**
      * If storage data should not be cleaned up.
@@ -89,9 +89,9 @@ abstract class FileSearchBaseIntegrationTest extends SearchBaseIntegrationTest
         parent::setUp();
 
         if (!isset(self::$installDir)) {
-            self::$installDir = $this->getConfigValue('ezpublish.kernel.root_dir');
+            self::$installDir = $this->getConfigValue('ibexa.kernel.root_dir');
             self::$storageDir = $this->getConfigValue(static::$storageDirConfigKey);
-            self::$ioRootDir = $this->getConfigValue('io_root_dir');
+            self::$ioRootDir = $this->getConfigValue('ibexa.io.dir.root');
 
             self::setUpIgnoredPath($this->getConfigValue('ignored_storage_files'));
         }

--- a/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -29,7 +29,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @var string
      */
-    protected static $storagePrefixConfigKey = 'image_storage_prefix';
+    protected static $storagePrefixConfigKey = 'ibexa.io.images.storage.prefix';
 
     protected function getStoragePrefix()
     {

--- a/tests/integration/Core/Repository/FieldType/MediaIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/MediaIntegrationTest.php
@@ -29,7 +29,7 @@ class MediaIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @var string
      */
-    protected static $storagePrefixConfigKey = 'binaryfile_storage_prefix';
+    protected static $storagePrefixConfigKey = 'ibexa.io.binary_file.storage.prefix';
 
     protected function getStoragePrefix()
     {

--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezsettings.default.io.file_storage.file_type_blacklist:
+    ibexa.site_access.config.default.io.file_storage.file_type_blacklist:
         - php
         - php3
         - phar
@@ -51,7 +51,7 @@ services:
         arguments:
             - '@logger'
             - []
-            - 'ezsettings'
+            - 'ibexa.site_access.config'
         calls:
             - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
             - [setContainer, ['@service_container']]

--- a/tests/integration/Core/Resources/settings/integration_legacy.yml
+++ b/tests/integration/Core/Resources/settings/integration_legacy.yml
@@ -6,7 +6,7 @@ parameters:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
     # Image Asset mappings
-    ezsettings.default.fieldtypes.ezimageasset.mappings:
+    ibexa.site_access.config.default.fieldtypes.ezimageasset.mappings:
         content_type_identifier: image
         content_field_identifier: image
         name_field_identifier: name
@@ -49,7 +49,7 @@ services:
         class: Doctrine\DBAL\Connection
         factory: ['@Ibexa\Tests\Core\Persistence\DatabaseConnectionFactory', 'createConnection']
         arguments:
-            $databaseURL: '%legacy_dsn%'
+            $databaseURL: '%ibexa.persistence.legacy.dsn%'
 
     Ibexa\Contracts\Core\Repository\SettingService:
         public: true

--- a/tests/integration/Core/Resources/settings/override.yml
+++ b/tests/integration/Core/Resources/settings/override.yml
@@ -8,4 +8,4 @@ parameters:
         - eng-GB
         - ger-DE
 
-    ezpublish.spi.persistence.cache.inmemory.ttl: 0
+    ibexa.spi.persistence.cache.inmemory.ttl: 0

--- a/tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
+++ b/tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
@@ -166,7 +166,7 @@ class UserLanguagePreferenceProviderTest extends TestCase
             realpath(dirname(__DIR__, 5) . '/src/bundle/Core/Resources/config/locale.yml')
         );
 
-        return $config['parameters']['ezpublish.locale.browser_map'];
+        return $config['parameters']['ibexa.locale.browser_map'];
     }
 }
 

--- a/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
@@ -150,14 +150,14 @@ class SiteAccessServiceTest extends TestCase
     private function getConfigResolverParameters(): array
     {
         return [
-            ['repository', 'ezsettings', 'current', 'repository_1'],
-            ['content.tree_root.location_id', 'ezsettings', 'current', 1],
-            ['repository', 'ezsettings', 'first_sa', 'repository_1'],
-            ['content.tree_root.location_id', 'ezsettings', 'first_sa', 1],
-            ['repository', 'ezsettings', 'second_sa', 'repository_1'],
-            ['content.tree_root.location_id', 'ezsettings', 'second_sa', 2],
-            ['repository', 'ezsettings', 'default', ''],
-            ['content.tree_root.location_id', 'ezsettings', 'default', 3],
+            ['repository', 'ibexa.site_access.config', 'current', 'repository_1'],
+            ['content.tree_root.location_id', 'ibexa.site_access.config', 'current', 1],
+            ['repository', 'ibexa.site_access.config', 'first_sa', 'repository_1'],
+            ['content.tree_root.location_id', 'ibexa.site_access.config', 'first_sa', 1],
+            ['repository', 'ibexa.site_access.config', 'second_sa', 'repository_1'],
+            ['content.tree_root.location_id', 'ibexa.site_access.config', 'second_sa', 2],
+            ['repository', 'ibexa.site_access.config', 'default', ''],
+            ['content.tree_root.location_id', 'ibexa.site_access.config', 'default', 3],
         ];
     }
 }

--- a/tests/lib/Persistence/Legacy/HandlerTest.php
+++ b/tests/lib/Persistence/Legacy/HandlerTest.php
@@ -259,7 +259,7 @@ class HandlerTest extends TestCase
                 ['eng-US', 'eng-GB']
             );
             $containerBuilder->setParameter(
-                'legacy_dsn',
+                'ibexa.persistence.legacy.dsn',
                 $this->getDsn()
             );
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#31

Rebranded service container parameter names and Ibexa Config Resolver namespaces to follow unified pattern

### TODO

- [ ] Run regressions
- [x] Test manually
