### PR TITLE
Fixed deprecated var interpolation style in Caching ContentHandler

### DIFF
--- a/src/lib/Persistence/Cache/ContentHandler.php
+++ b/src/lib/Persistence/Cache/ContentHandler.php
@@ -131,7 +131,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      */
     public function load($contentId, $versionNo = null, array $translations = null)
     {
-        $keySuffix = $versionNo ? "-${versionNo}-" : '-';
+        $keySuffix = $versionNo ? "-{$versionNo}-" : '-';
         $keySuffix .= empty($translations) ? self::ALL_TRANSLATIONS_KEY : implode('|', $translations);
 
         return $this->getCacheValue(
@@ -238,7 +238,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      */
     public function loadVersionInfo($contentId, $versionNo = null)
     {
-        $keySuffix = $versionNo ? "-${versionNo}" : '';
+        $keySuffix = $versionNo ? "-{$versionNo}" : '';
         $cacheItem = $this->cache->getItem(
             $this->cacheIdentifierGenerator->generateKey(
                 self::CONTENT_VERSION_INFO_IDENTIFIER,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug
| **Target Ibexa version** | `v4.4.x`
| **BC breaks**                          | no

Changes suggested by https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dollar-brace-interpolation

Avoid the following warnings when running on PHP 8.2:
- Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/vendor/ibexa/core/src/lib/Persistence/Cache/ContentHandler.php on line 134
- Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/vendor/ibexa/core/src/lib/Persistence/Cache/ContentHandler.php on line 241

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
