### PR TITLE
Fix using reduce noice and swirl filters when using imagick/gmagick

### DIFF
--- a/src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
@@ -7,6 +7,10 @@
 namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
 
 use Ibexa\Bundle\Core\Imagine\Filter\FilterConfiguration;
+use Ibexa\Bundle\Core\Imagine\Filter\Gmagick\ReduceNoiseFilter as GmagickReduceNoiseFilter;
+use Ibexa\Bundle\Core\Imagine\Filter\Gmagick\SwirlFilter as GmagickSwirlFilter;
+use Ibexa\Bundle\Core\Imagine\Filter\Imagick\ReduceNoiseFilter as ImagickReduceNoiseFilter;
+use Ibexa\Bundle\Core\Imagine\Filter\Imagick\SwirlFilter as ImagickSwirlFilter;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -35,26 +39,20 @@ class ImaginePass implements CompilerPassInterface
 
     private function processReduceNoiseFilter(ContainerBuilder $container, $driver)
     {
-        if ($driver !== 'imagick' && $driver !== 'gmagick') {
-            return;
+        if ($driver === 'imagick') {
+            $container->setAlias('ibexa.image_alias.imagine.filter.reduce_noise', new Alias(ImagickReduceNoiseFilter::class));
+        } elseif ($driver === 'gmagick') {
+            $container->setAlias('ibexa.image_alias.imagine.filter.reduce_noise', new Alias(GmagickReduceNoiseFilter::class));
         }
-
-        $container->setAlias(
-            'ibexa.image_alias.imagine.filter.reduce_noise',
-            new Alias("ezpublish.image_alias.imagine.filter.reduce_noise.$driver")
-        );
     }
 
     private function processSwirlFilter(ContainerBuilder $container, $driver)
     {
-        if ($driver !== 'imagick' && $driver !== 'gmagick') {
-            return;
+        if ($driver === 'imagick') {
+            $container->setAlias('ibexa.image_alias.imagine.filter.swirl', new Alias(ImagickSwirlFilter::class));
+        } elseif ($driver === 'gmagick') {
+            $container->setAlias('ibexa.image_alias.imagine.filter.swirl', new Alias(GmagickSwirlFilter::class));
         }
-
-        $container->setAlias(
-            'ibexa.image_alias.imagine.filter.swirl',
-            new Alias("ezpublish.image_alias.imagine.filter.swirl.$driver")
-        );
     }
 }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2442](https://issues.ibexa.co/browse/IBX-2442)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Using Imagick does not work on Ibexa 4.0.2.

When switching to Imagick from GD, the site fails to load with the following error:

```
The service "Ibexa\Bundle\Core\Imagine\Filter\Loader\ReduceNoiseFilterLoader" has a
dependency on a non-existent service "ezpublish.image_alias.imagine.filter.reduce_noise.imagick".
```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
