### PR TITLE
[Tests] Rebranded temporary directory prefix used by Core IO tests

### DIFF
--- a/src/contracts/Test/Repository/SetupFactory/Legacy.php
+++ b/src/contracts/Test/Repository/SetupFactory/Legacy.php
@@ -112,16 +112,15 @@ class Legacy extends SetupFactory
     }
 
     /**
-     * Creates a temporary directory and returns it.
+     * Creates a temporary directory and returns its path name.
      *
-     * @return string
      * @throw \RuntimeException If the root directory can't be created
      */
-    private function createTemporaryDirectory()
+    private function createTemporaryDirectory(): string
     {
         $tmpFile = tempnam(
             sys_get_temp_dir(),
-            'ez_legacy_tests_' . time()
+            'ibexa_core_io_tests_' . time()
         );
         unlink($tmpFile);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Discovered while working on [IBX-1439](https://issues.ibexa.co/browse/IBX-1439)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.3`+
| **BC breaks**                          | no BC promise for tests

Fixed outstanding directory naming of a temporary directory create by Legacy Setup Factory for Core IO tests.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage~ // already there.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.
