### PR TITLE
IBX-4046: Allow custom header name to be used in reverse proxy env

### DIFF
--- a/src/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriber.php
+++ b/src/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriber.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class TrustedHeaderClientIpEventSubscriber implements EventSubscriberInterface
 {
-    public const PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP = 'X-Client-IP';
+    private const PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP = 'X-Client-IP';
 
     private ?string $trustedHeaderName;
 

--- a/src/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriber.php
+++ b/src/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Core\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class TrustedHeaderClientIpEventSubscriber implements EventSubscriberInterface
+{
+    public const PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP = 'X-Client-IP';
+
+    private ?string $trustedHeaderName;
+
+    public function __construct(
+        ?string $trustedHeaderName
+    ) {
+        $this->trustedHeaderName = $trustedHeaderName;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', PHP_INT_MAX],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        $trustedProxies = Request::getTrustedProxies();
+        $trustedHeaderSet = Request::getTrustedHeaderSet();
+
+        $trustedHeaderName = $this->trustedHeaderName;
+        if (null === $trustedHeaderName && $this->isPlatformShProxy($request)) {
+            $trustedHeaderName = self::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP;
+        }
+
+        if (null === $trustedHeaderName) {
+            return;
+        }
+
+        $trustedClientIp = $request->headers->get($trustedHeaderName);
+
+        if (null !== $trustedClientIp) {
+            if ($trustedHeaderSet !== -1) {
+                $trustedHeaderSet |= Request::HEADER_X_FORWARDED_FOR;
+            }
+            $request->headers->set('X_FORWARDED_FOR', $trustedClientIp);
+        }
+
+        Request::setTrustedProxies($trustedProxies, $trustedHeaderSet);
+    }
+
+    private function isPlatformShProxy(Request $request): bool
+    {
+        return null !== $request->server->get('PLATFORM_RELATIONSHIPS');
+    }
+}

--- a/src/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriber.php
+++ b/src/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriber.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class TrustedHeaderClientIpEventSubscriber implements EventSubscriberInterface
+final class TrustedHeaderClientIpEventSubscriber implements EventSubscriberInterface
 {
     public const PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP = 'X-Client-IP';
 

--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -2,7 +2,7 @@ parameters:
     # Kernel related params
     webroot_dir: "%kernel.project_dir%/public"
 
-    trusted_header_client_ip_name: ~
+    ibexa.trusted_header_client_ip_name: ~
 
     ###
     # ibexa.site_access.config namespace, default scope

--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -2,6 +2,8 @@ parameters:
     # Kernel related params
     webroot_dir: "%kernel.project_dir%/public"
 
+    trusted_header_client_ip_name: ~
+
     ###
     # ibexa.site_access.config namespace, default scope
     ###

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -296,7 +296,7 @@ services:
 
     Ibexa\Bundle\Core\EventSubscriber\TrustedHeaderClientIpEventSubscriber:
         arguments:
-            $trustedHeaderName: '%trusted_header_client_ip_name%'
+            $trustedHeaderName: '%ibexa.trusted_header_client_ip_name%'
         tags:
             - {name: kernel.event_subscriber}
 

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -294,6 +294,12 @@ services:
         tags:
             - {name: kernel.event_subscriber}
 
+    Ibexa\Bundle\Core\EventSubscriber\TrustedHeaderClientIpEventSubscriber:
+        arguments:
+            $trustedHeaderName: '%trusted_header_client_ip_name%'
+        tags:
+            - {name: kernel.event_subscriber}
+
     Ibexa\Bundle\Core\Command\DeleteContentTranslationCommand:
         class: Ibexa\Bundle\Core\Command\DeleteContentTranslationCommand
         arguments:

--- a/tests/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriberTest.php
+++ b/tests/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriberTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 final class TrustedHeaderClientIpEventSubscriberTest extends TestCase
 {
+    private const PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP = 'X-Client-IP';
+
     private ?string $originalRemoteAddr;
 
     private const PROXY_IP = '127.100.100.1';
@@ -80,7 +82,7 @@ final class TrustedHeaderClientIpEventSubscriberTest extends TestCase
                 self::PROXY_IP,
                 self::PROXY_IP,
                 'X-Custom-Header',
-                [TrustedHeaderClientIpEventSubscriber::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP],
+                [self::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP],
                 ['PLATFORM_RELATIONSHIPS' => true],
             ],
             'use custom header with valid value on platform.sh' => [
@@ -88,7 +90,7 @@ final class TrustedHeaderClientIpEventSubscriberTest extends TestCase
                 self::PROXY_IP,
                 'X-Custom-Header',
                 [
-                    TrustedHeaderClientIpEventSubscriber::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP,
+                    self::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP,
                     'X-Custom-Header' => self::CUSTOM_CLIENT_IP,
                 ],
                 ['PLATFORM_RELATIONSHIPS' => true],
@@ -98,7 +100,7 @@ final class TrustedHeaderClientIpEventSubscriberTest extends TestCase
                 self::PROXY_IP,
                 null,
                 [
-                    TrustedHeaderClientIpEventSubscriber::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP,
+                    self::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP,
                     'X-Custom-Header' => self::CUSTOM_CLIENT_IP,
                 ],
                 ['PLATFORM_RELATIONSHIPS' => true],

--- a/tests/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriberTest.php
+++ b/tests/bundle/Core/EventSubscriber/TrustedHeaderClientIpEventSubscriberTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Core\EventSubscriber;
+
+use Ibexa\Bundle\Core\EventSubscriber\TrustedHeaderClientIpEventSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class TrustedHeaderClientIpEventSubscriberTest extends TestCase
+{
+    private ?string $originalRemoteAddr;
+
+    private const PROXY_IP = '127.100.100.1';
+
+    private const REAL_CLIENT_IP = '98.76.123.234';
+
+    private const CUSTOM_CLIENT_IP = '234.123.78.98';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->originalRemoteAddr = $_SERVER['REMOTE_ADDR'] ?? null;
+    }
+
+    protected function setUp(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = null;
+        Request::setTrustedProxies([], -1);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = $this->originalRemoteAddr;
+    }
+
+    public function getTrustedHeaderEventSubscriberTestData(): array
+    {
+        return [
+            'default behaviour' => [
+                self::REAL_CLIENT_IP,
+                self::REAL_CLIENT_IP,
+            ],
+            'use custom header name with valid value' => [
+                self::REAL_CLIENT_IP,
+                self::PROXY_IP,
+                'X-Custom-Header',
+                ['X-Custom-Header' => self::REAL_CLIENT_IP],
+            ],
+            'use custom header name without valid value' => [
+                self::PROXY_IP,
+                self::PROXY_IP,
+                'X-Custom-Header',
+            ],
+            'use custom header value without custom header name' => [
+                self::PROXY_IP,
+                self::PROXY_IP,
+                null,
+                ['X-Custom-Header' => self::REAL_CLIENT_IP],
+            ],
+            'default platform.sh behaviour' => [
+                self::REAL_CLIENT_IP,
+                self::PROXY_IP,
+                null,
+                ['X-Client-IP' => self::REAL_CLIENT_IP],
+                ['PLATFORM_RELATIONSHIPS' => true],
+            ],
+            'use custom header name without valid value on platform.sh' => [
+                self::PROXY_IP,
+                self::PROXY_IP,
+                'X-Custom-Header',
+                [TrustedHeaderClientIpEventSubscriber::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP],
+                ['PLATFORM_RELATIONSHIPS' => true],
+            ],
+            'use custom header with valid value on platform.sh' => [
+                self::CUSTOM_CLIENT_IP,
+                self::PROXY_IP,
+                'X-Custom-Header',
+                [
+                    TrustedHeaderClientIpEventSubscriber::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP,
+                    'X-Custom-Header' => self::CUSTOM_CLIENT_IP,
+                ],
+                ['PLATFORM_RELATIONSHIPS' => true],
+            ],
+            'use valid value without custom header name on platform.sh' => [
+                self::REAL_CLIENT_IP,
+                self::PROXY_IP,
+                null,
+                [
+                    TrustedHeaderClientIpEventSubscriber::PLATFORM_SH_TRUSTED_HEADER_CLIENT_IP => self::REAL_CLIENT_IP,
+                    'X-Custom-Header' => self::CUSTOM_CLIENT_IP,
+                ],
+                ['PLATFORM_RELATIONSHIPS' => true],
+            ],
+        ];
+    }
+
+    public function testTrustedHeaderEventSubscriberWithoutTrustedProxy(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = self::PROXY_IP;
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(
+            new TrustedHeaderClientIpEventSubscriber('X-Custom-Header')
+        );
+
+        $request = Request::create('/', 'GET', [], [], [], array_merge(
+            $_SERVER,
+            ['PLATFORM_RELATIONSHIPS' => true],
+        ));
+        $request->headers->add([
+            'X-Custom-Header' => self::REAL_CLIENT_IP,
+        ]);
+
+        $event = $eventDispatcher->dispatch(new RequestEvent(
+            self::createMock(KernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        ), KernelEvents::REQUEST);
+
+        /** @var \Symfony\Component\HttpFoundation\Request $request */
+        $request = $event->getRequest();
+
+        self::assertEquals(self::PROXY_IP, $request->getClientIp());
+    }
+
+    /**
+     * @dataProvider getTrustedHeaderEventSubscriberTestData
+     */
+    public function testTrustedHeaderEventSubscriberWithTrustedProxy(
+        string $expectedIp,
+        string $remoteAddrIp,
+        ?string $trustedHeaderName = null,
+        array $headers = [],
+        array $server = []
+    ): void {
+        $_SERVER['REMOTE_ADDR'] = $remoteAddrIp;
+        Request::setTrustedProxies(['REMOTE_ADDR'], Request::getTrustedHeaderSet());
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(
+            new TrustedHeaderClientIpEventSubscriber($trustedHeaderName)
+        );
+
+        $request = Request::create('/', 'GET', [], [], [], array_merge(
+            $server,
+            ['REMOTE_ADDR' => $remoteAddrIp],
+        ));
+        $request->headers->add($headers);
+
+        $event = $eventDispatcher->dispatch(new RequestEvent(
+            self::createMock(KernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        ), KernelEvents::REQUEST);
+
+        /** @var \Symfony\Component\HttpFoundation\Request $request */
+        $request = $event->getRequest();
+
+        self::assertEquals($expectedIp, $request->getClientIp());
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4046](https://issues.ibexa.co/browse/IBX-4046)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.3`
| **BC breaks**                          | yes

`trusted_header_client_ip_name` parameter to be used as a mapping between custom header and X_FORWARDED_FOR header. It requires dev to configure `trusted_proxies` with a proper proxy server IP to be allowed to use trusted headers in a first place (remainder in recipes: https://github.com/ibexa/recipes-dev/pull/27/commits/404a8998bd5b6159f0ca24b28d848b795515bb2a ).

It also covers Platform.sh `X-Client-Ip` header in a transparent way (dev still needs `trusted_proxies` to be set). Custom header still has priority over Platform.sh header (in case when custom header is used within P.sh env). 
 
#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
