### PR TITLE
IBX-3877: Made SettingHandler cache transaction-aware

### DIFF
--- a/src/lib/Persistence/Cache/SettingHandler.php
+++ b/src/lib/Persistence/Cache/SettingHandler.php
@@ -9,7 +9,7 @@ namespace Ibexa\Core\Persistence\Cache;
 use Ibexa\Contracts\Core\Persistence\Setting\Handler as SettingHandlerInterface;
 use Ibexa\Contracts\Core\Persistence\Setting\Setting;
 
-final class SettingHandler extends AbstractHandler implements SettingHandlerInterface
+final class SettingHandler extends AbstractInMemoryPersistenceHandler implements SettingHandlerInterface
 {
     private const SETTING_IDENTIFIER = 'setting';
 

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -349,7 +349,7 @@ services:
         parent: Ibexa\Core\Persistence\Cache\AbstractHandler
 
     Ibexa\Core\Persistence\Cache\SettingHandler:
-        parent: Ibexa\Core\Persistence\Cache\AbstractHandler
+        parent: Ibexa\Core\Persistence\Cache\AbstractInMemoryPersistenceHandler
 
     Ibexa\Core\Persistence\Cache\Handler:
         class: Ibexa\Core\Persistence\Cache\Handler

--- a/tests/lib/Persistence/Cache/AbstractBaseHandlerTest.php
+++ b/tests/lib/Persistence/Cache/AbstractBaseHandlerTest.php
@@ -102,7 +102,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
             new CacheNotificationHandler(...$cacheAbstractHandlerArguments),
             new CacheUserPreferenceHandler(...$cacheInMemoryHandlerArguments),
             new CacheUrlWildcardHandler(...$cacheAbstractHandlerArguments),
-            new CacheSettingHandler(...$cacheAbstractHandlerArguments),
+            new CacheSettingHandler(...$cacheInMemoryHandlerArguments),
             $this->loggerMock
         );
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3877](https://issues.ibexa.co/browse/IBX-3877)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

When performing `ibexa:install`, if at any point a command is issued that performs operations on settings, it is possible to insert entry to shared cache, which is then not removed when the command fails (and database transaction is rolled back).

This PR tries to remedy this by changing the implementation of cache to in memory, transaction aware one (as is the case for multitude of other handlers).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
