### PR TITLE
Merge IBX-2098: Handled missing files in 'images:normalize-paths' command

### DIFF
--- a/src/bundle/Core/Command/NormalizeImagesPathsCommand.php
+++ b/src/bundle/Core/Command/NormalizeImagesPathsCommand.php
@@ -190,7 +190,7 @@ EOT
     /**
      * @param resource $inputStream
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentValue
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     private function moveFile(
         string $oldFileName,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2098](https://issues.ibexa.co/browse/IBX-2098)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Merge PR of https://github.com/ezsystems/ezpublish-kernel/pull/3136
