### PR TITLE
IBX-2301: Added onfiguration to enable translations from `i18n` package

### DIFF
--- a/src/bundle/Core/DependencyInjection/Compiler/TranslationCollectorPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/TranslationCollectorPass.php
@@ -44,12 +44,15 @@ class TranslationCollectorPass implements CompilerPassInterface
         $collector = new GlobCollector($container->getParameterBag()->get('kernel.project_dir'));
 
         $availableTranslations = [self::ORIGINAL_TRANSLATION];
-        foreach ($collector->collect() as $file) {
-            /* TODO - to remove when translation files will have proper names. */
-            if (isset(self::LOCALES_MAP[$file['locale']])) {
-                $file['locale'] = self::LOCALES_MAP[$file['locale']];
+
+        if ($container->getParameter('ibexa.ui.translations.enabled')) {
+            foreach ($collector->collect() as $file) {
+                /* TODO - to remove when translation files will have proper names. */
+                if (isset(self::LOCALES_MAP[$file['locale']])) {
+                    $file['locale'] = self::LOCALES_MAP[$file['locale']];
+                }
+                $availableTranslations[] = $file['locale'];
             }
-            $availableTranslations[] = $file['locale'];
         }
 
         $container->setParameter('available_translations', array_values(array_unique($availableTranslations)));

--- a/src/bundle/Core/DependencyInjection/Configuration.php
+++ b/src/bundle/Core/DependencyInjection/Configuration.php
@@ -64,6 +64,7 @@ class Configuration extends SiteAccessConfiguration
         $this->addImagePlaceholderSection($rootNode);
         $this->addUrlWildcardsSection($rootNode);
         $this->addOrmSection($rootNode);
+        $this->addUITranslationsSection($rootNode);
 
         // Delegate SiteAccess config to configuration parsers
         $this->mainSiteAccessConfigParser->addSemanticConfig($this->generateScopeBaseNode($rootNode));
@@ -522,6 +523,41 @@ EOT;
                                     ->scalarNode('prefix')
                                         ->isRequired()
                                     ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * Defines configuration for UI Translations.
+     *
+     * The configuration is available at:
+     * <code>
+     * ibexa:
+     *     ui:
+     *         translations:
+     *              enabled: true
+     *
+     * </code>
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $rootNode
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     */
+    private function addUITranslationsSection($rootNode): ArrayNodeDefinition
+    {
+        return $rootNode
+            ->children()
+                ->arrayNode('ui')
+                    ->children()
+                        ->arrayNode('translations')
+                            ->children()
+                                ->booleanNode('enabled')
+                                    ->defaultFalse()
+                                    ->info('When enabled UI will be translated based on translations from i18n package')
                                 ->end()
                             ->end()
                         ->end()

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -131,6 +131,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         $this->registerUrlAliasConfiguration($config, $container);
         $this->registerUrlWildcardsConfiguration($config, $container);
         $this->registerOrmConfiguration($config, $container);
+        $this->registerUITranslationsConfiguration($config, $container);
 
         // Routing
         $this->handleRouting($config, $container, $loader);
@@ -318,6 +319,11 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
         $entityMappings = $config['orm']['entity_mappings'];
         $container->setParameter('ibexa.orm.entity_mappings', $entityMappings);
+    }
+
+    private function registerUITranslationsConfiguration(array $config, ContainerBuilder $container): void
+    {
+        $container->setParameter('ibexa.ui.translations.enabled', $config['ui']['translations']['enabled'] ?? false);
     }
 
     /**

--- a/tests/bundle/Core/DependencyInjection/Compiler/TranslationCollectorPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/TranslationCollectorPassTest.php
@@ -18,14 +18,20 @@ class TranslationCollectorPassTest extends AbstractCompilerPassTestCase
         $container->addCompilerPass(new TranslationCollectorPass());
     }
 
-    public function testTranslationCollector(): void
-    {
+    /**
+     * @dataProvider translationCollectorProvider
+     */
+    public function testTranslationCollector(
+        bool $translationsEnabled,
+        array $availableTranslations
+    ): void {
         $this->setDefinition('translator.default', new Definition());
         $this->setParameter('kernel.project_dir', __DIR__ . $this->normalizePath('/../Fixtures'));
+        $this->setParameter('ibexa.ui.translations.enabled', $translationsEnabled);
 
         $this->compile();
 
-        $this->assertContainerBuilderHasParameter('available_translations', ['en', 'hi', 'nb']);
+        $this->assertContainerBuilderHasParameter('available_translations', $availableTranslations);
     }
 
     /**
@@ -36,6 +42,22 @@ class TranslationCollectorPassTest extends AbstractCompilerPassTestCase
     private function normalizePath($path)
     {
         return str_replace('/', \DIRECTORY_SEPARATOR, $path);
+    }
+
+    /**
+     * @return iterable<string,array{bool,array{string}}>
+     */
+    public function translationCollectorProvider(): iterable
+    {
+        yield 'translations enabled' => [
+            true,
+            ['en', 'hi', 'nb'],
+        ];
+
+        yield 'translations disabled' => [
+            false,
+            ['en'],
+        ];
     }
 }
 

--- a/tests/bundle/Core/DependencyInjection/IbexaCoreExtensionTest.php
+++ b/tests/bundle/Core/DependencyInjection/IbexaCoreExtensionTest.php
@@ -147,6 +147,44 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('ibexa.image.imagemagick.executable', basename($_ENV['imagemagickConvertPath']));
     }
 
+    /**
+     * @dataProvider translationsConfigurationProvider
+     */
+    public function testUITranslationsConfiguration(
+        bool $enabled,
+        bool $expectedParameterValue
+    ): void {
+        if (is_bool($enabled)) {
+            $this->load(
+                [
+                    'ui' => [
+                        'translations' => [
+                            'enabled' => $enabled,
+                        ],
+                    ],
+                ]
+            );
+        }
+
+        $this->assertContainerBuilderHasParameter('ibexa.ui.translations.enabled', $expectedParameterValue);
+    }
+
+    /**
+     * @return iterable<string,array{bool,array{string}}>
+     */
+    public function translationsConfigurationProvider(): iterable
+    {
+        yield 'translations enabled' => [
+            true,
+            true,
+        ];
+
+        yield 'translations disabled' => [
+            false,
+            false,
+        ];
+    }
+
     public function testImageMagickConfigurationFilters()
     {
         if (!isset($_ENV['imagemagickConvertPath']) || !is_executable($_ENV['imagemagickConvertPath'])) {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2301](https://issues.ibexa.co/browse/IBX-2301)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Because `i18n` package will be added to the product there is a need to enable available translations on demand. This will prevent a bad user experience because of the lack of translations in the product. By default when a package with translations is installed, a language of a user interface is taken from browser settings. 
To see translated strings in a product such configuration should be added. 
```
ibexa:
    ui:
        translations:
            enabled: 

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
