### PR TITLE
Updated configuration of translations

### DIFF
--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -1019,14 +1019,13 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
     {
         $container->prependExtensionConfig('jms_translation', [
             'configs' => [
-                self::EXTENSION_NAME => [
+                'ibexa_core' => [
                     'dirs' => [
                         __DIR__ . '/../',
                     ],
                     'output_dir' => __DIR__ . '/../Resources/translations/',
                     'output_format' => 'xliff',
                     'excluded_dirs' => ['Behat', 'Tests', 'node_modules', 'Features'],
-                    'extractors' => [],
                 ],
             ],
         ]);

--- a/src/bundle/Core/EventListener/ExceptionListener.php
+++ b/src/bundle/Core/EventListener/ExceptionListener.php
@@ -71,7 +71,12 @@ class ExceptionListener implements EventSubscriberInterface
     {
         $message = $exception->getMessage();
         if ($exception instanceof Translatable) {
-            $message = $this->translator->trans($exception->getMessageTemplate(), $exception->getParameters(), 'repository_exceptions');
+            $message = $this->translator->trans(
+                /** @Ignore */
+                $exception->getMessageTemplate(),
+                $exception->getParameters(),
+                'repository_exceptions'
+            );
         }
 
         return $message;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

Fixed error during extraction of translations. Adjusted the name of the configuration for translation and removed empty extractors array. Change of the name will make it easier to check if translations are up to date. In all other packages, our convention is in the format `ibexa_package_name`. In the core package, it is `ibexa` and that`s why this PR changed it. It does not have to be `EXTENSION_NAME`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
