### PR TITLE
Enforce policy module name and function convention

### DIFF
--- a/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
+++ b/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
@@ -21,7 +21,17 @@ class PoliciesConfigBuilder extends ContainerConfigBuilder
 
         // We receive limitations as values, but we want them as keys to be used by isset().
         foreach ($config as $module => $functionArray) {
+            if (preg_match('/\W+/', $module)) {
+                throw new \InvalidArgumentException(
+                    "Policy module '{$module}' can only contain characters [a-zA-Z0-9_]"
+                );
+            }
             foreach ($functionArray as $function => $limitationCollection) {
+                if (preg_match('/\W+/', $function)) {
+                    throw new \InvalidArgumentException(
+                        "Policy function {$function}' can only contain characters [a-zA-Z0-9_]"
+                    );
+                }
                 if (null !== $limitationCollection && $this->policyExists($previousPolicyMap, $module, $function)) {
                     $limitations = array_merge_recursive($previousPolicyMap[$module][$function] ?? [], array_fill_keys((array)$limitationCollection, true));
                 } else {

--- a/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
+++ b/src/bundle/Core/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
@@ -29,7 +29,7 @@ class PoliciesConfigBuilder extends ContainerConfigBuilder
             foreach ($functionArray as $function => $limitationCollection) {
                 if (preg_match('/\W+/', $function)) {
                     throw new \InvalidArgumentException(
-                        "Policy function {$function}' can only contain characters [a-zA-Z0-9_]"
+                        "Policy function {$function}' can only contain letters, digits, or the underscore character."
                     );
                 }
                 if (null !== $limitationCollection && $this->policyExists($previousPolicyMap, $module, $function)) {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4938](https://issues.ibexa.co/browse/IBX-4938)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.2`, `v3.3`, `v4.0`
| **BC breaks**                          | no

Admin ui routes expects the policy module name to conform to  \w+

This fix assumes the restriction should be on both the module and and function as the formtype concats the two with '|'  and allowing other characters could cause issues.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
