### PR TITLE
IBX-5153: Could not find configuration for a filter: original

### DIFF
--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -175,7 +175,6 @@ parameters:
 
     ibexa.site_access.config.default.variation_handler_identifier: alias
     ibexa.site_access.config.default.image_variations:
-        original:
         reference:
             reference: ~
             filters:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5153](https://issues.ibexa.co/browse/IBX-5153)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

Looks like [IBX-4391](https://issues.ibexa.co/browse/IBX-4391) introduced [IBX-5153](https://issues.ibexa.co/browse/IBX-5153)
In [IBX-4391](https://issues.ibexa.co/browse/IBX-4391), [`original` is added to the list of image variations](https://github.com/ibexa/core/pull/185/files#diff-d183f8898f4aff26807fe10cab6d2b1299c395d13ea5dfa9f3d1c94c0b22e19e) and that causes this problem. 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
