### PR TITLE
Fixed deprecated ibexa_content controller references

### DIFF
--- a/src/bundle/Core/Resources/config/routing/internal.yml
+++ b/src/bundle/Core/Resources/config/routing/internal.yml
@@ -1,7 +1,7 @@
 ibexa.content.translation.view:
     path: /view/content/{contentId}/{viewType}/{layout}/translation/{languageCode}/{locationId}
     defaults:
-        _controller: ibexa_content:viewAction
+        _controller: ibexa_content::viewAction
         viewType: full
         locationId: null
         layout: true
@@ -11,7 +11,7 @@ ibexa.content.translation.view:
 ibexa.content.view:
     path: /view/content/{contentId}/{viewType}/{layout}/{locationId}
     defaults:
-        _controller: ibexa_content:viewAction
+        _controller: ibexa_content::viewAction
         viewType: full
         locationId: null
         layout: true

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -139,7 +139,7 @@ services:
               - { name: controller.service_arguments }
 
     # This alias allows easier management for subrequests
-    # {{ render( controller( "ibexa_content:viewAction", {"contentId": 12, "locationId": 123, "viewType": "line"} ) ) }
+    # {{ render( controller( "ibexa_content::viewAction", {"contentId": 12, "locationId": 123, "viewType": "line"} ) ) }
     ibexa_content:
         public: true
         alias: Ibexa\Core\MVC\Symfony\Controller\Content\ViewController

--- a/src/bundle/Core/Resources/views/content_fields.html.twig
+++ b/src/bundle/Core/Resources/views/content_fields.html.twig
@@ -282,7 +282,7 @@
         {% for contentId in field.value.destinationContentIds %}
             {% if parameters.available[contentId] %}
                 <li>
-            {{ render( controller( "ibexa_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
+            {{ render( controller( "ibexa_content::viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
         </li>{% endif %}
         {% endfor %}
     </ul>
@@ -477,7 +477,7 @@
 {% apply spaceless %}
 {% if not ibexa_field_is_empty( content, field ) and parameters.available %}
     <div {{ block( 'field_attributes' ) }}>
-        {{ render( controller( "ibexa_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
+        {{ render( controller( "ibexa_content::viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
     </div>
 {% endif %}
 {% endapply %}

--- a/src/bundle/Core/Resources/views/fielddefinition_settings.html.twig
+++ b/src/bundle/Core/Resources/views/fielddefinition_settings.html.twig
@@ -319,7 +319,7 @@
         <div class="ibexa-fielddefinition-setting-name">{{ 'fielddefinition.selection-root.label'|trans|desc("Selection root:")}}</div>
         <div class="ibexa-fielddefinition-setting-value">
         {% if rootLocationId %}
-            {{ render( controller( "ibexa_content:viewAction", {'locationId': rootLocationId,  'viewType': 'line', 'layout': false} ), {'strategy': 'esi'}) }}
+            {{ render( controller( "ibexa_content::viewAction", {'locationId': rootLocationId,  'viewType': 'line', 'layout': false} ), {'strategy': 'esi'}) }}
         {% else %}
             <em>{{ 'fielddefinition.selection-root.undefined'|trans|desc("No defined root")}}</em>
         {% endif %}

--- a/src/lib/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/PreviewController.php
@@ -157,7 +157,7 @@ EOF;
 
         if ($this->controllerChecker->usesCustomController($content, $location)) {
             $forwardRequestParameters = [
-                '_controller' => 'ibexa_content:viewAction',
+                '_controller' => 'ibexa_content::viewAction',
                 '_route' => self::CONTENT_VIEW_ROUTE,
             ] + $forwardRequestParameters;
         }

--- a/src/lib/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/src/lib/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -32,7 +32,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
 {
     public const URL_ALIAS_ROUTE_NAME = 'ibexa.url.alias';
 
-    public const VIEW_ACTION = 'ibexa_content:viewAction';
+    public const VIEW_ACTION = 'ibexa_content::viewAction';
 
     /** @var \Symfony\Component\Routing\RequestContext */
     protected $requestContext;

--- a/src/lib/MVC/Symfony/View/Builder/Registry/ControllerMatch.php
+++ b/src/lib/MVC/Symfony/View/Builder/Registry/ControllerMatch.php
@@ -37,7 +37,7 @@ class ControllerMatch implements ViewBuilderRegistry
     /**
      * Returns the ViewBuilder that matches the given controller string.
      *
-     * @param string $controllerString A controller string to match against. Example: ibexa_content:viewAction.
+     * @param string $controllerString A controller string to match against. Example: ibexa_content::viewAction.
      *
      * @return \Ibexa\Core\MVC\Symfony\View\Builder\ViewBuilder|null
      */

--- a/tests/bundle/Core/EventListener/ViewControllerListenerTest.php
+++ b/tests/bundle/Core/EventListener/ViewControllerListenerTest.php
@@ -120,7 +120,7 @@ class ViewControllerListenerTest extends TestCase
 
         $this->request->attributes->add(
             [
-                '_controller' => 'ibexa_content:viewAction',
+                '_controller' => 'ibexa_content::viewAction',
                 'contentId' => $contentId,
                 'locationId' => $locationId,
                 'viewType' => $viewType,

--- a/tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
+++ b/tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
@@ -288,7 +288,7 @@ class PreviewControllerTest extends TestCase
         $duplicatedRequest = new Request();
         $duplicatedRequest->attributes->add(
             [
-                '_controller' => 'ibexa_content:viewAction',
+                '_controller' => 'ibexa_content::viewAction',
                 'contentId' => $content->id,
                 'location' => $location,
                 'viewType' => ViewManagerInterface::VIEW_TYPE_FULL,

--- a/tests/lib/MVC/Symfony/View/Builder/ContentViewBuilderTest.php
+++ b/tests/lib/MVC/Symfony/View/Builder/ContentViewBuilderTest.php
@@ -326,7 +326,7 @@ class ContentViewBuilderTest extends TestCase
 
         $parameters = [
             'viewType' => 'full',
-            '_controller' => 'ibexa_content:viewAction',
+            '_controller' => 'ibexa_content::viewAction',
             'locationId' => 2,
         ];
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Fixed deprecated `ibexa_content:viewAction` references as suggested in logs:

```
PHP Deprecated: Since symfony/http-kernel 5.1: Referencing controllers with a single colon is deprecated. Use "ibexa_content::viewAction" instead. in /home/user/ibexa/projectvendor/symfony/deprecation-contracts/function.php on line 25
```


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
