### PR TITLE
Introduced IbexaTestKernelInterface for easier transition to separate package

### DIFF
--- a/src/contracts/Test/IbexaKernelTestTrait.php
+++ b/src/contracts/Test/IbexaKernelTestTrait.php
@@ -90,11 +90,11 @@ trait IbexaKernelTestTrait
     protected static function getTestServiceId(?string $id, string $className): string
     {
         $kernel = self::$kernel;
-        if (!$kernel instanceof IbexaTestKernel) {
+        if (!$kernel instanceof IbexaTestKernelInterface) {
             throw new RuntimeException(sprintf(
                 'Expected %s to be an instance of %s.',
                 get_class($kernel),
-                IbexaTestKernel::class,
+                IbexaTestKernelInterface::class,
             ));
         }
 

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -69,7 +69,7 @@ use Symfony\Component\HttpKernel\Kernel;
  * If don't need the repository services (or not all), you can replace the IbexaTestKernel::EXPOSED_SERVICES_BY_CLASS and
  * IbexaTestKernel::EXPOSED_SERVICES_BY_ID consts in extending class, without changing the methods above.
  */
-class IbexaTestKernel extends Kernel
+class IbexaTestKernel extends Kernel implements IbexaTestKernelInterface
 {
     /**
      * @var iterable<class-string>

--- a/src/contracts/Test/IbexaTestKernelInterface.php
+++ b/src/contracts/Test/IbexaTestKernelInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Test;
+
+/**
+ * @internal
+ * @experimental
+ */
+interface IbexaTestKernelInterface
+{
+    /**
+     * @return string a service ID that service aliases will be registered as
+     */
+    public static function getAliasServiceId(string $id): string;
+
+    /**
+     * @return iterable<string>
+     */
+    public function getSchemaFiles(): iterable;
+
+    /**
+     * @return iterable<\Ibexa\Contracts\Core\Test\Persistence\Fixture>
+     */
+    public function getFixtures(): iterable;
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no

Introduces `IbexaTestKernelInterface` to allow separate package to create it's own class of Kernel, and have the test case work correctly with it.

Additionally, this potentially allows application kernel to work with our integration tests if so desired (i.e. having a `AppKernel` with added interface / extended also be capable of working with tests).

Used in:
 * https://github.com/ibexa/test-core/pull/1

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
