### PR TITLE
IBX-5541: Fixed Alias Generators' service priorities

### DIFF
--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -112,7 +112,7 @@ services:
             - '@Ibexa\Core\FieldType\ImageAsset\AssetMapper'
         public: false
         tags:
-            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias' }
+            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias', priority: -100 }
 
     Ibexa\Bundle\Core\Imagine\PlaceholderProviderRegistry:
         class: 'Ibexa\Bundle\Core\Imagine\PlaceholderProviderRegistry'
@@ -297,7 +297,7 @@ services:
             - '@Ibexa\Core\FieldType\Image\IO\Legacy'
             - '@liip_imagine'
         tags:
-            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias', priority: 10 }
+            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias', priority: -50 }
 
     Ibexa\Bundle\Core\Imagine\VariationPathGenerator\WebpFormatVariationPathGenerator:
         decorates: ibexa.image_alias.variation_path_generator

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -297,7 +297,7 @@ services:
             - '@Ibexa\Core\FieldType\Image\IO\Legacy'
             - '@liip_imagine'
         tags:
-            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias' }
+            - { name: 'ibexa.media.images.variation.handler', identifier: 'alias', priority: 10 }
 
     Ibexa\Bundle\Core\Imagine\VariationPathGenerator\WebpFormatVariationPathGenerator:
         decorates: ibexa.image_alias.variation_path_generator


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5541](https://issues.ibexa.co/browse/IBX-5541)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

Seems like the first `AliasGenerator` fired was `Ibexa\Bundle\Core\Imagine\AliasGenerator` but it should be `Ibexa\Bundle\Core\Imagine\ImageAsset\AliasGenerator`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
