### PR TITLE
IBX-5293: Added event dispatcher in default success handler

### DIFF
--- a/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
@@ -106,6 +106,10 @@ class SecurityPass implements CompilerPassInterface
             'setConfigResolver',
             [$configResolverRef]
         );
+        $successHandlerDef->addMethodCall(
+            'setEventDispatcher',
+            [new Reference('event_dispatcher')]
+        );
     }
 }
 

--- a/src/lib/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/lib/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -19,30 +19,32 @@ class DefaultAuthenticationSuccessHandler extends BaseSuccessHandler
 
     /**
      * Injects the ConfigResolver to potentially override default_target_path for redirections after authentication success.
-     *
-     * @param \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface $configResolver
      */
-    public function setConfigResolver(ConfigResolverInterface $configResolver)
+    public function setConfigResolver(ConfigResolverInterface $configResolver): void
     {
         $this->configResolver = $configResolver;
     }
 
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
     {
         $this->eventDispatcher = $eventDispatcher;
     }
 
     protected function determineTargetUrl(Request $request)
     {
-        $defaultPage = $this->configResolver->getParameter('default_page');
-        if ($defaultPage !== null) {
-            $this->options['default_target_path'] = $defaultPage;
+        if (isset($this->configResolver)) {
+            $defaultPage = $this->configResolver->getParameter('default_page');
+            if ($defaultPage !== null) {
+                $this->options['default_target_path'] = $defaultPage;
+            }
         }
 
-        $event = new DetermineTargetUrlEvent($request, $this->options, $this->getFirewallName());
-        $this->eventDispatcher->dispatch($event);
+        if (isset($this->eventDispatcher)) {
+            $event = new DetermineTargetUrlEvent($request, $this->options, $this->getFirewallName());
+            $this->eventDispatcher->dispatch($event);
 
-        $this->options = $event->getOptions();
+            $this->options = $event->getOptions();
+        }
 
         return parent::determineTargetUrl($request);
     }

--- a/src/lib/MVC/Symfony/Security/Authentication/DetermineTargetUrlEvent.php
+++ b/src/lib/MVC/Symfony/Security/Authentication/DetermineTargetUrlEvent.php
@@ -11,7 +11,7 @@ namespace Ibexa\Core\MVC\Symfony\Security\Authentication;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class DetermineTargetUrlEvent extends Event
+final class DetermineTargetUrlEvent extends Event
 {
     private Request $request;
 
@@ -20,6 +20,9 @@ class DetermineTargetUrlEvent extends Event
     /** @var array<string, mixed> */
     private array $options;
 
+    /**
+     * @param array<string, mixed> $options
+     **/
     public function __construct(
         Request $request,
         array $options,

--- a/src/lib/MVC/Symfony/Security/Authentication/DetermineTargetUrlEvent.php
+++ b/src/lib/MVC/Symfony/Security/Authentication/DetermineTargetUrlEvent.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Core\MVC\Symfony\Security\Authentication;
 
-use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class DetermineTargetUrlEvent extends Event
 {

--- a/src/lib/MVC/Symfony/Security/Authentication/DetermineTargetUrlEvent.php
+++ b/src/lib/MVC/Symfony/Security/Authentication/DetermineTargetUrlEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\Security\Authentication;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+class DetermineTargetUrlEvent extends Event
+{
+    private Request $request;
+
+    private string $firewallName;
+
+    /** @var array<string, mixed> */
+    private array $options;
+
+    public function __construct(
+        Request $request,
+        array $options,
+        string $firewallName
+    ) {
+        $this->request = $request;
+        $this->firewallName = $firewallName;
+        $this->options = $options;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getFirewallName(): string
+    {
+        return $this->firewallName;
+    }
+
+    /** @return array<string, mixed> */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /** @param array<string, mixed> $options */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/tests/lib/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/tests/lib/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -9,14 +9,29 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Security\Authentication;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\DefaultAuthenticationSuccessHandler;
 use Ibexa\Core\MVC\Symfony\Security\HttpUtils;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class DefaultAuthenticationSuccessHandlerTest extends TestCase
 {
     public function testSetConfigResolver()
     {
-        $successHandler = new DefaultAuthenticationSuccessHandler(new HttpUtils(), []);
+        $siteAccess = new SiteAccess(
+            'test',
+            SiteAccess::DEFAULT_MATCHING_TYPE,
+            $this->createMock(Matcher::class)
+        );
+        $httpUtils = new HttpUtils();
+        $httpUtils->setSiteAccess($siteAccess);
+        $successHandler = new DefaultAuthenticationSuccessHandler($httpUtils, []);
+        $successHandler->setFirewallName('test_firewall');
+
         $refHandler = new ReflectionObject($successHandler);
         $refOptions = $refHandler->getProperty('options');
         $refOptions->setAccessible(true);
@@ -31,6 +46,18 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
             ->with('default_page')
             ->will($this->returnValue($defaultPage));
         $successHandler->setConfigResolver($configResolver);
+        $successHandler->setEventDispatcher($this->createMock(EventDispatcherInterface::class));
+
+        $request = $this->createMock(Request::class);
+        $request
+            ->method('getSession')
+            ->willReturn($this->createMock(Session::class));
+
+        $request
+            ->method('getUriForPath')
+            ->willReturn($defaultPage);
+
+        $successHandler->onAuthenticationSuccess($request, $this->createMock(TokenInterface::class));
         $options = $refOptions->getValue($successHandler);
         $this->assertSame($defaultPage, $options['default_target_path']);
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5293](https://issues.ibexa.co/browse/IBX-5293)
| **Type**                                   | feature/bug/improvement 
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

Working with custom success handler is troublesome if you do not want to define it explicite in security configuration - and we do not want to do it, as it adds more complexity on client side. What's more we had problems with constructor signature change in the past - that's why I decided to drop custom handler inside adminUI package (https://github.com/ibexa/admin-ui/pull/732) and instead of it emit event that can be modified in any package (corporate-account in mind) an based on that could handle redirects based on external logic.

Two extra things done:

I have moved setting `default_target_path` based on config resolver from set method to `determineTargetUrl` one.
 - first of all, `setConfigResolver` didnt actually set it config resolver.
 - that method was called before `setOptions` (which is defined in Symfony Security Extension) - meaning that just after setting default_target_path from resolver it was overriden by defaults.
 
 I have decided to use now working default_page configuration to set default page for adminUI, hence:
https://github.com/ibexa/recipes-dev/pull/57

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
