### PR TITLE
IBX-4929: Removed reference to non-existent ObjectStateService example

### DIFF
--- a/src/lib/Repository/ObjectStateService.php
+++ b/src/lib/Repository/ObjectStateService.php
@@ -31,8 +31,6 @@ use Ibexa\Core\Repository\Values\ObjectState\ObjectStateGroup;
 
 /**
  * ObjectStateService service.
- *
- * @example Examples/objectstates.php tbd.
  */
 class ObjectStateService implements ObjectStateServiceInterface
 {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.4.1`
| **BC breaks**                          | no

The `@example` leads to a non existing path.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
