### PR TITLE
Fixed wrong docblock declaration for `FieldHelper::isFieldEmpty` method

### DIFF
--- a/src/lib/Helper/FieldHelper.php
+++ b/src/lib/Helper/FieldHelper.php
@@ -34,7 +34,7 @@ class FieldHelper
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
      * @param string $fieldDefIdentifier
-     * @param null $forcedLanguage
+     * @param string|null $forcedLanguage
      *
      * @return bool
      */


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes/no

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
