### PR TITLE
[Behat] Adapted tests to the rebranding

### DIFF
--- a/src/bundle/Core/Features/Context/QueryControllerContext.php
+++ b/src/bundle/Core/Features/Context/QueryControllerContext.php
@@ -61,7 +61,7 @@ class QueryControllerContext extends RawMinkContext implements Context
         $configurationBlockName = 'behat_query_controller_' . $this->matchedContent->id;
 
         $configuration = [
-            'ezplatform' => [
+            'ibexa' => [
                 'system' => [
                     'default' => [
                         'content_view' => [
@@ -95,7 +95,7 @@ class QueryControllerContext extends RawMinkContext implements Context
         $configurationBlockName = 'behat_paging_query_controller_' . $this->matchedContent->id;
 
         $configuration = [
-            'ezplatform' => [
+            'ibexa' => [
                 'system' => [
                     'default' => [
                         'content_view' => [
@@ -281,7 +281,7 @@ class QueryControllerContext extends RawMinkContext implements Context
         $configurationBlockName = 'behat_paging_query_controller_' . $this->matchedContent->id;
 
         $configuration = [
-            'ezplatform' => [
+            'ibexa' => [
                 'system' => [
                     'default' => [
                         'content_view' => [

--- a/src/bundle/Core/Features/QueryController/query_controller.feature
+++ b/src/bundle/Core/Features/QueryController/query_controller.feature
@@ -7,7 +7,7 @@ Scenario: A content view can be configured to run and render a query
     Given a content item that matches the view configuration block below
       And the following content view configuration block:
       """
-      controller: ez_query:locationQueryAction
+      controller: ibexa_query:locationQueryAction
       params:
           query:
               query_type: 'LocationChildren'
@@ -54,7 +54,7 @@ Scenario: A content view can be configured to run and render a query and return 
     Given a content item that matches the view configuration block below
     And the following content view configuration block with paging action:
       """
-      controller: ez_query:pagingQueryAction
+      controller: ibexa_query:pagingQueryAction
       params:
           query:
               query_type: 'LocationChildren'
@@ -103,7 +103,7 @@ Scenario: A content view can be configured to run and render a query return a Pa
       """
     And the following content view configuration block with paging action and the template set above:
       """
-      controller: ez_query:pagingQueryAction
+      controller: ibexa_query:pagingQueryAction
       template: tests.html.twig
       params:
           query:
@@ -155,7 +155,7 @@ Scenario: A content view can be configured to run and render a query and set a s
       """
     And the following content view configuration block with paging action and the template set above:
       """
-      controller: ez_query:pagingQueryAction
+      controller: ibexa_query:pagingQueryAction
       template: tests.html.twig
       params:
           query:


### PR DESCRIPTION
Failing build: https://github.com/ibexa/core/runs/5035114137?check_suite_focus=true

Tests were failing with:
```
In FileLoader.php line 174:
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  [Symfony\Component\Config\Exception\LoaderLoadException]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  There is no extension able to load the configuration for "ezplatform" (in "/var/www/config/packages/behat/ezplatform_behat_c22c9f1b08d3b83ec0aa9787abf7c94e51d8f589.yaml"). Looked for namespace "ezplatform", found ""framework", "sensio_framework_extra", "twig", "monolog", "doctrine", "doctrine_migrations", "security", "twig_extra", "swiftmailer", "webpack_encore", "bazinga_js_translation", "fos_js_routing", "fos_http_cache", "jms_translation", "liip_imagine", "nelmio_cors", "oneup_flysystem", "knp_menu", "ibexa", "ibexa_legacy_search_engine", "ibexa_io", "ibexa_debug", "ibexa_http_cache", "ibexa_rest", "ibexa_solr", "ibexa_system_info", "ibexa_cron", "ibexa_repository_installer", "ibexa_doctrine_schema", "ibexa_content_forms", "ibexa_design_engine", "ibexa_standard_design", "ibexa_fieldtype_richtext", "ibexa_admin_ui", "ibexa_user", "ibexa_field_type_matrix", "ibexa_graphql", "ibexa_field_type_query", "ibexa_search", "overblog_graphql", "babdev_pagerfanta", "hautelook_templated_uri", "lexik_jwt_authentication", "friends_of_behat_symfony_extension", "e_z_behat"" in /var/www/config/packages/behat/ezplatform_behat_c22c9f1b08d3b83ec0aa9787abf7c94e51d8f589.yaml (which is being imported from "/var/www/config/packages/behat/ezplatform.yaml").                                                                          
```
and
```
The controller for URI "/admin/view/content/54/full/true/55" is not callable: Controller "ez_query" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?
```

I've adjusted the tests to the rebranding


CI failure:
```
1) Ibexa\Tests\Integration\Core\Repository\UserServiceTest::testUpdateUserToken
Ibexa\Core\Base\Exceptions\NotFoundException: Could not find 'user' with identifier '0800fc577294c34e0b28ad2839435945'
```
is not related to this PR

