### PR TITLE
IBX-1543: Fixed ibexa_render_content name

### DIFF
--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -48,7 +48,7 @@ final class RenderContentExtension extends AbstractExtension
                 ]
             ),
             new TwigFunction(
-                'ez_render_content',
+                'ibexa_render_content',
                 [$this, 'renderContent'],
                 ['is_safe' => ['html']]
             ),


### PR DESCRIPTION
Typo made in e766878c07435ee29997e9d4e704fd8235c9cce6

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1543](https://issues.ibexa.co/browse/IBX-1543)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.2`
| **BC breaks**                          | no

Cherry-picked and rebased from https://github.com/ibexa/core/pull/151 as it seems it was left behind for some time.
#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
