### PR TITLE
IBX-2509: Fix generating links on URI based siteaccesses

### DIFF
--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -32,7 +32,7 @@ services:
         abstract: true
         calls:
             - [setRequestContext, ["@router.request_context"]]
-            - [setSiteAccess, ["@?ezpublish.siteaccess"]]
+            - [setSiteAccess, ['@?Ibexa\Core\MVC\Symfony\SiteAccess']]
             - [setSiteAccessRouter, ['@Ibexa\Core\MVC\Symfony\SiteAccess\Router']]
             - [setLogger, ["@?logger"]]
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2509](https://issues.ibexa.co/browse/IBX-2509)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

If you have a URI based matched siteaccess (e.g.  `/admin`), generated URLs do not include the siteaccess prefix.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
