### PR TITLE
IBX-4391: Repurpose built-in variation as common variation abstraction

### DIFF
--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Image.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Image.php
@@ -114,7 +114,6 @@ class Image extends AbstractParser implements SuggestionCollectorAwareInterface
             ->end()
             ->scalarNode('variation_handler_identifier')
                 ->info('Variation handler to be used. Defaults to built-in alias variations.')
-                ->defaultValue('alias')
                 ->example('alias')
             ->end()
             ->scalarNode('image_host')

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Image.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Image.php
@@ -112,6 +112,11 @@ class Image extends AbstractParser implements SuggestionCollectorAwareInterface
                     ->end()
                 ->end()
             ->end()
+            ->scalarNode('variation_handler_identifier')
+                ->info('Variation handler to be used. Defaults to built-in alias variations.')
+                ->defaultValue('alias')
+                ->example('alias')
+            ->end()
             ->scalarNode('image_host')
                 ->info('Images host. All system images URLs are prefixed with given host if configured.')
                 ->example('https://ezplatform.com')
@@ -122,6 +127,7 @@ class Image extends AbstractParser implements SuggestionCollectorAwareInterface
     {
         $contextualizer->mapConfigArray('image_variations', $config);
         $contextualizer->mapSetting('image_host', $config);
+        $contextualizer->mapSetting('variation_handler_identifier', $config);
     }
 
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)

--- a/src/bundle/Core/Imagine/Filter/Loader/BorderFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/BorderFilterLoader.php
@@ -19,6 +19,8 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
  */
 class BorderFilterLoader implements LoaderInterface
 {
+    public const IDENTIFIER = 'border';
+
     public const DEFAULT_BORDER_COLOR = '#000';
 
     public function load(ImageInterface $image, array $options = [])

--- a/src/bundle/Core/Imagine/Filter/Loader/CropFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/CropFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class CropFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/crop';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (count($options) < 4) {

--- a/src/bundle/Core/Imagine/Filter/Loader/GrayscaleFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/GrayscaleFilterLoader.php
@@ -15,6 +15,8 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
  */
 class GrayscaleFilterLoader implements LoaderInterface
 {
+    public const IDENTIFIER = 'colorspace/gray';
+
     public function load(ImageInterface $image, array $options = [])
     {
         $image->effects()->grayscale();

--- a/src/bundle/Core/Imagine/Filter/Loader/ReduceNoiseFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ReduceNoiseFilterLoader.php
@@ -19,6 +19,8 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
  */
 class ReduceNoiseFilterLoader implements LoaderInterface
 {
+    public const IDENTIFIER = 'filter/noise';
+
     /** @var \Ibexa\Bundle\Core\Imagine\Filter\FilterInterface */
     private $filter;
 

--- a/src/bundle/Core/Imagine/Filter/Loader/ScaleDownOnlyFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScaleDownOnlyFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleDownOnlyFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scaledownonly';
+
     /**
      * Loads and applies a filter on the given image.
      *

--- a/src/bundle/Core/Imagine/Filter/Loader/ScaleExactFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScaleExactFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleExactFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scaleexact';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (count($options) < 2) {

--- a/src/bundle/Core/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scale';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (count($options) < 2) {

--- a/src/bundle/Core/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleHeightDownOnlyFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scaleheightdownonly';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (empty($options)) {

--- a/src/bundle/Core/Imagine/Filter/Loader/ScaleHeightFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScaleHeightFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleHeightFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scaleheight';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (empty($options)) {

--- a/src/bundle/Core/Imagine/Filter/Loader/ScalePercentFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScalePercentFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScalePercentFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scalepercent';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (count($options) < 2) {

--- a/src/bundle/Core/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleWidthDownOnlyFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scalewidthdownonly';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (empty($options)) {

--- a/src/bundle/Core/Imagine/Filter/Loader/ScaleWidthFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/ScaleWidthFilterLoader.php
@@ -15,6 +15,8 @@ use Imagine\Image\ImageInterface;
  */
 class ScaleWidthFilterLoader extends FilterLoaderWrapped
 {
+    public const IDENTIFIER = 'geometry/scalewidth';
+
     public function load(ImageInterface $image, array $options = [])
     {
         if (empty($options)) {

--- a/src/bundle/Core/Imagine/Filter/Loader/SwirlFilterLoader.php
+++ b/src/bundle/Core/Imagine/Filter/Loader/SwirlFilterLoader.php
@@ -12,6 +12,8 @@ use Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface;
 
 class SwirlFilterLoader implements LoaderInterface
 {
+    public const IDENTIFIER = 'filter/swirl';
+
     /** @var \Ibexa\Bundle\Core\Imagine\Filter\FilterInterface */
     private $filter;
 

--- a/src/bundle/Core/Imagine/IORepositoryResolver.php
+++ b/src/bundle/Core/Imagine/IORepositoryResolver.php
@@ -53,7 +53,7 @@ class IORepositoryResolver extends PathResolver implements ResolverInterface
         return $this->ioService->exists($this->getFilePath($path, $filter));
     }
 
-    public function resolve($path, $filter)
+    public function resolve($path, $filter): string
     {
         try {
             $binaryFile = $this->ioService->loadBinaryFile($path);

--- a/src/bundle/Core/Imagine/Variation/ImagineAwareAliasGenerator.php
+++ b/src/bundle/Core/Imagine/Variation/ImagineAwareAliasGenerator.php
@@ -7,11 +7,11 @@
 namespace Ibexa\Bundle\Core\Imagine\Variation;
 
 use Ibexa\Bundle\Core\Imagine\IORepositoryResolver;
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Variation\Values\ImageVariation;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Core\IO\IOServiceInterface;
 use Imagine\Image\ImagineInterface;
 
@@ -24,7 +24,7 @@ class ImagineAwareAliasGenerator implements VariationHandler
     /** @var \Ibexa\Contracts\Core\Variation\VariationHandler */
     private $aliasGenerator;
 
-    /** @var \Ibexa\Bundle\Core\Imagine\VariationPathGenerator */
+    /** @var \Ibexa\Contracts\Core\Variation\VariationPathGenerator */
     private $variationPathGenerator;
 
     /** @var \Ibexa\Core\IO\IOServiceInterface */

--- a/src/bundle/Core/Imagine/VariationPathGenerator.php
+++ b/src/bundle/Core/Imagine/VariationPathGenerator.php
@@ -6,20 +6,10 @@
  */
 namespace Ibexa\Bundle\Core\Imagine;
 
-/**
- * Generates the path to variations of original images.
- */
-interface VariationPathGenerator
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator as VariationPathGeneratorContract;
+
+interface VariationPathGenerator extends VariationPathGeneratorContract
 {
-    /**
-     * Returns the variation for image $originalPath with $filter.
-     *
-     * @param string $originalPath
-     * @param string $filter
-     *
-     * @return string
-     */
-    public function getVariationPath($originalPath, $filter);
 }
 
 class_alias(VariationPathGenerator::class, 'eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator');

--- a/src/bundle/Core/Imagine/VariationPathGenerator.php
+++ b/src/bundle/Core/Imagine/VariationPathGenerator.php
@@ -8,6 +8,9 @@ namespace Ibexa\Bundle\Core\Imagine;
 
 use Ibexa\Contracts\Core\Variation\VariationPathGenerator as VariationPathGeneratorContract;
 
+/**
+ * @deprecated 4.4.0 Use \Ibexa\Contracts\Core\Variation\VariationPathGenerator instead.
+ */
 interface VariationPathGenerator extends VariationPathGeneratorContract
 {
 }

--- a/src/bundle/Core/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
+++ b/src/bundle/Core/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 
 /**
  * Puts variations in the an _alias/<aliasName> subfolder.

--- a/src/bundle/Core/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
+++ b/src/bundle/Core/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 
 /**
  * Puts variations in the same folder than the original, suffixed with the filter name:.

--- a/src/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurger.php
+++ b/src/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurger.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Bundle\Core\Imagine\VariationPurger;
 
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Contracts\Core\Variation\VariationPurger;
 use Ibexa\Core\IO\IOServiceInterface;
 use Iterator;
@@ -25,7 +25,7 @@ class ImageFileVariationPurger implements VariationPurger
     /** @var \Ibexa\Core\IO\IOServiceInterface */
     private $ioService;
 
-    /** @var \Ibexa\Bundle\Core\Imagine\VariationPathGenerator */
+    /** @var \Ibexa\Contracts\Core\Variation\VariationPathGenerator */
     private $variationPathGenerator;
 
     /** @var \Psr\Log\LoggerInterface */

--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -172,7 +172,9 @@ parameters:
     ibexa.site_access.config.default.image.temporary_dir: imagetmp
     ibexa.site_access.config.default.image.published_images_dir: images
     ibexa.site_access.config.default.image.versioned_images_dir: images-versioned
+
     ibexa.site_access.config.default.image_variations:
+        original:
         reference:
             reference: ~
             filters:

--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -173,6 +173,7 @@ parameters:
     ibexa.site_access.config.default.image.published_images_dir: images
     ibexa.site_access.config.default.image.versioned_images_dir: images-versioned
 
+    ibexa.site_access.config.default.variation_handler_identifier: alias
     ibexa.site_access.config.default.image_variations:
         original:
         reference:

--- a/src/bundle/Core/Resources/config/fieldtype_services.yml
+++ b/src/bundle/Core/Resources/config/fieldtype_services.yml
@@ -57,10 +57,6 @@ services:
         arguments:
             $configResolver: '@ibexa.config.resolver'
 
-    # Image alias generator
-    ibexa.field_type.ezimage.variation_service:
-        alias: Ibexa\Bundle\Core\Imagine\ImageAsset\AliasGenerator
-
     ibexa.field_type.ezimage.io_service.published:
         parent: ibexa.core.io.service
 

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -71,14 +71,6 @@ services:
         calls:
             - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
 
-    Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator:
-        class: Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator
-        arguments:
-            - '@ibexa.image_alias.imagine.alias_generator'
-            - '@ibexa.image_alias.variation_path_generator'
-            - '@Ibexa\Core\FieldType\Image\IO\Legacy'
-            - '@liip_imagine'
-
     ibexa.image_alias.imagine.alias_generator:
         class: Ibexa\Bundle\Core\Imagine\AliasGenerator
         arguments:
@@ -119,6 +111,8 @@ services:
             - '@ibexa.api.service.content'
             - '@Ibexa\Core\FieldType\ImageAsset\AssetMapper'
         public: false
+        tags:
+            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias' }
 
     Ibexa\Bundle\Core\Imagine\PlaceholderProviderRegistry:
         class: 'Ibexa\Bundle\Core\Imagine\PlaceholderProviderRegistry'
@@ -285,5 +279,29 @@ services:
     Ibexa\Bundle\Core\Imagine\VariationPathGenerator\AliasDirectoryVariationPathGenerator:
         class: Ibexa\Bundle\Core\Imagine\VariationPathGenerator\AliasDirectoryVariationPathGenerator
 
+    # Abstract Image Variations
+
+    Ibexa\Core\Variation\VariationHandlerRegistry:
+        arguments:
+            $variationHandlers: !tagged_iterator { tag: 'ibexa.media.images.variation.handler', index_by: 'identifier' }
+
+    Ibexa\Bundle\Core\Variation\VariationHandlerResolver:
+        autowire: true
+        autoconfigure: true
+
+    Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator:
+        class: Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator
+        arguments:
+            - '@ibexa.image_alias.imagine.alias_generator'
+            - '@ibexa.image_alias.variation_path_generator'
+            - '@Ibexa\Core\FieldType\Image\IO\Legacy'
+            - '@liip_imagine'
+        tags:
+            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias' }
+
     # SPI Aliases
-    Ibexa\Contracts\Core\Variation\VariationHandler: '@Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator'
+    Ibexa\Contracts\Core\Variation\VariationHandler: '@Ibexa\Bundle\Core\Variation\VariationHandlerResolver'
+
+    # Image alias generator
+    ibexa.field_type.ezimage.variation_service:
+        alias: Ibexa\Contracts\Core\Variation\VariationHandler

--- a/src/bundle/Core/Resources/views/default/content/full.html.twig
+++ b/src/bundle/Core/Resources/views/default/content/full.html.twig
@@ -1,6 +1,5 @@
 {% extends no_layout == true ? view_base_layout : page_layout %}
 {% block content %}
-    <pre>{{ ibexa_image_alias(content.getField('image'), content.versionInfo, 'medium').uri }}</pre>
     <h2>{{ ibexa_content_name(content) }}</h2>
     {% for field in content.fieldsByLanguage(language|default(null)) %}
         <h3>{{ field.fieldDefIdentifier }}</h3>

--- a/src/bundle/Core/Resources/views/default/content/full.html.twig
+++ b/src/bundle/Core/Resources/views/default/content/full.html.twig
@@ -1,5 +1,6 @@
 {% extends no_layout == true ? view_base_layout : page_layout %}
 {% block content %}
+    <pre>{{ ibexa_image_alias(content.getField('image'), content.versionInfo, 'medium').uri }}</pre>
     <h2>{{ ibexa_content_name(content) }}</h2>
     {% for field in content.fieldsByLanguage(language|default(null)) %}
         <h3>{{ field.fieldDefIdentifier }}</h3>

--- a/src/bundle/Core/Resources/views/default/content/full.html.twig
+++ b/src/bundle/Core/Resources/views/default/content/full.html.twig
@@ -1,5 +1,6 @@
 {% extends no_layout == true ? view_base_layout : page_layout %}
 {% block content %}
+    {{ dump(ibexa_image_alias(content.getField('image'), content.versionInfo, 'medium').uri) }}
     <h2>{{ ibexa_content_name(content) }}</h2>
     {% for field in content.fieldsByLanguage(language|default(null)) %}
         <h3>{{ field.fieldDefIdentifier }}</h3>

--- a/src/bundle/Core/Resources/views/default/content/full.html.twig
+++ b/src/bundle/Core/Resources/views/default/content/full.html.twig
@@ -1,6 +1,5 @@
 {% extends no_layout == true ? view_base_layout : page_layout %}
 {% block content %}
-    {{ dump(ibexa_image_alias(content.getField('image'), content.versionInfo, 'medium').uri) }}
     <h2>{{ ibexa_content_name(content) }}</h2>
     {% for field in content.fieldsByLanguage(language|default(null)) %}
         <h3>{{ field.fieldDefIdentifier }}</h3>

--- a/src/bundle/Core/Variation/PathResolver.php
+++ b/src/bundle/Core/Variation/PathResolver.php
@@ -30,7 +30,7 @@ abstract class PathResolver
      *
      * @return string
      */
-    public function getFilePath(string $path, string $variation)
+    public function getFilePath(?string $path, string $variation)
     {
         return $this->variationPathGenerator->getVariationPath($path, $variation);
     }

--- a/src/bundle/Core/Variation/PathResolver.php
+++ b/src/bundle/Core/Variation/PathResolver.php
@@ -27,8 +27,10 @@ abstract class PathResolver
 
     /**
      * Returns path for filtered image from original path, using the VariationPathGenerator.
+     *
+     * @return string
      */
-    public function getFilePath(string $path, string $variation): string
+    public function getFilePath(string $path, string $variation)
     {
         return $this->variationPathGenerator->getVariationPath($path, $variation);
     }

--- a/src/bundle/Core/Variation/PathResolver.php
+++ b/src/bundle/Core/Variation/PathResolver.php
@@ -23,6 +23,8 @@ abstract class PathResolver
         $this->variationPathGenerator = $variationPathGenerator;
     }
 
+    abstract public function resolve($path, $variation): string;
+
     /**
      * Returns path for filtered image from original path, using the VariationPathGenerator.
      */

--- a/src/bundle/Core/Variation/PathResolver.php
+++ b/src/bundle/Core/Variation/PathResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Bundle\Core\Variation;
+
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
+use Symfony\Component\Routing\RequestContext;
+
+abstract class PathResolver
+{
+    protected RequestContext $requestContext;
+
+    protected VariationPathGenerator $variationPathGenerator;
+
+    public function __construct(
+        RequestContext $requestContext,
+        VariationPathGenerator $variationPathGenerator
+    ) {
+        $this->requestContext = $requestContext;
+        $this->variationPathGenerator = $variationPathGenerator;
+    }
+
+    /**
+     * Returns path for filtered image from original path, using the VariationPathGenerator.
+     */
+    public function getFilePath(string $path, string $variation): string
+    {
+        return $this->variationPathGenerator->getVariationPath($path, $variation);
+    }
+
+    /**
+     * Returns base URL, with scheme, host and port, for current request context.
+     * If no delivery URL is configured for current SiteAccess, will return base URL from current RequestContext.
+     */
+    protected function getBaseUrl(): string
+    {
+        $port = '';
+        if ($this->requestContext->getScheme() === 'https' && $this->requestContext->getHttpsPort() != 443) {
+            $port = ":{$this->requestContext->getHttpsPort()}";
+        }
+
+        if ($this->requestContext->getScheme() === 'http' && $this->requestContext->getHttpPort() != 80) {
+            $port = ":{$this->requestContext->getHttpPort()}";
+        }
+
+        $baseUrl = $this->requestContext->getBaseUrl();
+        if (substr($this->requestContext->getBaseUrl(), -4) === '.php') {
+            $baseUrl = pathinfo($this->requestContext->getBaseurl(), PATHINFO_DIRNAME);
+        }
+        $baseUrl = rtrim($baseUrl, '/\\');
+
+        return sprintf(
+            '%s://%s%s%s',
+            $this->requestContext->getScheme(),
+            $this->requestContext->getHost(),
+            $port,
+            $baseUrl
+        );
+    }
+}

--- a/src/bundle/Core/Variation/VariationHandlerResolver.php
+++ b/src/bundle/Core/Variation/VariationHandlerResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Bundle\Core\Variation;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Contracts\Core\Variation\Values\Variation;
+use Ibexa\Contracts\Core\Variation\VariationHandler;
+use Ibexa\Core\Variation\VariationHandlerRegistry;
+
+class VariationHandlerResolver implements VariationHandler
+{
+    private VariationHandlerRegistry $variationHandlerRegistry;
+    private ConfigResolverInterface $configResolver;
+
+    public function __construct(
+        VariationHandlerRegistry $variationHandlerRegistry,
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->variationHandlerRegistry = $variationHandlerRegistry;
+        $this->configResolver = $configResolver;
+    }
+
+    public function getVariation(
+        Field $field,
+        VersionInfo $versionInfo,
+        $variationName,
+        array $parameters = []
+    ): Variation {
+        $variationHandlerIdentifier = $this->configResolver->getParameter('variation_handler_identifier');
+        $handler = $this->variationHandlerRegistry->getVariationHandler($variationHandlerIdentifier);
+
+        return $handler->getVariation(
+            $field,
+            $versionInfo,
+            $variationName,
+            $parameters
+        );
+    }
+}

--- a/src/bundle/Core/Variation/VariationHandlerResolver.php
+++ b/src/bundle/Core/Variation/VariationHandlerResolver.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Variation\Values\Variation;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
 use Ibexa\Core\Variation\VariationHandlerRegistry;
 
-class VariationHandlerResolver implements VariationHandler
+final class VariationHandlerResolver implements VariationHandler
 {
     private VariationHandlerRegistry $variationHandlerRegistry;
 

--- a/src/bundle/Core/Variation/VariationHandlerResolver.php
+++ b/src/bundle/Core/Variation/VariationHandlerResolver.php
@@ -16,6 +16,7 @@ use Ibexa\Core\Variation\VariationHandlerRegistry;
 class VariationHandlerResolver implements VariationHandler
 {
     private VariationHandlerRegistry $variationHandlerRegistry;
+
     private ConfigResolverInterface $configResolver;
 
     public function __construct(

--- a/src/bundle/IO/Migration/FileLister/ImageFileLister.php
+++ b/src/bundle/IO/Migration/FileLister/ImageFileLister.php
@@ -6,10 +6,10 @@
  */
 namespace Ibexa\Bundle\IO\Migration\FileLister;
 
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 use Ibexa\Bundle\IO\ApiLoader\HandlerRegistry;
 use Ibexa\Bundle\IO\Migration\FileListerInterface;
 use Ibexa\Bundle\IO\Migration\MigrationHandler;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Core\IO\Exception\BinaryFileNotFoundException;
 use Iterator;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
@@ -21,7 +21,7 @@ class ImageFileLister extends MigrationHandler implements FileListerInterface
     /** @var \Ibexa\Bundle\Core\Imagine\VariationPurger\ImageFileList */
     private $imageFileList;
 
-    /** @var \Ibexa\Bundle\Core\Imagine\VariationPathGenerator */
+    /** @var \Ibexa\Contracts\Core\Variation\VariationPathGenerator */
     private $variationPathGenerator;
 
     /** @var \Liip\ImagineBundle\Imagine\Filter\FilterConfiguration */
@@ -35,7 +35,7 @@ class ImageFileLister extends MigrationHandler implements FileListerInterface
      * @param \Ibexa\Bundle\IO\ApiLoader\HandlerRegistry $binarydataHandlerRegistry
      * @param \Psr\Log\LoggerInterface $logger
      * @param \Iterator $imageFileList
-     * @param \Ibexa\Bundle\Core\Imagine\VariationPathGenerator
+     * @param \Ibexa\Contracts\Core\Variation\VariationPathGenerator
      * @param \Liip\ImagineBundle\Imagine\Filter\FilterConfiguration
      * @param string $imagesDir Directory where images are stored, within the storage dir. Example: 'images'
      */

--- a/src/contracts/Variation/Values/ImageVariation.php
+++ b/src/contracts/Variation/Values/ImageVariation.php
@@ -7,8 +7,8 @@
 namespace Ibexa\Contracts\Core\Variation\Values;
 
 /**
- * @property-read int $width The width as number of pixels (for example "320")
- * @property-read int $height The height as number of pixels (for example "256")
+ * @property-read int|null $width The width as number of pixels (for example "320")
+ * @property-read int|null $height The height as number of pixels (for example "256")
  * @property-read string $name The name of the image alias (for example "original")
  * @property-read mixed $info Extra information about the image, depending on the image type
  * @property-read mixed $imageId
@@ -18,7 +18,7 @@ class ImageVariation extends Variation
     /**
      * The width as number of pixels (for example "320").
      *
-     * @var int
+     * @var int|null
      */
     protected $width;
 

--- a/src/contracts/Variation/Values/ImageVariation.php
+++ b/src/contracts/Variation/Values/ImageVariation.php
@@ -25,7 +25,7 @@ class ImageVariation extends Variation
     /**
      * The height as number of pixels (for example "256").
      *
-     * @var int
+     * @var int|null
      */
     protected $height;
 
@@ -50,6 +50,17 @@ class ImageVariation extends Variation
 
     /** @var mixed */
     protected $imageId;
+
+    /**
+     * Contains identifier of variation handler used to generate this particular variation.
+     */
+    protected ?string $handler = null;
+
+    /**
+     * Indicator if variation image is external (like Fastly IO) or local (like built-in Imagine based alias).
+     * External images won't have SPLInfo data and image dimensions as it would be redundant to fetch file.
+     */
+    protected bool $isExternal = false;
 }
 
 class_alias(ImageVariation::class, 'eZ\Publish\SPI\Variation\Values\ImageVariation');

--- a/src/contracts/Variation/VariationPathGenerator.php
+++ b/src/contracts/Variation/VariationPathGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Contracts\Core\Variation;
+
+/**
+ * Generates the path to variations of original images.
+ */
+interface VariationPathGenerator
+{
+    /**
+     * Returns the variation for image $path with $variation.
+     *
+     * @param string $path
+     * @param string $variation
+     *
+     * @return string
+     */
+    public function getVariationPath($path, $variation);
+}

--- a/src/lib/Variation/VariationHandlerRegistry.php
+++ b/src/lib/Variation/VariationHandlerRegistry.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Variation;
+
+use Ibexa\Contracts\Core\Exception\InvalidArgumentException;
+use Ibexa\Contracts\Core\Variation\VariationHandler;
+use Traversable;
+
+final class VariationHandlerRegistry
+{
+    /** @var iterable<string, \Ibexa\Contracts\Core\Variation\VariationHandler> */
+    private iterable $variationHandlers;
+
+    public function __construct(iterable $variationHandlers)
+    {
+        $handlers = $variationHandlers instanceof Traversable
+            ? iterator_to_array($variationHandlers)
+            : $variationHandlers;
+
+        foreach ($handlers as $identifier => $handler) {
+            $this->setVariationHandler($identifier, $handler);
+        }
+    }
+
+    public function hasVariationHandler(string $identifier): bool
+    {
+        return isset($this->variationHandlers[$identifier]);
+    }
+
+    public function getVariationHandler(string $identifier): VariationHandler
+    {
+        if (!$this->hasVariationHandler($identifier)) {
+            throw new InvalidArgumentException('identifier', 'VariationHandler is not registered');
+        }
+
+        return $this->variationHandlers[$identifier];
+    }
+
+    public function setVariationHandler(string $identifier, VariationHandler $variationHandler): void
+    {
+        $this->variationHandlers[$identifier] = $variationHandler;
+    }
+}

--- a/tests/bundle/Core/Imagine/AliasGeneratorTest.php
+++ b/tests/bundle/Core/Imagine/AliasGeneratorTest.php
@@ -8,11 +8,11 @@ namespace Ibexa\Tests\Bundle\Core\Imagine;
 
 use Ibexa\Bundle\Core\Imagine\AliasGenerator;
 use Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator;
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 use Ibexa\Contracts\Core\FieldType\Value as FieldTypeValue;
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidVariationException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Variation\Values\ImageVariation;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Core\FieldType\Image\Value as ImageValue;
 use Ibexa\Core\FieldType\TextLine\Value as TextLineValue;
 use Ibexa\Core\IO\IOServiceInterface;
@@ -67,7 +67,7 @@ class AliasGeneratorTest extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Core\IO\IOServiceInterface */
     private $ioService;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Bundle\Core\Imagine\VariationPathGenerator */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\Variation\VariationPathGenerator */
     private $variationPathGenerator;
 
     protected function setUp(): void

--- a/tests/bundle/Core/Imagine/IORepositoryResolverTest.php
+++ b/tests/bundle/Core/Imagine/IORepositoryResolverTest.php
@@ -8,8 +8,8 @@ namespace Ibexa\Tests\Bundle\Core\Imagine;
 
 use Ibexa\Bundle\Core\Imagine\Filter\FilterConfiguration;
 use Ibexa\Bundle\Core\Imagine\IORepositoryResolver;
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Contracts\Core\Variation\VariationPurger;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\IO\IOServiceInterface;
@@ -42,7 +42,7 @@ class IORepositoryResolverTest extends TestCase
     /** @var \Ibexa\Contracts\Core\Variation\VariationPurger|\PHPUnit\Framework\MockObject\MockObject */
     protected $variationPurger;
 
-    /** @var \Ibexa\Bundle\Core\Imagine\VariationPathGenerator|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Contracts\Core\Variation\VariationPathGenerator|\PHPUnit\Framework\MockObject\MockObject */
     protected $variationPathGenerator;
 
     protected function setUp(): void

--- a/tests/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
+++ b/tests/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
@@ -7,8 +7,8 @@
 namespace Ibexa\Tests\Bundle\Core\Imagine\VariationPurger;
 
 use ArrayIterator;
-use Ibexa\Bundle\Core\Imagine\VariationPathGenerator;
 use Ibexa\Bundle\Core\Imagine\VariationPurger\ImageFileVariationPurger;
+use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Core\IO\IOServiceInterface;
 use Ibexa\Core\IO\Values\BinaryFile;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +18,7 @@ class ImageFileVariationPurgerTest extends TestCase
     /** @var \Ibexa\Core\IO\IOServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
     protected $ioServiceMock;
 
-    /** @var \Ibexa\Bundle\Core\Imagine\VariationPathGenerator|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Contracts\Core\Variation\VariationPathGenerator|\PHPUnit\Framework\MockObject\MockObject */
     protected $pathGeneratorMock;
 
     /** @var \Ibexa\Bundle\Core\Imagine\VariationPurger\ImageFileVariationPurger */


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4391](https://issues.ibexa.co/browse/IBX-4391)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
