### PR TITLE
Fixed: missing ibexa_render_content

### DIFF
--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -48,7 +48,7 @@ final class RenderContentExtension extends AbstractExtension
                 ]
             ),
             new TwigFunction(
-                'ez_render_content',
+                'ibexa_render_content',
                 [$this, 'renderContent'],
                 ['is_safe' => ['html']]
             ),


### PR DESCRIPTION
Typo made in e766878c07435ee29997e9d4e704fd8235c9cce6

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
