### PR TITLE
Limited test of SensitiveParameter

### DIFF
--- a/src/lib/Repository/User/PasswordHashService.php
+++ b/src/lib/Repository/User/PasswordHashService.php
@@ -42,7 +42,10 @@ final class PasswordHashService implements PasswordHashServiceInterface
     /**
      * @throws \Ibexa\Core\Repository\User\Exception\UnsupportedPasswordHashType
      */
-    public function createPasswordHash(string $password, ?int $hashType = null): string
+    public function createPasswordHash(
+        #[\SensitiveParameter]
+        string $password,
+        ?int $hashType = null): string
     {
         $hashType = $hashType ?? $this->defaultHashType;
 
@@ -58,10 +61,15 @@ final class PasswordHashService implements PasswordHashServiceInterface
         }
     }
 
-    public function isValidPassword(string $plainPassword, string $passwordHash, ?int $hashType = null): bool
+    public function isValidPassword(
+        #[\SensitiveParameter]
+        string $plainPassword,
+        #[\SensitiveParameter]
+        string $passwordHash,
+        ?int $hashType = null): bool
     {
         if ($hashType === User::PASSWORD_HASH_BCRYPT || $hashType === User::PASSWORD_HASH_PHP_DEFAULT) {
-            // In case of bcrypt let php's password functionality do it's magic
+            // In case of bcrypt let PHP's password functionality do its magic
             return password_verify($plainPassword, $passwordHash);
         }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4414](https://issues.ibexa.co/browse/IBX-4414)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

Use the [SensitiveParameter attribute](https://www.php.net/manual/en/class.sensitive-parameter.php) to hide passwords and similarly sensitive arguments in stack traces (if stack trace arguments are enabled). This requires PHP 8.2 to work, but will afaict not break anything in older PHP as it will be interpreted as code comments.

**Work in progress**
Early test in just a single file. There are plenty of other places where we can apply the same.

#### Checklist:
- [x] Provided PR description.
- [x] ~Tested the solution manually.~ PHP 8.2 isn't released yet.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
