### PR TITLE
IBX-4598: Added support for generating urls for content wrappers in ibexa_url/ibexa_path

### DIFF
--- a/src/contracts/Repository/Values/Content/ContentAware.php
+++ b/src/contracts/Repository/Values/Content/ContentAware.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content;
+
+interface ContentAware
+{
+    public function getContent(): Content;
+}

--- a/src/contracts/Repository/Values/Content/ContentAwareInterface.php
+++ b/src/contracts/Repository/Values/Content/ContentAwareInterface.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content;
 
-interface ContentAware
+interface ContentAwareInterface
 {
     public function getContent(): Content;
 }

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
-use Ibexa\Contracts\Core\Repository\Values\Content\ContentAware;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGeneratorInterface;
@@ -126,7 +126,7 @@ class RoutingExtension extends AbstractExtension
             $parameters += [
                 'contentId' => $object->id,
             ];
-        } elseif ($object instanceof ContentAware) {
+        } elseif ($object instanceof ContentAwareInterface) {
             $routeName = UrlAliasRouter::URL_ALIAS_ROUTE_NAME;
             $parameters += [
                 'contentId' => $object->getContent()->id,

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
@@ -129,7 +129,7 @@ class RoutingExtension extends AbstractExtension
         } elseif ($object instanceof ContentAwareInterface) {
             $routeName = UrlAliasRouter::URL_ALIAS_ROUTE_NAME;
             $parameters += [
-                'contentId' => $object->getContent()->id,
+                'contentId' => $object->getContent()->getVersionInfo()->getContentInfo()->id,
             ];
         } elseif ($object instanceof RouteReference) {
             $routeName = $object->getRoute();

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAware;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGeneratorInterface;
@@ -124,6 +125,11 @@ class RoutingExtension extends AbstractExtension
             $routeName = UrlAliasRouter::URL_ALIAS_ROUTE_NAME;
             $parameters += [
                 'contentId' => $object->id,
+            ];
+        } elseif ($object instanceof ContentAware) {
+            $routeName = UrlAliasRouter::URL_ALIAS_ROUTE_NAME;
+            $parameters += [
+                'contentId' => $object->getContent()->id,
             ];
         } elseif ($object instanceof RouteReference) {
             $routeName = $object->getRoute();

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
-use Ibexa\Contracts\Core\Repository\Values\Content\ContentAware;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
 use Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
@@ -52,9 +52,9 @@ final class RoutingExtensionTest extends IntegrationTestCase
         ]);
     }
 
-    protected function getExampleContentAware(int $id): ContentAware
+    protected function getExampleContentAware(int $id): ContentAwareInterface
     {
-        $contentAware = $this->createMock(ContentAware::class);
+        $contentAware = $this->createMock(ContentAwareInterface::class);
         $contentAware->method('getContent')->willReturn($this->getExampleContent($id));
 
         return $contentAware;

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAware;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
 use Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
@@ -49,6 +50,14 @@ final class RoutingExtensionTest extends IntegrationTestCase
                 'contentInfo' => $this->getExampleContentInfo($id),
             ]),
         ]);
+    }
+
+    protected function getExampleContentAware(int $id): ContentAware
+    {
+        $contentAware = $this->createMock(ContentAware::class);
+        $contentAware->method('getContent')->willReturn($this->getExampleContent($id));
+
+        return $contentAware;
     }
 
     protected function getExampleContentInfo(int $id): ContentInfo

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_path.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_path.test
@@ -16,6 +16,9 @@ Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instea
 Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 14.
 Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 15.
 Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 16.
+Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 17.
+Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 18.
+Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 19.
 --TEMPLATE--
 {{ ez_path(location) }}
 {{ ez_path(location, {}, true) }}
@@ -26,6 +29,9 @@ Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instea
 {{ ez_path(content_info) }}
 {{ ez_path(content_info, {}, true) }}
 {{ ez_path(content_info, {'foo': 'foo'}) }}
+{{ ez_path(content_aware) }}
+{{ ez_path(content_aware, {}, true) }}
+{{ ez_path(content_aware, {'foo': 'foo'}) }}
 {{ ez_path(route_ref) }}
 {{ ez_path(route_ref, {}, true) }}
 {{ ez_path(route_ref, {'baz': 'baz'}) }}
@@ -37,6 +43,7 @@ return [
     'location' => $this->getExampleLocation(54),
     'content' => $this->getExampleContent(2),
     'content_info' => $this->getExampleContentInfo(2),
+    'content_aware' => $this->getExampleContentAware(64),
     'route_ref' => $this->getExampleRouteReference(
         'example_route',
         [
@@ -56,6 +63,9 @@ return [
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":1}
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":2}
 {"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":2},"$referenceType":1}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":1}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":2}
+{"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":64},"$referenceType":1}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":1}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":2}
 {"$name":"example_route","$parameters":{"baz":"baz","foo":"foo","bar":"bar"},"$referenceType":1}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_url.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_url.test
@@ -13,9 +13,12 @@ Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead 
 Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 11.
 Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 12.
 Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 13.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 14.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 15.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 16.
+Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 14.
+Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 15.
+Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 16.
+Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 17.
+Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 18.
+Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 19.
 --TEMPLATE--
 {{ ez_url(location) }}
 {{ ez_url(location, {}, true) }}
@@ -26,17 +29,21 @@ Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instea
 {{ ez_url(content_info) }}
 {{ ez_url(content_info, {}, true) }}
 {{ ez_url(content_info, {'foo': 'foo'}) }}
+{{ ez_url(content_aware) }}
+{{ ez_url(content_aware, {}, true) }}
+{{ ez_url(content_aware, {'foo': 'foo'}) }}
 {{ ez_url(route_ref) }}
 {{ ez_url(route_ref, {}, true) }}
 {{ ez_url(route_ref, {'baz': 'baz'}) }}
-{{ ez_path(unsupported_object) }}
-{{ ez_path(unsupported_object, {}, true) }}
-{{ ez_path(unsupported_object, {'baz': 'baz'}) }}
+{{ ez_url(unsupported_object) }}
+{{ ez_url(unsupported_object, {}, true) }}
+{{ ez_url(unsupported_object, {'baz': 'baz'}) }}
 --DATA--
 return [
     'location' => $this->getExampleLocation(54),
     'content' => $this->getExampleContent(2),
     'content_info' => $this->getExampleContentInfo(2),
+    'content_aware' => $this->getExampleContentAware(64),
     'route_ref' => $this->getExampleRouteReference(
         'example_route',
         [
@@ -56,9 +63,12 @@ return [
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":0}
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":3}
 {"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":2},"$referenceType":0}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":0}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":3}
+{"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":64},"$referenceType":0}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":0}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":3}
 {"$name":"example_route","$parameters":{"baz":"baz","foo":"foo","bar":"bar"},"$referenceType":0}
-{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":1}
-{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":2}
-{"$name":"","$parameters":{"baz":"baz","_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":1}
+{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":0}
+{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":3}
+{"$name":"","$parameters":{"baz":"baz","_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":0}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ibexa_path.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ibexa_path.test
@@ -10,6 +10,9 @@
 {{ ibexa_path(content_info) }}
 {{ ibexa_path(content_info, {}, true) }}
 {{ ibexa_path(content_info, {'foo': 'foo'}) }}
+{{ ibexa_path(content_aware) }}
+{{ ibexa_path(content_aware, {}, true) }}
+{{ ibexa_path(content_aware, {'foo': 'foo'}) }}
 {{ ibexa_path(route_ref) }}
 {{ ibexa_path(route_ref, {}, true) }}
 {{ ibexa_path(route_ref, {'baz': 'baz'}) }}
@@ -21,6 +24,7 @@ return [
     'location' => $this->getExampleLocation(54),
     'content' => $this->getExampleContent(2),
     'content_info' => $this->getExampleContentInfo(2),
+    'content_aware' => $this->getExampleContentAware(64),
     'route_ref' => $this->getExampleRouteReference(
         'example_route',
         [
@@ -40,6 +44,9 @@ return [
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":1}
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":2}
 {"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":2},"$referenceType":1}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":1}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":2}
+{"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":64},"$referenceType":1}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":1}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":2}
 {"$name":"example_route","$parameters":{"baz":"baz","foo":"foo","bar":"bar"},"$referenceType":1}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ibexa_url.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ibexa_url.test
@@ -10,17 +10,21 @@
 {{ ibexa_url(content_info) }}
 {{ ibexa_url(content_info, {}, true) }}
 {{ ibexa_url(content_info, {'foo': 'foo'}) }}
+{{ ibexa_url(content_aware) }}
+{{ ibexa_url(content_aware, {}, true) }}
+{{ ibexa_url(content_aware, {'foo': 'foo'}) }}
 {{ ibexa_url(route_ref) }}
 {{ ibexa_url(route_ref, {}, true) }}
 {{ ibexa_url(route_ref, {'baz': 'baz'}) }}
-{{ ibexa_path(unsupported_object) }}
-{{ ibexa_path(unsupported_object, {}, true) }}
-{{ ibexa_path(unsupported_object, {'baz': 'baz'}) }}
+{{ ibexa_url(unsupported_object) }}
+{{ ibexa_url(unsupported_object, {}, true) }}
+{{ ibexa_url(unsupported_object, {'baz': 'baz'}) }}
 --DATA--
 return [
     'location' => $this->getExampleLocation(54),
     'content' => $this->getExampleContent(2),
     'content_info' => $this->getExampleContentInfo(2),
+    'content_aware' => $this->getExampleContentAware(64),
     'route_ref' => $this->getExampleRouteReference(
         'example_route',
         [
@@ -40,9 +44,12 @@ return [
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":0}
 {"$name":"ibexa.url.alias","$parameters":{"contentId":2},"$referenceType":3}
 {"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":2},"$referenceType":0}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":0}
+{"$name":"ibexa.url.alias","$parameters":{"contentId":64},"$referenceType":3}
+{"$name":"ibexa.url.alias","$parameters":{"foo":"foo","contentId":64},"$referenceType":0}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":0}
 {"$name":"example_route","$parameters":{"foo":"foo","bar":"bar"},"$referenceType":3}
 {"$name":"example_route","$parameters":{"baz":"baz","foo":"foo","bar":"bar"},"$referenceType":0}
-{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":1}
-{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":2}
-{"$name":"","$parameters":{"baz":"baz","_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":1}
+{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":0}
+{"$name":"","$parameters":{"_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":3}
+{"$name":"","$parameters":{"baz":"baz","_route_object":{"foo":"foo","bar":"bar"}},"$referenceType":0}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4598](https://issues.ibexa.co/browse/IBX-4598)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Added support for generating urls for content wrappers (e.g. Taxonomy Entry, Product) in ibexa_url/ibexa_path.

```twig
{# content_wrapper implements \Ibexa\Contracts\Core\Repository\Values\Content\ContentAware #}
{{ ibexa_url(content_wrapper) }}
```

#### Checklist:
- [X] Provided PR description.
- [ ] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
