### PR TITLE
IBX-3877: Added logger to cache identifier generation

### DIFF
--- a/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
+++ b/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
@@ -9,13 +9,18 @@ declare(strict_types=1);
 namespace Ibexa\Core\Persistence\Cache\Identifier;
 
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 /**
  * @internal
  */
-final class CacheIdentifierGenerator implements CacheIdentifierGeneratorInterface
+final class CacheIdentifierGenerator implements CacheIdentifierGeneratorInterface, LoggerAwareInterface
 {
     private const PLACEHOLDER = '-%s';
+
+    use LoggerAwareTrait;
 
     /** @var string */
     private $prefix;
@@ -31,6 +36,7 @@ final class CacheIdentifierGenerator implements CacheIdentifierGeneratorInterfac
         $this->prefix = $prefix;
         $this->tagPatterns = $tagPatterns;
         $this->keyPatterns = $keyPatterns;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -76,6 +82,12 @@ final class CacheIdentifierGenerator implements CacheIdentifierGeneratorInterfac
         if ($withPrefix) {
             $cacheIdentifier = $this->prefix . $cacheIdentifier;
         }
+
+        $this->logger->debug(sprintf('Generated cache identifier: %s', $cacheIdentifier), [
+            'values' => $values,
+            'pattern' => $pattern,
+            'prefix' => $withPrefix ? $this->prefix : null,
+        ]);
 
         return $cacheIdentifier;
     }

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -248,6 +248,8 @@ services:
             $prefix: '%ibexa.core.persistence.cache.tag_prefix%'
             $tagPatterns: '%ibexa.core.persistence.cache.tag_patterns%'
             $keyPatterns: '%ibexa.core.persistence.cache.key_patterns%'
+        tags:
+            - { name: monolog.logger, channel: 'ibexa.cache' }
 
     # SPI Persistence Cache Handlers, incl abstracts
     Ibexa\Core\Persistence\Cache\AbstractHandler:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3877](https://issues.ibexa.co/browse/IBX-3877)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.2`
| **BC breaks**                          | no

Adds logger capability to cache identifier generator, so that cache keys can be investigated.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
