### PR TITLE
IBX-3740: Prepended default Core settings

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1786,11 +1786,6 @@ parameters:
 			path: src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\DependencyInjection\\\\IbexaCoreExtension\\:\\:handleDefaultSettingsLoading\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\DependencyInjection\\\\IbexaCoreExtension\\:\\:handleHelpers\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/Core/DependencyInjection/IbexaCoreExtension.php

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -831,12 +831,6 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
     {
         $projectDir = $container->getParameter('kernel.project_dir');
 
-        // Run for all hooks, incl build step
-        if ($_SERVER['PLATFORM_PROJECT_ENTROPY'] ?? false) {
-            // Disable PHPStormPass as we don't have write access & it's not localhost
-            $container->setParameter('ezdesign.phpstorm.enabled', false);
-        }
-
         // Will not be executed on build step
         $relationships = $_SERVER['PLATFORM_RELATIONSHIPS'] ?? false;
         if (!$relationships) {

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -127,9 +127,6 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
             $loader->load('routing/js_routing.yml');
         }
 
-        // Default settings
-        $this->handleDefaultSettingsLoading($container, $loader);
-
         $this->registerRepositoriesConfiguration($config, $container);
         $this->registerSiteAccessConfiguration($config, $container);
         $this->registerImageMagickConfiguration($config, $container);
@@ -198,6 +195,9 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
         $this->prependDoctrineConfiguration($container);
         $this->prependJMSTranslation($container);
 
+        // Default settings
+        $this->handleDefaultSettingsLoading($container);
+
         $this->configureGenericSetup($container);
         $this->configurePlatformShSetup($container);
     }
@@ -236,15 +236,14 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * Handle default settings.
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param \Symfony\Component\DependencyInjection\Loader\FileLoader $loader
-     *
      * @throws \Exception
      */
-    private function handleDefaultSettingsLoading(ContainerBuilder $container, FileLoader $loader)
+    private function handleDefaultSettingsLoading(ContainerBuilder $container): void
     {
+        $loader = new Loader\YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config')
+        );
         $loader->load('default_settings.yml');
 
         foreach ($this->defaultSettingsCollection as $fileLocation => $files) {

--- a/src/lib/Resources/settings/settings.yml
+++ b/src/lib/Resources/settings/settings.yml
@@ -1,5 +1,5 @@
 parameters:
-    ibexa.persistence.legacy.dsn: sqlite://:memory:
+    ibexa.persistence.legacy.dsn: 'sqlite://:memory:'
     anonymous_user_id: 10
     kernel.debug: false
     languages: []

--- a/tests/integration/Core/Resources/settings/override.yml
+++ b/tests/integration/Core/Resources/settings/override.yml
@@ -9,4 +9,6 @@ parameters:
         - ger-DE
 
     ibexa.spi.persistence.cache.inmemory.ttl: 0
+    ibexa.io.dir.storage: var/ibexa_demo_site/storage
+    ibexa.url_prefix: var/ibexa_demo_site/storage
     ibexa.legacy.url_prefix: var/ibexa_demo_site/storage


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3740](https://issues.ibexa.co/browse/IBX-3740)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`+
| **BC breaks**                          | no

This PR foremost moves loading default settings into `prepend` stage. My initial idea was to move everything into `load` stage, however processing merged project configuration for `ibexa` extension is occurs before `IbexaCoreExtension::load` stage, therefore some of settings created by `configureGenericSetup` need to be available before `load` as well (e.g. `purge_type` parameter value).

Some side issues were fixed as well:
- dropped setting parameter for dropped ezdesign PHPStorm integration (setting the parameter doesn't do anything).
- fixed fallback DFS configuration for consistency's sake, settings should be loaded from project config anyway
- removed redundant fallback storage path container parameter
- fixed malformed `ibexa.persistence.legacy.dsn` parameter value

### QA

All issues reported in [IBX-3740](https://issues.ibexa.co/browse/IBX-3740) should be resolved by this. We need to focus on DFS configuration as it affects Flysystem v2 upgrade.

Scope: It affects both standalone installation and Platform.sh.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually (local, not p.sh).
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review
