### PR TITLE
IBX-2432: Removed unused dependency from SelecionConverter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,11 +181,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Templating/GlobalHelper.php
 
 		-
-			message: "#^Class Ibexa\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\FieldValue\\\\Converter\\\\SelectionConverter constructor invoked with 0 parameters, 1 required\\.$#"
-			count: 1
-			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Handler\\:\\:deleteContent\\(\\) should return bool but return statement is missing\\.$#"
 			count: 1
 			path: src/lib/Persistence/Legacy/Content/Handler.php

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -9,7 +9,6 @@ namespace Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use DOMDocument;
 use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
-use Ibexa\Contracts\Core\Repository\LanguageService;
 use Ibexa\Core\FieldType\FieldSettings;
 use Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
@@ -17,18 +16,6 @@ use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
 
 class SelectionConverter implements Converter
 {
-    /** @var \Ibexa\Contracts\Core\Repository\LanguageService */
-    private $languageService;
-
-    /**
-     * @param \Ibexa\Contracts\Core\Repository\LanguageService $languageService
-     */
-    public function __construct(
-        LanguageService $languageService
-    ) {
-        $this->languageService = $languageService;
-    }
-
     /**
      * Factory for current class.
      *

--- a/src/lib/Resources/settings/storage_engines/legacy/field_value_converters.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/field_value_converters.yml
@@ -56,8 +56,6 @@ services:
 
     Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter:
         class: Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter
-        arguments:
-            - '@ibexa.api.service.language'
         tags:
             - {name: ibexa.field_type.storage.legacy.converter, alias: ezselection}
 

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
@@ -9,7 +9,6 @@ namespace Ibexa\Tests\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use Ibexa\Contracts\Core\Persistence\Content\FieldTypeConstraints;
 use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
-use Ibexa\Contracts\Core\Repository\LanguageService;
 use Ibexa\Core\FieldType\FieldSettings;
 use Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
@@ -27,9 +26,8 @@ class SelectionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $languageServiceMock = $this->createMock(LanguageService::class);
 
-        $this->converter = new SelectionConverter($languageServiceMock);
+        $this->converter = new SelectionConverter();
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2432](https://issues.ibexa.co/browse/IBX-2432)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Repository LanguageService is not used in the SelectionConverter and it also does not belong in this layer.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
