### PR TITLE
IBX-3051: Fixed custom non-string Criterion query value mapping

### DIFF
--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
@@ -13,7 +13,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator as CriterionOperator;
 use Ibexa\Core\Persistence\TransformationProcessor;
 use RuntimeException;
-use function GuzzleHttp\default_ca_bundle;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -163,7 +162,7 @@ abstract class Handler
     {
         if (is_string($value)) {
             return $this->lowerCase($value);
-        } else if (is_array($value)) {
+        } elseif (is_array($value)) {
             return array_map([$this, 'prepareParameter'], $value);
         }
 

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
@@ -178,7 +178,7 @@ abstract class Handler
     {
         switch ($column) {
             case 'sort_key_string':
-                $parameterValue = $this->lowerCase($value);
+                $parameterValue = $this->prepareParameter($value);
                 $parameterType = ParameterType::STRING;
                 break;
             case 'sort_key_integer':


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3051](https://issues.ibexa.co/browse/IBX-3051)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
