### PR TITLE
Better support for Swoole Runtime

### DIFF
--- a/src/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListener.php
+++ b/src/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListener.php
@@ -35,6 +35,12 @@ class RejectExplicitFrontControllerRequestsListener implements EventSubscriberIn
         }
 
         $request = $event->getRequest();
+        
+        // Not every symfony runtime provides SCRIPT_FILENAME
+        if ( ! $request->server->has('SCRIPT_FILENAME') ) {
+            return;
+        }
+        
         $scriptFileName = preg_quote(basename($request->server->get('SCRIPT_FILENAME')), '\\');
         // This pattern has to match with vhost.template files in meta repository
         $pattern = sprintf('<^/([^/]+/)?%s([/?#]|$)>', $scriptFileName);

--- a/src/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListener.php
+++ b/src/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListener.php
@@ -35,12 +35,12 @@ class RejectExplicitFrontControllerRequestsListener implements EventSubscriberIn
         }
 
         $request = $event->getRequest();
-        
+
         // Not every symfony runtime provides SCRIPT_FILENAME
-        if ( ! $request->server->has('SCRIPT_FILENAME') ) {
+        if (!$request->server->has('SCRIPT_FILENAME')) {
             return;
         }
-        
+
         $scriptFileName = preg_quote(basename($request->server->get('SCRIPT_FILENAME')), '\\');
         // This pattern has to match with vhost.template files in meta repository
         $pattern = sprintf('<^/([^/]+/)?%s([/?#]|$)>', $scriptFileName);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.2`
| **BC breaks**                          | no

# Replaces #146 due to lack of response.

SCRIPT_FILENAME is not set in Swoole

You can reproduce it with 
```shell
export APP_ENV="prod"
export APP_DEBUG="0"
export APP_RUNTIME="Runtime\Swoole\Runtime"
```

```php
# public/index.php
<?php

use App\Kernel;
$_SERVER['APP_ENV'] = 'dev';
$_SERVER['APP_DEBUG'] = true;

$_SERVER['APP_RUNTIME_OPTIONS'] = [
    'host' => '0.0.0.0',
    'port' => 8080,
    'mode' => SWOOLE_BASE,
    'settings' => [
        \Swoole\Constant::OPTION_WORKER_NUM => swoole_cpu_num() * 2,
        \Swoole\Constant::OPTION_ENABLE_STATIC_HANDLER => true,
        \Swoole\Constant::OPTION_DOCUMENT_ROOT => dirname(__DIR__).'/public'
    ],
];

require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

return function (array $context) {
    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
};

```


#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
