### PR TITLE
Added ordering by Limitation identifier when loading Role

### DIFF
--- a/src/lib/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -138,6 +138,10 @@ final class DoctrineDatabase extends Gateway
         return $query;
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\DBAL\Driver\Exception
+     */
     public function loadRole(int $roleId, int $status = Role::STATUS_DEFINED): array
     {
         $query = $this->getLoadRoleQueryBuilder();
@@ -151,11 +155,16 @@ final class DoctrineDatabase extends Gateway
             ->andWhere(
                 $this->buildRoleDraftQueryConstraint($status, $query)
             )
-            ->orderBy('p.id', 'ASC');
+            ->orderBy('p.id', 'ASC')
+            ->addOrderBy('l.identifier', 'ASC');
 
-        return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
+        return $query->execute()->fetchAllAssociative();
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\DBAL\Driver\Exception
+     */
     public function loadRoleByIdentifier(
         string $identifier,
         int $status = Role::STATUS_DEFINED
@@ -171,11 +180,10 @@ final class DoctrineDatabase extends Gateway
             ->andWhere(
                 $this->buildRoleDraftQueryConstraint($status, $query)
             )
-            ->orderBy('p.id', 'ASC');
+            ->orderBy('p.id', 'ASC')
+            ->addOrderBy('l.identifier', 'ASC');
 
-        $statement = $query->execute();
-
-        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
+        return $query->execute()->fetchAllAssociative();
     }
 
     public function loadRoleDraftByRoleId(int $roleId): array


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.4`+
| **BC breaks**                          | no

This PR attempts to fix random but very common CI failures that cost us many GHA restarts.
The query loading Roles with Limitations didn't have ordering by Limitations, so it was returned by a DBMS in an arbitrary order. I haven't been able to reproduce this locally, so the fix is rather based on the error on CI:

```
1) Ibexa\Tests\Integration\Core\Repository\RoleServiceTest::testCopyRoleWithPolicies with data set "with-limitations" (Ibexa\Core\Repository\Values\User\RoleCreateStruct Object (...), Ibexa\Core\Repository\Values\User\RoleCopyStruct Object (...), array(Ibexa\Core\Repository\Values\User\PolicyCreateStruct Object (...), Ibexa\Core\Repository\Values\User\PolicyCreateStruct Object (...)))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
         'module' => 'content'
         'function' => 'read'
         'limitations' => Array (
-            0 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation Object &000000000000cfb50000000000000000 (
+            0 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation Object &000000000000d2200000000000000000 (
                 'limitationValues' => Array &0 (
-                    0 => '/1/2/'
+                    0 => '2'
                 )
             )
-            1 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation Object &000000000000d6fd0000000000000000 (
+            1 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation Object &000000000000d5f50000000000000000 (
                 'limitationValues' => Array &0 (
-                    0 => '2'
+                    0 => '/1/2/'
                 )
             )
         )

Error: /home/runner/work/core/core/tests/integration/Core/Repository/RoleServiceTest.php:642

2) Ibexa\Tests\Integration\Core\Repository\RoleServiceTest::testCopyRoleWithPoliciesAndLimitations with data set "with-limitations" (Ibexa\Core\Repository\Values\User\RoleCreateStruct Object (...), Ibexa\Core\Repository\Values\User\RoleCopyStruct Object (...), array(Ibexa\Core\Repository\Values\User\PolicyCreateStruct Object (...), Ibexa\Core\Repository\Values\User\PolicyCreateStruct Object (...)))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
         'module' => 'content'
         'function' => 'read'
         'limitations' => Array (
-            0 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation Object &000000000000dfbd0000000000000000 (
+            0 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation Object &000000000000e3120000000000000000 (
                 'limitationValues' => Array &0 (
-                    0 => '/1/2/'
+                    0 => '2'
                 )
             )
-            1 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation Object &000000000000d4e40000000000000000 (
+            1 => Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation Object &000000000000d5d30000000000000000 (
                 'limitationValues' => Array &0 (
-                    0 => '2'
+                    0 => '/1/2/'
                 )
             )
         )
```

#### TODO
- [x] See if there are any failures after the change

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
