### PR TITLE
[PHPDoc] Removed `@internal param` from IOConfigurationPass::processHandlers

### DIFF
--- a/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
+++ b/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
@@ -74,8 +74,6 @@ class IOConfigurationPass implements CompilerPassInterface
      * @param array $configuredHandlers Handlers configuration declared via semantic config
      * @param \Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory[]|\ArrayObject $factories Map of alias => handler service id
      * @param string $defaultHandler default handler id
-     *
-     * @internal param $HandlerTypesMap
      */
     protected function processHandlers(
         ContainerBuilder $container,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

`IOConfigurationPass::processHandlers` method is excluded of PHP API Reference because of an `@internal` tag. This tag doesn't seem relevant and I propose its removal.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
