### PR TITLE
IBX-2961: Implemented ConfigurationDumper for Ibexa Encore files

### DIFF
--- a/src/contracts/Container/Encore/ConfigurationDumper.php
+++ b/src/contracts/Container/Encore/ConfigurationDumper.php
@@ -98,8 +98,11 @@ final class ConfigurationDumper
         );
     }
 
-    private function createFinder(array $bundlesMetadata, $configFile, string $rootPath): Finder
-    {
+    private function createFinder(
+        array $bundlesMetadata,
+        string $configFile,
+        string $rootPath
+    ): Finder {
         $finder = new Finder();
         $finder
             ->in(array_column($bundlesMetadata, 'path'))

--- a/src/contracts/Container/Encore/ConfigurationDumper.php
+++ b/src/contracts/Container/Encore/ConfigurationDumper.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Container\Encore;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Scans project and bundles resources for the given configuration paths.
+ * To be used only during container building, in Bundle Extension class.
+ *
+ * @internal for internal use by Ibexa 1st party packages to provide specific extension points
+ */
+final class ConfigurationDumper
+{
+    public const ENCORE_DIR = 'encore';
+
+    private ContainerInterface $containerBuilder;
+
+    public function __construct(ContainerInterface $containerBuilder)
+    {
+        $this->containerBuilder = $containerBuilder;
+    }
+
+    /**
+     * @param array<string, array<string, array{?'deprecated': bool, ?'alternative': string}>> $webpackConfigNames
+     *
+     * @throws \JsonException
+     */
+    public function dumpCustomConfiguration(
+        array $webpackConfigNames
+    ): void {
+        $bundlesMetadata = $this->containerBuilder->getParameter('kernel.bundles_metadata');
+        $rootPath = $this->containerBuilder->getParameter('kernel.project_dir') . '/';
+        $targetPath = 'var/encore';
+
+        foreach ($webpackConfigNames as $configName => $configFiles) {
+            $paths = $this->locateConfigurationFiles($bundlesMetadata, $configFiles, $rootPath);
+            $this->dumpConfigurationPaths($configName, $rootPath . $targetPath, $paths);
+        }
+    }
+
+    private function locateConfigurationFiles(
+        array $bundlesMetadata,
+        array $configFiles,
+        string $rootPath
+    ): array {
+        $paths = [];
+        foreach ($configFiles as $configFile => $options) {
+            $finder = new Finder();
+            $finder
+                ->in(array_column($bundlesMetadata, 'path'))
+                ->path('Resources/' . self::ENCORE_DIR)
+                ->name($configFile)
+                // include top-level project resources
+                ->append(
+                    (new Finder())
+                        ->in($rootPath)
+                        ->path(self::ENCORE_DIR)
+                        ->name($configFile)
+                        ->depth(1)
+                        ->files()
+                )
+                ->files();
+
+            /** @var \Symfony\Component\Finder\SplFileInfo $fileInfo */
+            foreach ($finder as $fileInfo) {
+                if ($options['deprecated'] ?? false) {
+                    trigger_deprecation(
+                        'ibexa/core',
+                        '4.0.0',
+                        'Support for old configuration files is deprecated, please update name of %s file, to %s',
+                        $fileInfo->getPathname(),
+                        $options['alternative']
+                    );
+                }
+
+                $paths[] = preg_replace(
+                    '/^' . preg_quote($rootPath, '/') . '/',
+                    './',
+                    $fileInfo->getRealPath()
+                );
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    private function dumpConfigurationPaths(
+        string $configName,
+        string $targetPath,
+        array $paths
+    ): void {
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($targetPath);
+        $filesystem->dumpFile(
+            $targetPath . '/' . $configName,
+            sprintf('module.exports = %s;', json_encode($paths, JSON_THROW_ON_ERROR))
+        );
+    }
+}

--- a/tests/lib/Container/Encore/ConfigurationDumperTest.php
+++ b/tests/lib/Container/Encore/ConfigurationDumperTest.php
@@ -24,14 +24,16 @@ final class ConfigurationDumperTest extends TestCase
     private Filesystem $filesystem;
 
     private string $projectDir;
+    private string $fooBarBundlePath;
 
     protected function setUp(): void
     {
         $this->projectDir = dirname(__DIR__, 4) . self::PROJECT_DIR;
+        $this->fooBarBundlePath = $this->projectDir . self::FOO_BAR_BUNDLE_DIR;
         $this->filesystem = new Filesystem();
-        $this->filesystem->mkdir($this->projectDir . self::FOO_BAR_BUNDLE_DIR);
+        $this->filesystem->mkdir($this->fooBarBundlePath);
         $this->filesystem->dumpFile(
-            $this->projectDir . self::FOO_BAR_BUNDLE_DIR . '/Resources/encore/foo-bar.js',
+            $this->fooBarBundlePath . '/Resources/encore/foo-bar.js',
             'console.log("Hello, Foo Bar!");'
         );
         $this->filesystem->dumpFile(
@@ -50,7 +52,7 @@ final class ConfigurationDumperTest extends TestCase
             [
                 [
                     'kernel.bundles_metadata',
-                    ['FooBar' => ['path' => $this->projectDir . self::FOO_BAR_BUNDLE_DIR]],
+                    ['FooBar' => ['path' => $this->fooBarBundlePath]],
                 ],
                 ['kernel.project_dir', $this->projectDir],
             ],

--- a/tests/lib/Container/Encore/ConfigurationDumperTest.php
+++ b/tests/lib/Container/Encore/ConfigurationDumperTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Container\Encore;
+
+use Ibexa\Contracts\Core\Container\Encore\ConfigurationDumper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @covers \Ibexa\Contracts\Core\Container\Encore\ConfigurationDumper
+ */
+final class ConfigurationDumperTest extends TestCase
+{
+    private const PROJECT_DIR = '/var/io-tests/';
+    private const FOO_BAR_BUNDLE_DIR = 'foo-bar';
+
+    private Filesystem $filesystem;
+
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = dirname(__DIR__, 4) . self::PROJECT_DIR;
+        $this->filesystem = new Filesystem();
+        $this->filesystem->mkdir($this->projectDir . self::FOO_BAR_BUNDLE_DIR);
+        $this->filesystem->dumpFile(
+            $this->projectDir . self::FOO_BAR_BUNDLE_DIR . '/Resources/encore/foo-bar.js',
+            'console.log("Hello, Foo Bar!");'
+        );
+        $this->filesystem->dumpFile(
+            $this->projectDir . 'encore/foo-bar.js',
+            'console.log("Hello, world!");'
+        );
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    public function testDumpCustomConfiguration(): void
+    {
+        $containerMock = $this->createMock(ContainerInterface::class);
+        $containerMock->method('getParameter')->willReturnMap(
+            [
+                [
+                    'kernel.bundles_metadata',
+                    ['FooBar' => ['path' => $this->projectDir . self::FOO_BAR_BUNDLE_DIR]],
+                ],
+                ['kernel.project_dir', $this->projectDir],
+            ],
+        );
+        $configurationDumper = new ConfigurationDumper($containerMock);
+        $configurationDumper->dumpCustomConfiguration(['foo-bar.js' => ['foo-bar.js' => []]]);
+
+        $compiledFilePath = $this->projectDir . '/var/encore/foo-bar.js';
+        self::assertFileExists($compiledFilePath);
+        $compiledFileContents = file_get_contents($compiledFilePath);
+        self::assertRegExp(
+            '@^module\.exports = \[.*io-tests\\\/foo-bar\\\/Resources\\\/encore\\\/foo-bar\.js@',
+            $compiledFileContents
+        );
+        self::assertRegExp(
+            '@^module\.exports = \[.*io-tests\\\/encore\\\/foo-bar\.js@',
+            $compiledFileContents
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->projectDir);
+    }
+}

--- a/tests/lib/Container/Encore/ConfigurationDumperTest.php
+++ b/tests/lib/Container/Encore/ConfigurationDumperTest.php
@@ -24,6 +24,7 @@ final class ConfigurationDumperTest extends TestCase
     private Filesystem $filesystem;
 
     private string $projectDir;
+
     private string $fooBarBundlePath;
 
     protected function setUp(): void


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2961](https://issues.ibexa.co/browse/IBX-2961)
| **Required by**                       | <ul><li>ibexa/fieldtype-richtext#46</li><li>ibexa/admin-ui#471</li></ul>
| **Type**                                   | feature
| **Target Ibexa version** | `v4.1`+
| **BC breaks**                          | no

Based on ibexa/core@fb9c26f.

This PR provides the new `ConfigurationDumper` class to be used by 1st party Ibexa packages to provide Ibexa Encore extension points, like the one in ibexa/fieldtype-richtext#46.

The differences with ibexa/core@fb9c26f are that the code was encapsulated into a class, so 1st party usage is as simple as possible. Moreover it's project-first, following philosophy of Symfony which got rid of `AppBundle` and extracted Resources to top-level project directories. It's possible to place required file either in top level `encore/` directory or bundle-level `Resources/encore` directory.

### Why in ibexa/core?

We need to provide an extension point in [ibexa/fieldtype-richtext](https://github.com/ibexa/fieldtype-richtext) which has no knowledge of AdminUI. At the same time the mechanism used there will be common for the future extension points, so ibexa/core ATM makes the most sense (as core was meant to be a merge of former ezplatform-core and ezplatform-kernel).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
