### PR TITLE
Improved exception handling for Settings handler

### DIFF
--- a/src/lib/Persistence/Legacy/Setting/Handler.php
+++ b/src/lib/Persistence/Legacy/Setting/Handler.php
@@ -30,6 +30,10 @@ class Handler implements BaseSettingHandler
 
         $setting = $this->settingGateway->loadSettingById($lastId);
 
+        if (empty($setting)) {
+            throw $this->createNotFoundException($group, $identifier);
+        }
+
         return new Setting([
             'group' => $setting['group'],
             'identifier' => $setting['identifier'],
@@ -50,6 +54,10 @@ class Handler implements BaseSettingHandler
 
         $setting = $this->settingGateway->loadSetting($group, $identifier);
 
+        if (empty($setting)) {
+            throw $this->createNotFoundException($group, $identifier);
+        }
+
         return new Setting([
             'group' => $setting['group'],
             'identifier' => $setting['identifier'],
@@ -65,10 +73,7 @@ class Handler implements BaseSettingHandler
         $setting = $this->settingGateway->loadSetting($group, $identifier);
 
         if (empty($setting)) {
-            throw new NotFound('Setting', [
-                'group' => $group,
-                'identifier' => $identifier,
-            ]);
+            throw $this->createNotFoundException($group, $identifier);
         }
 
         return new Setting([
@@ -81,6 +86,14 @@ class Handler implements BaseSettingHandler
     public function delete(string $group, string $identifier): void
     {
         $this->settingGateway->deleteSetting($group, $identifier);
+    }
+
+    private function createNotFoundException(string $group, string $identifier): NotFound
+    {
+        return new NotFound('Setting', [
+            'group' => $group,
+            'identifier' => $identifier,
+        ]);
     }
 }
 

--- a/tests/lib/Persistence/Legacy/Setting/SettingHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Setting/SettingHandlerTest.php
@@ -7,6 +7,7 @@
 namespace Ibexa\Tests\Core\Persistence\Legacy\Setting;
 
 use Ibexa\Contracts\Core\Persistence\Setting\Setting;
+use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Persistence\Legacy\Setting\Gateway;
 use Ibexa\Core\Persistence\Legacy\Setting\Handler;
 use Ibexa\Tests\Core\Persistence\Legacy\TestCase;
@@ -15,37 +16,37 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * @covers \Ibexa\Core\Persistence\Legacy\Setting\Handler::create
  */
-class SettingHandlerTest extends TestCase
+final class SettingHandlerTest extends TestCase
 {
     /** @var \Ibexa\Core\Persistence\Legacy\Setting\Handler */
-    protected $settingHandler;
+    private $settingHandler;
 
     /** @var \Ibexa\Core\Persistence\Legacy\Setting\Gateway */
-    protected $gatewayMock;
+    private $gatewayMock;
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $handler = $this->getSettingHandler();
         $gatewayMock = $this->getGatewayMock();
 
-        $gatewayMock->expects($this->once())
+        $gatewayMock->expects(self::once())
             ->method('insertSetting')
             ->with(
-                $this->equalTo('group_a1'),
-                $this->equalTo('identifier_b2'),
-                $this->equalTo('value_c3')
-            )->will($this->returnValue(123));
+                self::identicalTo('group_a1'),
+                self::identicalTo('identifier_b2'),
+                self::identicalTo('value_c3')
+            )->willReturn(123);
 
-        $gatewayMock->expects($this->once())
+        $gatewayMock->expects(self::once())
             ->method('loadSettingById')
             ->with(
-                $this->equalTo(123)
+                self::identicalTo(123)
             )
-            ->will($this->returnValue([
+            ->willReturn([
                 'group' => 'group_a1',
                 'identifier' => 'identifier_b2',
                 'value' => 'value_c3',
-            ]));
+            ]);
 
         $settingRef = new Setting([
             'group' => 'group_a1',
@@ -59,33 +60,68 @@ class SettingHandlerTest extends TestCase
             'value_c3',
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             $settingRef,
             $result
+        );
+    }
+
+    public function testCreateFailsToLoad(): void
+    {
+        $handler = $this->getSettingHandler();
+        $gatewayMock = $this->getGatewayMock();
+
+        $gatewayMock->expects(self::once())
+            ->method('insertSetting')
+            ->with(
+                self::identicalTo('group_a1'),
+                self::identicalTo('identifier_b2'),
+                self::identicalTo('value_c3')
+            )->willReturn(123);
+
+        $gatewayMock->expects(self::once())
+            ->method('loadSettingById')
+            ->with(
+                self::identicalTo(123)
+            )
+            ->willReturn(null);
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(<<<ERROR
+        Could not find 'Setting' with identifier 'array (
+          'group' => 'group_a1',
+          'identifier' => 'identifier_b2',
+        )'
+        ERROR);
+
+        $handler->create(
+            'group_a1',
+            'identifier_b2',
+            'value_c3',
         );
     }
 
     /**
      * @throws \Ibexa\Core\Base\Exceptions\NotFoundException
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $handler = $this->getSettingHandler();
         $gatewayMock = $this->getGatewayMock();
 
-        $gatewayMock->expects($this->once())
+        $gatewayMock->expects(self::once())
             ->method('updateSetting')
             ->with(
-                $this->equalTo('group_d1'),
-                $this->equalTo('identifier_e2'),
-                $this->equalTo('value_f3')
+                self::identicalTo('group_d1'),
+                self::identicalTo('identifier_e2'),
+                self::identicalTo('value_f3')
             );
 
-        $gatewayMock->expects($this->once())
+        $gatewayMock->expects(self::once())
             ->method('loadSetting')
             ->with(
-                $this->equalTo('group_d1'),
-                $this->equalTo('identifier_e2')
+                self::identicalTo('group_d1'),
+                self::identicalTo('identifier_e2')
             )
             ->will($this->returnValue([
                 'group' => 'group_d1',
@@ -105,33 +141,67 @@ class SettingHandlerTest extends TestCase
             'value_f3'
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             $settingRef,
             $result
+        );
+    }
+
+    public function testUpdateFailsToLoad(): void
+    {
+        $handler = $this->getSettingHandler();
+        $gatewayMock = $this->getGatewayMock();
+
+        $gatewayMock->expects(self::once())
+            ->method('updateSetting')
+            ->with(
+                self::identicalTo('group_d1'),
+                self::identicalTo('identifier_e2'),
+                self::identicalTo('value_f3')
+            );
+
+        $gatewayMock->expects(self::once())
+            ->method('loadSetting')
+            ->with(
+                self::identicalTo('group_d1'),
+                self::identicalTo('identifier_e2')
+            )
+            ->will($this->returnValue(null));
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(<<<ERROR
+        Could not find 'Setting' with identifier 'array (
+          'group' => 'group_d1',
+          'identifier' => 'identifier_e2',
+        )'
+        ERROR);
+
+        $handler->update(
+            'group_d1',
+            'identifier_e2',
+            'value_f3'
         );
     }
 
     /**
      * @throws \Ibexa\Core\Base\Exceptions\NotFoundException
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $handler = $this->getSettingHandler();
 
         $gatewayMock = $this->getGatewayMock();
 
-        $gatewayMock->expects($this->once())
+        $gatewayMock->expects(self::once())
             ->method('loadSetting')
             ->with(
-                $this->equalTo('group_a1'),
-                $this->equalTo('identifier_b2')
-            )->will(
-                $this->returnValue([
-                    'group' => 'group_a1',
-                    'identifier' => 'identifier_b2',
-                    'value' => 'value_c3',
-                ])
-            );
+                self::identicalTo('group_a1'),
+                self::identicalTo('identifier_b2')
+            )->willReturn([
+                'group' => 'group_a1',
+                'identifier' => 'identifier_b2',
+                'value' => 'value_c3',
+            ]);
 
         $settingRef = new Setting([
             'group' => 'group_a1',
@@ -144,22 +214,52 @@ class SettingHandlerTest extends TestCase
             'identifier_b2'
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             $settingRef,
             $result
         );
     }
 
-    public function testDelete()
+    /**
+     * @throws \Ibexa\Core\Base\Exceptions\NotFoundException
+     */
+    public function testLoadFailsToLoad(): void
+    {
+        $handler = $this->getSettingHandler();
+
+        $gatewayMock = $this->getGatewayMock();
+
+        $gatewayMock->expects(self::once())
+            ->method('loadSetting')
+            ->with(
+                self::identicalTo('group_a1'),
+                self::identicalTo('identifier_b2')
+            )->willReturn(null);
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(<<<ERROR
+        Could not find 'Setting' with identifier 'array (
+          'group' => 'group_a1',
+          'identifier' => 'identifier_b2',
+        )'
+        ERROR);
+
+        $handler->load(
+            'group_a1',
+            'identifier_b2'
+        );
+    }
+
+    public function testDelete(): void
     {
         $handler = $this->getSettingHandler();
         $gatewayMock = $this->getGatewayMock();
 
-        $gatewayMock->expects($this->once())
+        $gatewayMock->expects(self::once())
             ->method('deleteSetting')
             ->with(
-                $this->equalTo('group_a1'),
-                $this->equalTo('identifier_b2')
+                self::identicalTo('group_a1'),
+                self::identicalTo('identifier_b2')
             );
 
         $handler->delete(
@@ -185,7 +285,7 @@ class SettingHandlerTest extends TestCase
     protected function getGatewayMock(): MockObject
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this->getMockForAbstractClass(Gateway::class);
+            $this->gatewayMock = $this->createMock(Gateway::class);
         }
 
         return $this->gatewayMock;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.2`
| **BC breaks**                          | no (it failed in those situations already, just a `TypeError`)

This PR improves the exception message that might happen when a setting is updated and subsequently fails to load.

I'm still trying to pinpoint the exact issue, but this provide me with additional information when it happens.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
