### PR TITLE
IBX-3877: Fixed logger not being injected in CacheIdentifierGenerator

### DIFF
--- a/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
+++ b/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
@@ -11,6 +11,7 @@ namespace Ibexa\Core\Persistence\Cache\Identifier;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -31,12 +32,12 @@ final class CacheIdentifierGenerator implements CacheIdentifierGeneratorInterfac
     /** @var array<string,string> */
     private $keyPatterns;
 
-    public function __construct(string $prefix, array $tagPatterns, array $keyPatterns)
+    public function __construct(string $prefix, array $tagPatterns, array $keyPatterns, ?LoggerInterface $logger)
     {
         $this->prefix = $prefix;
         $this->tagPatterns = $tagPatterns;
         $this->keyPatterns = $keyPatterns;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**

--- a/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
+++ b/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
@@ -32,7 +32,7 @@ final class CacheIdentifierGenerator implements CacheIdentifierGeneratorInterfac
     /** @var array<string,string> */
     private $keyPatterns;
 
-    public function __construct(string $prefix, array $tagPatterns, array $keyPatterns, ?LoggerInterface $logger)
+    public function __construct(string $prefix, array $tagPatterns, array $keyPatterns, ?LoggerInterface $logger = null)
     {
         $this->prefix = $prefix;
         $this->tagPatterns = $tagPatterns;

--- a/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
+++ b/src/lib/Persistence/Cache/Identifier/CacheIdentifierGenerator.php
@@ -11,7 +11,6 @@ namespace Ibexa\Core\Persistence\Cache\Identifier;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -32,12 +31,12 @@ final class CacheIdentifierGenerator implements CacheIdentifierGeneratorInterfac
     /** @var array<string,string> */
     private $keyPatterns;
 
-    public function __construct(string $prefix, array $tagPatterns, array $keyPatterns, ?LoggerInterface $logger = null)
+    public function __construct(string $prefix, array $tagPatterns, array $keyPatterns)
     {
         $this->prefix = $prefix;
         $this->tagPatterns = $tagPatterns;
         $this->keyPatterns = $keyPatterns;
-        $this->logger = $logger ?? new NullLogger();
+        $this->logger = new NullLogger();
     }
 
     /**

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -244,6 +244,7 @@ services:
     Ibexa\Core\Persistence\Cache\LocationPathConverter: ~
 
     Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGenerator:
+        autoconfigure: true
         arguments:
             $prefix: '%ibexa.core.persistence.cache.tag_prefix%'
             $tagPatterns: '%ibexa.core.persistence.cache.tag_patterns%'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3877](https://issues.ibexa.co/browse/IBX-3877)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Follow up for #149.

Apparently logger with correct channel is not injected (or actually, a logger is not injected at all) if there are no registered `Definition::setMethodCalls()` or an argument in constructor named `logger` in service definition.

See https://github.com/symfony/monolog-bundle/blob/4054b2e940a25195ae15f0a49ab0c51718922eb4/DependencyInjection/Compiler/LoggerChannelPass.php#L53-L66.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
