### PR TITLE
IBX-1294: Fixed deprecated RequestStack::getMasterRequest usages

### DIFF
--- a/src/bundle/Core/Routing/JsRouting/ExposedRoutesExtractor.php
+++ b/src/bundle/Core/Routing/JsRouting/ExposedRoutesExtractor.php
@@ -47,7 +47,7 @@ class ExposedRoutesExtractor implements ExposedRoutesExtractorInterface
     public function getBaseUrl(): string
     {
         $baseUrl = $this->innerExtractor->getBaseUrl();
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
         if ($request === null) {
             return $baseUrl;
         }

--- a/tests/bundle/Core/Routing/JsRouting/ExposedRoutesExtractorTest.php
+++ b/tests/bundle/Core/Routing/JsRouting/ExposedRoutesExtractorTest.php
@@ -67,7 +67,7 @@ final class ExposedRoutesExtractorTest extends TestCase
         $requestStack = $this->createMock(RequestStack::class);
 
         $innerExtractor->method('getBaseUrl')->willReturn(self::BASE_URL);
-        $requestStack->method('getMasterRequest')->willReturn($masterRequest);
+        $requestStack->method('getMainRequest')->willReturn($masterRequest);
 
         $extractor = new ExposedRoutesExtractor($innerExtractor, $requestStack);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1294](https://issues.ibexa.co/browse/IBX-1294)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

`\Symfony\Component\HttpFoundation\RequestStack::getMasterRequest` method is deprecated  since SF 5.3 and should be replaced by getMainRequest

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
