### PR TITLE
IBX-3767: Exposed default image variation handler as env variable

### DIFF
--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -173,7 +173,7 @@ parameters:
     ibexa.site_access.config.default.image.published_images_dir: images
     ibexa.site_access.config.default.image.versioned_images_dir: images-versioned
 
-    ibexa.site_access.config.default.variation_handler_identifier: alias
+    ibexa.site_access.config.default.variation_handler_identifier: '%env(string:VARIATION_HANDLER_IDENTIFIER)%'
     ibexa.site_access.config.default.image_variations:
         original:
         reference:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3767](https://issues.ibexa.co/browse/IBX-3767)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

Without exposing it to env variable, local environment would be handicapped to use the same configuration as ie. Platform.sh does (and Fastly IO does not work on local environment).

## Requires: https://github.com/ibexa/recipes-dev/pull/48

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
