### PR TITLE
IBX-2901: Added Aliases for Security Providers

### DIFF
--- a/src/bundle/Core/Resources/config/security.yml
+++ b/src/bundle/Core/Resources/config/security.yml
@@ -48,3 +48,5 @@ services:
             - { name: kernel.event_subscriber }
 
     ibexa.security.user_provider: '@Ibexa\Core\MVC\Symfony\Security\User\UsernameProvider'
+    ibexa.security.user_provider.username: '@Ibexa\Core\MVC\Symfony\Security\User\UsernameProvider'
+    ibexa.security.user_provider.email: '@Ibexa\Core\MVC\Symfony\Security\User\EmailProvider'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2901](https://issues.ibexa.co/browse/IBX-2901)
| **Type**                                   | bug
| **Target Ibexa version** | `4.1`
| **BC breaks**                          | no

Configuration according https://doc.ibexa.co/en/latest/guide/user_management/user_management/#login-methods needs service ids `ibexa.security.user_provider.username` and `ibexa.security.user_provider.email`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
