### PR TITLE
IBX-5061: Improved readability for DateMetadata criterion targets

### DIFF
--- a/src/contracts/Repository/Values/Content/Query/Criterion/DateMetadata.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/DateMetadata.php
@@ -64,7 +64,11 @@ class DateMetadata extends Criterion implements TrashCriterion, FilteringCriteri
     public function __construct(string $target, string $operator, $value)
     {
         if (!in_array($target, self::TARGETS)) {
-            throw new InvalidArgumentException("Unknown DateMetadata $target");
+            throw new InvalidArgumentException(sprintf(
+                'Unknown DateMetadata target "%s". Expected one of: "%s"',
+                $target,
+                implode('", "', self::TARGETS),
+            ));
         }
         parent::__construct($target, $operator, $value);
     }

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
@@ -80,6 +80,8 @@ class DateMetadata extends CriterionHandler
                 return 't.' . Criterion\DateMetadata::TRASHED;
             case Criterion\DateMetadata::MODIFIED:
                 return 'c.' . Criterion\DateMetadata::MODIFIED;
+            case Criterion\DateMetadata::CREATED:
+            case Criterion\DateMetadata::PUBLISHED:
             default:
                 return 'c.' . Criterion\DateMetadata::PUBLISHED;
         }

--- a/tests/lib/Repository/Values/Content/Query/Criterion/DateMetadataTest.php
+++ b/tests/lib/Repository/Values/Content/Query/Criterion/DateMetadataTest.php
@@ -2,7 +2,7 @@
 
 namespace Ibexa\Tests\Core\Repository\Values\Content\Query\Criterion;
 
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\DateMetadata;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\DateMetadata;
 use PHPUnit\Framework\TestCase;
 
 final class DateMetadataTest extends TestCase

--- a/tests/lib/Repository/Values/Content/Query/Criterion/DateMetadataTest.php
+++ b/tests/lib/Repository/Values/Content/Query/Criterion/DateMetadataTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ibexa\Tests\Core\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\DateMetadata;
+use PHPUnit\Framework\TestCase;
+
+final class DateMetadataTest extends TestCase
+{
+    /**
+     * @dataProvider provideValidConstructorArguments
+     */
+    public function testConstruction(string $target, string $operator, $value): void
+    {
+        $criterion = new DateMetadata($target, $operator, $value);
+        self::assertSame($target, $criterion->target);
+    }
+
+    /**
+     * @return iterable<array{non-empty-string, string, integer}>
+     */
+    public static function provideValidConstructorArguments(): iterable
+    {
+        $date = 0;
+        $operator = '=';
+
+        yield ['modified', $operator, $date];
+        yield ['created', $operator, $date];
+        yield ['published', $operator, $date];
+        yield ['trashed', $operator, $date];
+    }
+
+    public function testExceptionOnInvalidTarget(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown DateMetadata target "foo". Expected one of: "modified", "created", "published", "trashed"');
+        new DateMetadata('foo', '=', 0);
+    }
+}

--- a/tests/lib/Repository/Values/Content/Query/Criterion/DateMetadataTest.php
+++ b/tests/lib/Repository/Values/Content/Query/Criterion/DateMetadataTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace Ibexa\Tests\Core\Repository\Values\Content\Query\Criterion;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\DateMetadata;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5061](https://issues.ibexa.co/browse/IBX-5061)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

This PR:
 * Provides more readable exception when invalid `DateMetadata.target` is provided.
 * Explicitly declares column matching for `published` and `created` targets, so they can be more easily spotted when checking their usage.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
