### PR TITLE
Fixed deprecation notices in string interpolation with PHP 8.2

### DIFF
--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -782,7 +782,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 
         // Cache settings
         // If CACHE_POOL env variable is set, check if there is a yml file that needs to be loaded for it
-        if (($pool = $_SERVER['CACHE_POOL'] ?? false) && file_exists($projectDir . "/config/packages/cache_pool/${pool}.yaml")) {
+        if (($pool = $_SERVER['CACHE_POOL'] ?? false) && file_exists($projectDir . "/config/packages/cache_pool/$pool.yaml")) {
             $loader = new Loader\YamlFileLoader($container, new FileLocator($projectDir . '/config/packages/cache_pool'));
             $loader->load($pool . '.yaml');
         }

--- a/src/bundle/Core/Features/Context/UserContext.php
+++ b/src/bundle/Core/Features/Context/UserContext.php
@@ -544,7 +544,7 @@ class UserContext implements Context
      */
     private function findNonExistingUserEmail($username = 'User')
     {
-        $email = "${username}@ibexa.co";
+        $email = "{$username}@ibexa.co";
         if ($this->checkUserExistenceByEmail($email)) {
             return $email;
         }

--- a/src/lib/FieldType/GatewayBasedStorage.php
+++ b/src/lib/FieldType/GatewayBasedStorage.php
@@ -87,7 +87,7 @@ abstract class GatewayBasedStorage implements FieldStorage
         );
 
         if (!isset($this->gateways[$context['identifier']])) {
-            throw new \OutOfBoundsException("No gateway for ${context['identifier']} available.");
+            throw new \OutOfBoundsException("No gateway for $context[identifier] available.");
         }
 
         $gateway = $this->gateways[$context['identifier']];

--- a/src/lib/Persistence/Cache/ContentHandler.php
+++ b/src/lib/Persistence/Cache/ContentHandler.php
@@ -131,7 +131,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      */
     public function load($contentId, $versionNo = null, array $translations = null)
     {
-        $keySuffix = $versionNo ? "-${versionNo}-" : '-';
+        $keySuffix = $versionNo ? "-{$versionNo}-" : '-';
         $keySuffix .= empty($translations) ? self::ALL_TRANSLATIONS_KEY : implode('|', $translations);
 
         return $this->getCacheValue(
@@ -238,7 +238,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      */
     public function loadVersionInfo($contentId, $versionNo = null)
     {
-        $keySuffix = $versionNo ? "-${versionNo}" : '';
+        $keySuffix = $versionNo ? "-{$versionNo}" : '';
         $cacheItem = $this->cache->getItem(
             $this->cacheIdentifierGenerator->generateKey(
                 self::CONTENT_VERSION_INFO_IDENTIFIER,

--- a/tests/integration/Core/Repository/BaseTest.php
+++ b/tests/integration/Core/Repository/BaseTest.php
@@ -173,7 +173,7 @@ abstract class BaseTest extends TestCase
         if (null === $this->setupFactory) {
             if (false === ($setupClass = getenv('setupFactory'))) {
                 $setupClass = LegacySetupFactory::class;
-                putenv("setupFactory=${setupClass}");
+                putenv("setupFactory=$setupClass");
             }
 
             if (false === getenv('fixtureDir')) {

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -874,7 +874,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
                     $this->assertEquals(
                         $typeCreate->$propertyName,
                         $contentType->$propertyName,
-                        "Did not assert that property '${propertyName}' is equal on struct and resulting value object"
+                        "Did not assert that property '$propertyName' is equal on struct and resulting value object"
                     );
                     break;
             }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          |
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.3`
| **BC breaks**                          | no

Fixes new PHP 8.2 deprecation notices:
`Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ...`

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
