### PR TITLE
IBX-4929: Fixed PHPDoc(s) referencing `static<TValue>` return type

### DIFF
--- a/src/contracts/Collection/AbstractInMemoryCollection.php
+++ b/src/contracts/Collection/AbstractInMemoryCollection.php
@@ -52,7 +52,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @return self
+     * @phpstan-return static<TValue>
      */
     public function filter(Closure $predicate): self
     {
@@ -60,7 +60,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @return self
+     * @phpstan-return static<TValue>
      */
     public function map(Closure $function): self
     {
@@ -92,7 +92,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     /**
      * @param TValue[] $items
      *
-     * @return self
+     * @phpstan-return static<TValue>
      */
     abstract protected function createFrom(array $items): self;
 }

--- a/src/contracts/Collection/AbstractInMemoryCollection.php
+++ b/src/contracts/Collection/AbstractInMemoryCollection.php
@@ -52,7 +52,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @return static<TValue>
+     * @return self
      */
     public function filter(Closure $predicate): self
     {
@@ -60,7 +60,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @return static<TValue>
+     * @return self
      */
     public function map(Closure $function): self
     {
@@ -92,7 +92,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     /**
      * @param TValue[] $items
      *
-     * @return static<TValue>
+     * @return self
      */
     abstract protected function createFrom(array $items): self;
 }

--- a/src/contracts/Collection/StreamableInterface.php
+++ b/src/contracts/Collection/StreamableInterface.php
@@ -19,7 +19,7 @@ interface StreamableInterface
      * Returns all the elements of this collection that satisfy the predicate.
      * The order of the elements is preserved.
      *
-     * @return static<TValue>
+     * @phpstan-return static<TValue>
      */
     public function filter(Closure $predicate): self;
 
@@ -27,7 +27,7 @@ interface StreamableInterface
      * Applies the given function to each element in the collection and returns
      * a new collection with the elements returned by the function.
      *
-     * @return static<TValue>
+     * @phpstan-return static<TValue>
      */
     public function map(Closure $function): self;
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.4.1`
| **BC breaks**                          | no

From phpDocumentor v3.3.1:
* `Unable to parse file "vendor/ibexa/core/src/contracts/Collection/AbstractInMemoryCollection.php", an error was detected: static is not a collection`
* `Unable to parse file "vendor/ibexa/core/src/contracts/Collection/StreamableInterface.php", an error was detected: static is not a collection`

Use `@phpstan-return static<TValue>` instead of `@return static<TValue>`

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
