### PR TITLE
Fixed file visitor for extracting exception messages

### DIFF
--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -1024,10 +1024,10 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
             'configs' => [
                 'ibexa_core' => [
                     'dirs' => [
-                        __DIR__ . '/../',
+                        __DIR__ . '/../../../',
                     ],
                     'output_dir' => __DIR__ . '/../Resources/translations/',
-                    'output_format' => 'xliff',
+                    'output_format' => 'xlf',
                     'excluded_dirs' => ['Behat', 'Tests', 'node_modules', 'Features'],
                 ],
             ],

--- a/src/bundle/Core/Resources/translations/content_fields.en.xlf
+++ b/src/bundle/Core/Resources/translations/content_fields.en.xlf
@@ -8,12 +8,12 @@
     <body>
       <trans-unit id="f337a8fd9042dbc4de8b5d305b6d8df3c0c374c4" resname="content-field.latitude.not_set">
         <source>Not set</source>
-        <target state="new">Not set</target>
+        <target>Not set</target>
         <note>key: content-field.latitude.not_set</note>
       </trans-unit>
       <trans-unit id="687973ca20983f27a99c50243e364e346c9c4814" resname="content-field.longitude.not_set">
         <source>Not set</source>
-        <target state="new">Not set</target>
+        <target>Not set</target>
         <note>key: content-field.longitude.not_set</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/fielddefinition.en.xlf
+++ b/src/bundle/Core/Resources/translations/fielddefinition.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-07-12T12:57:32Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,388 +10,311 @@
         <source>Any</source>
         <target>Any</target>
         <note>key: fielddefinition.allowed-content-types.any</note>
-        <jms:reference-file line="261">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="70d065216b588dd0cf8c624132941a29f1c1459f" resname="fielddefinition.allowed-content-types.label">
         <source>Allowed content types:</source>
         <target>Allowed content types:</target>
         <note>key: fielddefinition.allowed-content-types.label</note>
-        <jms:reference-file line="251">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="403c5c915c461ee1ee00f5c2e193266067672e3a" resname="fielddefinition.default-layout.label">
-        <source>Default layout:</source>
-        <target>Default layout:</target>
-        <note>key: fielddefinition.default-layout.label</note>
-        <jms:reference-file line="273">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="becaad6a0d63182875b2bc7d21b0c6a801ba764f" resname="fielddefinition.default-layout.none">
-        <source>None</source>
-        <target>None</target>
-        <note>key: fielddefinition.default-layout.none</note>
-        <jms:reference-file line="274">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="eb0eeb83b3f40e1293f0edd593a8cce658d9f35d" resname="fielddefinition.default-value.checked">
         <source>Checked</source>
         <target>Checked</target>
         <note>key: fielddefinition.default-value.checked</note>
-        <jms:reference-file line="69">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="aa6b4bece2c401e90fc0828a11ad372eaf2f3695" resname="fielddefinition.default-value.current_author">
+        <source>Current User</source>
+        <target>Current User</target>
+        <note>key: fielddefinition.default-value.current_author</note>
       </trans-unit>
       <trans-unit id="3410f38fd1f44cb841ec374c13daca04dcc5910b" resname="fielddefinition.default-value.current_date">
         <source>Current date</source>
         <target>Current date</target>
         <note>key: fielddefinition.default-value.current_date</note>
-        <jms:reference-file line="107">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="d3cda4b47dfae160f1e7f982570b8b544a494701" resname="fielddefinition.default-value.current_datetime">
         <source>Current datetime</source>
         <target>Current datetime</target>
         <note>key: fielddefinition.default-value.current_datetime</note>
-        <jms:reference-file line="83">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="5cdfd0738c76b8fe520f77e56b819fd3a781a514" resname="fielddefinition.default-value.current_datetime_adjust_by">
         <source>Current datetime adjusted by</source>
         <target>Current datetime adjusted by</target>
         <note>key: fielddefinition.default-value.current_datetime_adjust_by</note>
-        <jms:reference-file line="86">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="baf973c669d404a5aa072edce1d84deaaf936a0f" resname="fielddefinition.default-value.current_time">
         <source>Current time</source>
         <target>Current time</target>
         <note>key: fielddefinition.default-value.current_time</note>
-        <jms:reference-file line="118">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa5a2f0bf185c7e872f77b81a24867afb9ef0ec7" resname="fielddefinition.default-value.empty">
         <source>Empty</source>
         <target>Empty</target>
         <note>key: fielddefinition.default-value.empty</note>
-        <jms:reference-file line="105">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="116">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="81">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ad6776fd58e0ae4b2ba44ff014986ec6b1ec4de4" resname="fielddefinition.default-value.label">
         <source>Default value:</source>
         <target>Default value:</target>
         <note>key: fielddefinition.default-value.label</note>
-        <jms:reference-file line="347">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="66">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="232dd99b54158ff1f3be77113aae16e691ce406a" resname="fielddefinition.default-value.unchecked">
         <source>Unchecked</source>
         <target>Unchecked</target>
         <note>key: fielddefinition.default-value.unchecked</note>
-        <jms:reference-file line="71">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="908870d411d8599211d188e35d0240bfecb98b5e" resname="fielddefinition.default-value.undefined">
         <source>No default value</source>
         <target>No default value</target>
         <note>key: fielddefinition.default-value.undefined</note>
-        <jms:reference-file line="352">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="34ced944f5d7159b0597b98279e73be045c0ccd9" resname="fielddefinition.interval.day">
         <source>%default% %day% day(s)</source>
         <target>%default% %day% day(s)</target>
         <note>key: fielddefinition.interval.day</note>
-        <jms:reference-file line="89">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4b31f5a6cfde5d347f3ad264daa7db77e704a5e0" resname="fielddefinition.interval.hour">
         <source>%default% %hour% hour(s)</source>
         <target>%default% %hour% hour(s)</target>
         <note>key: fielddefinition.interval.hour</note>
-        <jms:reference-file line="90">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="388ff2c36717a410a72060911657dce61108ed3c" resname="fielddefinition.interval.minute">
         <source>%default% %minute% minute(s)</source>
         <target>%default% %minute% minute(s)</target>
         <note>key: fielddefinition.interval.minute</note>
-        <jms:reference-file line="91">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b93b6a1548ffa873b1ef5a95c727f93d7be2fd0c" resname="fielddefinition.interval.month">
         <source>%default% %month% month(s)</source>
         <target>%default% %month% month(s)</target>
         <note>key: fielddefinition.interval.month</note>
-        <jms:reference-file line="88">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c410f54bc82c293dcce4b252928dc4a020ab1705" resname="fielddefinition.interval.second">
         <source>%default% %second% second(s)</source>
         <target>%default% %second% second(s)</target>
         <note>key: fielddefinition.interval.second</note>
-        <jms:reference-file line="92">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c88fa282a777c6f3a778f513fc9e46800ffe0198" resname="fielddefinition.interval.year">
         <source>%default% %year% year(s)</source>
         <target>%default% %year% year(s)</target>
         <note>key: fielddefinition.interval.year</note>
-        <jms:reference-file line="87">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="fa2595f063cfd4284226372dc99eb3dfbbc36498" resname="fielddefinition.isbn.label">
         <source>Selected ISBN format:</source>
         <target>Selected ISBN format:</target>
         <note>key: fielddefinition.isbn.label</note>
-        <jms:reference-file line="393">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c963dbac20e5526d70d08b17ebffdaaf44e1c2c3" resname="fielddefinition.max-length.label">
         <source>Max string length:</source>
         <target>Max string length:</target>
         <note>key: fielddefinition.max-length.label</note>
-        <jms:reference-file line="28">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c8c3fa9b71c848069950539011a09b45abb1c11f" resname="fielddefinition.max-length.undefined">
         <source>No defined maximum string length</source>
         <target>No defined maximum string length</target>
         <note>key: fielddefinition.max-length.undefined</note>
-        <jms:reference-file line="33">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="9a3d23487e45edf331407c501ead33d70461f9e3" resname="fielddefinition.max-length.value">
         <source>%max% characters</source>
         <target>%max% characters</target>
         <note>key: fielddefinition.max-length.value</note>
-        <jms:reference-file line="31">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="11e7b0a01edea69919ea6191acdbd5ad7c2bf279" resname="fielddefinition.max-value.label">
         <source>Maximum value:</source>
         <target>Maximum value:</target>
         <note>key: fielddefinition.max-value.label</note>
-        <jms:reference-file line="373">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="444423d6eff78ccc1c92077813a212b4e5a002c8" resname="fielddefinition.max-value.undefined">
         <source>No defined maximum value</source>
         <target>No defined maximum value</target>
         <note>key: fielddefinition.max-value.undefined</note>
-        <jms:reference-file line="378">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="63f939a170c5c3675f13ca3e330ea981d4a5540c" resname="fielddefinition.maximum-file-size.label">
         <source>Maximum file size:</source>
         <target>Maximum file size:</target>
         <note>key: fielddefinition.maximum-file-size.label</note>
-        <jms:reference-file line="308">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e58e37a5cd49fa5884d15ea8af61ad6973f33412" resname="fielddefinition.maximum-file-size.undefined">
         <source>No defined maximum size</source>
         <target>No defined maximum size</target>
         <note>key: fielddefinition.maximum-file-size.undefined</note>
-        <jms:reference-file line="313">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="3e08813722e7959e982f4d8624c98b83d077cd55" resname="fielddefinition.maximum-file-size.value">
         <source>%max% MB</source>
         <target>%max% MB</target>
         <note>key: fielddefinition.maximum-file-size.value</note>
-        <jms:reference-file line="311">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b9bb83913e23ad5a59eb7485ca48386bd7fce66e" resname="fielddefinition.media-player-type.flash">
         <source>Flash</source>
         <target>Flash</target>
         <note>key: fielddefinition.media-player-type.flash</note>
-        <jms:reference-file line="182">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1c31870437c9baa0d08c67140d35fa54c6223922" resname="fielddefinition.media-player-type.html5_audio">
         <source>HTML5 Audio</source>
         <target>HTML5 Audio</target>
         <note>key: fielddefinition.media-player-type.html5_audio</note>
-        <jms:reference-file line="194">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="22881c3ebee12191bc6f269d943c1140eea4bfb1" resname="fielddefinition.media-player-type.html5_video">
         <source>HTML5 Video</source>
         <target>HTML5 Video</target>
         <note>key: fielddefinition.media-player-type.html5_video</note>
-        <jms:reference-file line="192">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0aaa90efdf7cc5042723e7500891db70da3f8850" resname="fielddefinition.media-player-type.label">
         <source>Media player type:</source>
         <target>Media player type:</target>
         <note>key: fielddefinition.media-player-type.label</note>
-        <jms:reference-file line="179">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c7a28f2ea418dc17e634bf386d5f1db091582fc8" resname="fielddefinition.media-player-type.quick_time">
         <source>Quicktime</source>
         <target>Quicktime</target>
         <note>key: fielddefinition.media-player-type.quick_time</note>
-        <jms:reference-file line="184">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="edd8db0307e234e095d1788540bd026e48e173f8" resname="fielddefinition.media-player-type.real_player">
         <source>Real Player</source>
         <target>Real Player</target>
         <note>key: fielddefinition.media-player-type.real_player</note>
-        <jms:reference-file line="186">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4ad14874021f1b806f9c93b41ef195b12fe5ab3f" resname="fielddefinition.media-player-type.silverlight">
         <source>Silverlight</source>
         <target>Silverlight</target>
         <note>key: fielddefinition.media-player-type.silverlight</note>
-        <jms:reference-file line="188">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="738ddf9e6b12ae22e5f8e62839f63221c24f1431" resname="fielddefinition.media-player-type.undefined">
         <source>No defined value</source>
         <target>No defined value</target>
         <note>key: fielddefinition.media-player-type.undefined</note>
-        <jms:reference-file line="196">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="61d9fc8a2cbcb067d39496dba7e884caf51cf245" resname="fielddefinition.media-player-type.windows_media_player">
         <source>Window Media Player</source>
         <target>Window Media Player</target>
         <note>key: fielddefinition.media-player-type.windows_media_player</note>
-        <jms:reference-file line="190">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ee5c85f0dae011c10d9d2bfb1fcd86e529c55536" resname="fielddefinition.min-length.label">
         <source>Min string length:</source>
-        <target state="new">Min string length:</target>
+        <target>Min string length:</target>
         <note>key: fielddefinition.min-length.label</note>
-        <jms:reference-file line="18">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="09fff8d9a67512b01bb3e58b5d25cf5d042ba195" resname="fielddefinition.min-length.undefined">
         <source>No defined minimum string length</source>
-        <target state="new">No defined minimum string length</target>
+        <target>No defined minimum string length</target>
         <note>key: fielddefinition.min-length.undefined</note>
-        <jms:reference-file line="23">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="904a83f949dd73a0bed006f8e78a211c80b4816a" resname="fielddefinition.min-length.value">
         <source>%min% characters</source>
-        <target state="new">%min% characters</target>
+        <target>%min% characters</target>
         <note>key: fielddefinition.min-length.value</note>
-        <jms:reference-file line="21">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1feb12108139bb4d34877c40ade8362c0872b528" resname="fielddefinition.min-value.label">
         <source>Minimum value:</source>
         <target>Minimum value:</target>
         <note>key: fielddefinition.min-value.label</note>
-        <jms:reference-file line="360">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="625d3f00da19e0e839ad54eb5cc6b3504033b882" resname="fielddefinition.min-value.undefined">
         <source>No defined minimum value</source>
         <target>No defined minimum value</target>
         <note>key: fielddefinition.min-value.undefined</note>
-        <jms:reference-file line="365">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="694dc611591facca075a581721e399e272b758fe" resname="fielddefinition.multiple.label">
         <source>Allow multiple choices:</source>
         <target>Allow multiple choices:</target>
         <note>key: fielddefinition.multiple.label</note>
-        <jms:reference-file line="386">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="ec31a6088a9e8cb3266bf0b99e057ca0677fcd82" resname="fielddefinition.multiple.yes">
-        <source>Yes</source>
-        <target>Yes</target>
-        <note>key: fielddefinition.multiple.yes</note>
-        <jms:reference-file line="387">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="0b8ef090df7e5c7780364c51f060db3f5b8f076a" resname="fielddefinition.multiple.no">
         <source>No</source>
         <target>No</target>
         <note>key: fielddefinition.multiple.no</note>
-        <jms:reference-file line="387">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ec31a6088a9e8cb3266bf0b99e057ca0677fcd82" resname="fielddefinition.multiple.yes">
+        <source>Yes</source>
+        <target>Yes</target>
+        <note>key: fielddefinition.multiple.yes</note>
       </trans-unit>
       <trans-unit id="4d59776118124c81734aacab8a71198ee555479c" resname="fielddefinition.options.label">
         <source>Defined options</source>
         <target>Defined options</target>
         <note>key: fielddefinition.options.label</note>
-        <jms:reference-file line="153">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="030aa959f56ae9ba0e1d84a99606995a02c5bd97" resname="fielddefinition.preferred-rows-number.label">
         <source>Preferred number of rows:</source>
         <target>Preferred number of rows:</target>
         <note>key: fielddefinition.preferred-rows-number.label</note>
-        <jms:reference-file line="321">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="f552c76a800b38e41d8b16afa53d3d22d3b37692" resname="fielddefinition.preferred-rows-number.undefined">
         <source>No preferred number of rows</source>
         <target>No preferred number of rows</target>
         <note>key: fielddefinition.preferred-rows-number.undefined</note>
-        <jms:reference-file line="326">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ac0aff5c558fb078621da0f46b2ae5b0e04afcaa" resname="fielddefinition.preferred-rows-number.value">
         <source>%rows% rows</source>
         <target>%rows% rows</target>
         <note>key: fielddefinition.preferred-rows-number.value</note>
-        <jms:reference-file line="324">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="b21527196a76acac750d478bfe8137cae7aff914" resname="fielddefinition.selection-method.browse">
         <source>Browse</source>
         <target>Browse</target>
         <note>key: fielddefinition.selection-method.browse</note>
-        <jms:reference-file line="215">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="234">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="02c78e1886bdf844e359ddd54b190eb718286557" resname="fielddefinition.selection-method.checkbox">
         <source>List with checkboxes</source>
         <target>List with checkboxes</target>
         <note>key: fielddefinition.selection-method.checkbox</note>
-        <jms:reference-file line="240">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="a60c81e556aa14c00b3b44ffb6e49f90b882c286" resname="fielddefinition.selection-method.label">
         <source>Selection method:</source>
         <target>Selection method:</target>
         <note>key: fielddefinition.selection-method.label</note>
-        <jms:reference-file line="212">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="231">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="cd94d6146477b427bdc6dbbe19be20bd6db31542" resname="fielddefinition.selection-method.list">
         <source>Drop-down list</source>
         <target>Drop-down list</target>
         <note>key: fielddefinition.selection-method.list</note>
-        <jms:reference-file line="217">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="236">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="7d8f219b8fc1dab2be8b6a82898b0e7a8920c928" resname="fielddefinition.selection-method.multi_template">
         <source>Template based, multi</source>
         <target>Template based, multi</target>
         <note>key: fielddefinition.selection-method.multi_template</note>
-        <jms:reference-file line="244">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="1095b3a335cbfeed0e396f081895affe81e7b7fd" resname="fielddefinition.selection-method.multiple_list">
         <source>Multiple selection list</source>
         <target>Multiple selection list</target>
         <note>key: fielddefinition.selection-method.multiple_list</note>
-        <jms:reference-file line="242">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="60f06115f038572328285e2ca1fc5ad811105c49" resname="fielddefinition.selection-method.radio">
         <source>List with radio buttons</source>
         <target>List with radio buttons</target>
         <note>key: fielddefinition.selection-method.radio</note>
-        <jms:reference-file line="238">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="37121f3c9e8054432510a9f85fd3235e5f549734" resname="fielddefinition.selection-method.single_template">
         <source>Template based, single</source>
         <target>Template based, single</target>
         <note>key: fielddefinition.selection-method.single_template</note>
-        <jms:reference-file line="246">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e0b6bc6950269d05c7318553912abe4042d6a423" resname="fielddefinition.selection-method.tree">
         <source>Drop-down tree</source>
         <target>Drop-down tree</target>
         <note>key: fielddefinition.selection-method.tree</note>
-        <jms:reference-file line="219">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="ccf4d68283a388e6a965caf9e507c6a39fffc46f" resname="fielddefinition.selection-root.label">
         <source>Selection root:</source>
         <target>Selection root:</target>
         <note>key: fielddefinition.selection-root.label</note>
-        <jms:reference-file line="334">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="c7b711d3eb6c197d83e064f309bd2e9791a0950d" resname="fielddefinition.selection-root.undefined">
         <source>No defined root</source>
         <target>No defined root</target>
         <note>key: fielddefinition.selection-root.undefined</note>
-        <jms:reference-file line="339">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4c9eb21a084528340d7944eeb0ffe525fc5e5e75" resname="fielddefinition.use-seconds.label">
         <source>Use seconds:</source>
         <target>Use seconds:</target>
         <note>key: fielddefinition.use-seconds.label</note>
-        <jms:reference-file line="122">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="96">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="edc26cd0186a48016fc5bc286c4d64e238043658" resname="fielddefinition.use-seconds.yes">
-        <source>Yes</source>
-        <target>Yes</target>
-        <note>key: fielddefinition.use-seconds.yes</note>
-        <jms:reference-file line="123">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="97">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="8c785cf266419d05f444b0e88bbf34f07c0b6fde" resname="fielddefinition.use-seconds.no">
         <source>No</source>
         <target>No</target>
         <note>key: fielddefinition.use-seconds.no</note>
-        <jms:reference-file line="123">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
-        <jms:reference-file line="97">src/bundle/Core/Resources/views/fielddefinition_settings.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="edc26cd0186a48016fc5bc286c4d64e238043658" resname="fielddefinition.use-seconds.yes">
+        <source>Yes</source>
+        <target>Yes</target>
+        <note>key: fielddefinition.use-seconds.yes</note>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Core/Resources/translations/forms.en.xlf
+++ b/src/bundle/Core/Resources/translations/forms.en.xlf
@@ -8,317 +8,317 @@
     <body>
       <trans-unit id="f52e45b25ff70b3d1d07c57911ceda58dcdf7431" resname="role.policy.class">
         <source>Content Type</source>
-        <target state="new">Content Type</target>
+        <target>Content Type</target>
         <note>key: role.policy.class</note>
       </trans-unit>
       <trans-unit id="2f746c35c587bdc84cacf38d0e63e08855e831ab" resname="role.policy.class.all_functions">
         <source>Content Type / All functions</source>
-        <target state="new">Content Type / All functions</target>
+        <target>Content Type / All functions</target>
         <note>key: role.policy.class.all_functions</note>
       </trans-unit>
       <trans-unit id="02049080d0f8dea3f723bbd1a280900b0657914e" resname="role.policy.class.create">
         <source>Content Type / Create</source>
-        <target state="new">Content Type / Create</target>
+        <target>Content Type / Create</target>
         <note>key: role.policy.class.create</note>
       </trans-unit>
       <trans-unit id="17ee6a3320ad9ac02c376bdcb875b266c28e34db" resname="role.policy.class.delete">
         <source>Content Type / Delete</source>
-        <target state="new">Content Type / Delete</target>
+        <target>Content Type / Delete</target>
         <note>key: role.policy.class.delete</note>
       </trans-unit>
       <trans-unit id="f47b14b0adc8b08abd44c37e801d6b2c3180a2ee" resname="role.policy.class.update">
         <source>Content Type / Update</source>
-        <target state="new">Content Type / Update</target>
+        <target>Content Type / Update</target>
         <note>key: role.policy.class.update</note>
       </trans-unit>
       <trans-unit id="ffe83a713e8b33558df040efa1eeadd0b1cc18e0" resname="role.policy.content">
         <source>Content</source>
-        <target state="new">Content</target>
+        <target>Content</target>
         <note>key: role.policy.content</note>
       </trans-unit>
       <trans-unit id="ea72f76a43bc0ec3eff965e68279dab5597b19c0" resname="role.policy.content.all_functions">
         <source>Content / All functions</source>
-        <target state="new">Content / All functions</target>
+        <target>Content / All functions</target>
         <note>key: role.policy.content.all_functions</note>
       </trans-unit>
       <trans-unit id="e050709df5ae56b1e9168038182f4c52221ffab9" resname="role.policy.content.cleantrash">
         <source>Content / Cleantrash</source>
-        <target state="new">Content / Cleantrash</target>
+        <target>Content / Cleantrash</target>
         <note>key: role.policy.content.cleantrash</note>
       </trans-unit>
       <trans-unit id="597c25abf1e2d91e50b82d2699f8b85f68c9f305" resname="role.policy.content.create">
         <source>Content / Create</source>
-        <target state="new">Content / Create</target>
+        <target>Content / Create</target>
         <note>key: role.policy.content.create</note>
       </trans-unit>
       <trans-unit id="019bae55ae37c03117c05eb25cc208e9b2396827" resname="role.policy.content.diff">
         <source>Content / Diff</source>
-        <target state="new">Content / Diff</target>
+        <target>Content / Diff</target>
         <note>key: role.policy.content.diff</note>
       </trans-unit>
       <trans-unit id="bdb3e6e10d770d20ffa7966acb58d3e9cf9805e2" resname="role.policy.content.edit">
         <source>Content / Edit</source>
-        <target state="new">Content / Edit</target>
+        <target>Content / Edit</target>
         <note>key: role.policy.content.edit</note>
       </trans-unit>
       <trans-unit id="1049e14eb7fec2dc053571f607e0eb044a06e455" resname="role.policy.content.hide">
         <source>Content / Hide</source>
-        <target state="new">Content / Hide</target>
+        <target>Content / Hide</target>
         <note>key: role.policy.content.hide</note>
       </trans-unit>
       <trans-unit id="d05f0b35c91f7d444c466871ff02886d74dc8f55" resname="role.policy.content.manage_locations">
         <source>Content / Manage locations</source>
-        <target state="new">Content / Manage locations</target>
+        <target>Content / Manage locations</target>
         <note>key: role.policy.content.manage_locations</note>
       </trans-unit>
       <trans-unit id="0c943bab11cd582ac439e67289d4efd86d8599e7" resname="role.policy.content.pendinglist">
         <source>Content / Pendinglist</source>
-        <target state="new">Content / Pendinglist</target>
+        <target>Content / Pendinglist</target>
         <note>key: role.policy.content.pendinglist</note>
       </trans-unit>
       <trans-unit id="6f595f392af03d8b2e46449d527530e3e1f8eb94" resname="role.policy.content.publish">
         <source>Content / Publish</source>
-        <target state="new">Content / Publish</target>
+        <target>Content / Publish</target>
         <note>key: role.policy.content.publish</note>
       </trans-unit>
       <trans-unit id="2b5e52d4783100540d791657f21d9dc1a9fbbb30" resname="role.policy.content.read">
         <source>Content / Read</source>
-        <target state="new">Content / Read</target>
+        <target>Content / Read</target>
         <note>key: role.policy.content.read</note>
       </trans-unit>
       <trans-unit id="967c7d2238b619a63fd0fe00bc0ccd4589e9de4f" resname="role.policy.content.remove">
         <source>Content / Remove</source>
-        <target state="new">Content / Remove</target>
+        <target>Content / Remove</target>
         <note>key: role.policy.content.remove</note>
       </trans-unit>
       <trans-unit id="4ce8821efab15ebdd683e28f0dcffaa352d1ef0f" resname="role.policy.content.restore">
         <source>Content / Restore</source>
-        <target state="new">Content / Restore</target>
+        <target>Content / Restore</target>
         <note>key: role.policy.content.restore</note>
       </trans-unit>
       <trans-unit id="7ad7cd36512ca57f6d6cb31b7de0740d4754961c" resname="role.policy.content.reverserelatedlist">
         <source>Content / Reverserelatedlist</source>
-        <target state="new">Content / Reverserelatedlist</target>
+        <target>Content / Reverserelatedlist</target>
         <note>key: role.policy.content.reverserelatedlist</note>
       </trans-unit>
       <trans-unit id="c9a69e432793ed3480c2252f3ca1b4e6564e853e" resname="role.policy.content.translate">
         <source>Content / Translate</source>
-        <target state="new">Content / Translate</target>
+        <target>Content / Translate</target>
         <note>key: role.policy.content.translate</note>
       </trans-unit>
       <trans-unit id="3f9650d96394bc9e6d53360117d2dd3d6842735f" resname="role.policy.content.translations">
         <source>Content / Translations</source>
-        <target state="new">Content / Translations</target>
+        <target>Content / Translations</target>
         <note>key: role.policy.content.translations</note>
       </trans-unit>
       <trans-unit id="74ccbb06e1226201f9642eefa451b67360a4145b" resname="role.policy.content.unlock">
         <source>Content / Unlock</source>
-        <target state="new">Content / Unlock</target>
+        <target>Content / Unlock</target>
         <note>key: role.policy.content.unlock</note>
       </trans-unit>
       <trans-unit id="79ffa7a2f2449d08574ef7c5b1f447b439db97b2" resname="role.policy.content.urltranslator">
         <source>Content / Urltranslator</source>
-        <target state="new">Content / Urltranslator</target>
+        <target>Content / Urltranslator</target>
         <note>key: role.policy.content.urltranslator</note>
       </trans-unit>
       <trans-unit id="0a641d7ab31b48b6b87a9d2cd4763afae237219d" resname="role.policy.content.versionread">
         <source>Content / Versionread</source>
-        <target state="new">Content / Versionread</target>
+        <target>Content / Versionread</target>
         <note>key: role.policy.content.versionread</note>
       </trans-unit>
       <trans-unit id="4e615fcc14a6f5b70fb3e7957518c27bc508d92f" resname="role.policy.content.versionremove">
         <source>Content / Versionremove</source>
-        <target state="new">Content / Versionremove</target>
+        <target>Content / Versionremove</target>
         <note>key: role.policy.content.versionremove</note>
       </trans-unit>
       <trans-unit id="6ff0bcc1b70d0dbde113af7649393f667612cace" resname="role.policy.role">
         <source>Role</source>
-        <target state="new">Role</target>
+        <target>Role</target>
         <note>key: role.policy.role</note>
       </trans-unit>
       <trans-unit id="17f55c17c76ccfcf636ce429b867f89069609bcd" resname="role.policy.role.all_functions">
         <source>Role / All functions</source>
-        <target state="new">Role / All functions</target>
+        <target>Role / All functions</target>
         <note>key: role.policy.role.all_functions</note>
       </trans-unit>
       <trans-unit id="cf922ebcfc51ae098cb57a938984916e03c0481c" resname="role.policy.role.assign">
         <source>Role / Assign</source>
-        <target state="new">Role / Assign</target>
+        <target>Role / Assign</target>
         <note>key: role.policy.role.assign</note>
       </trans-unit>
       <trans-unit id="f12cc8bc381274c232a90deae7ce981dbc3634cb" resname="role.policy.role.create">
         <source>Role / Create</source>
-        <target state="new">Role / Create</target>
+        <target>Role / Create</target>
         <note>key: role.policy.role.create</note>
       </trans-unit>
       <trans-unit id="d17c0339a48c6e273c56673c31037427fd95ecee" resname="role.policy.role.delete">
         <source>Role / Delete</source>
-        <target state="new">Role / Delete</target>
+        <target>Role / Delete</target>
         <note>key: role.policy.role.delete</note>
       </trans-unit>
       <trans-unit id="1e809cc5ab4e914e5dc51fa2dc0a6b62a90bc2f1" resname="role.policy.role.read">
         <source>Role / Read</source>
-        <target state="new">Role / Read</target>
+        <target>Role / Read</target>
         <note>key: role.policy.role.read</note>
       </trans-unit>
       <trans-unit id="2f8dccfd705bd25a633826ff76f595e118a71dcf" resname="role.policy.role.update">
         <source>Role / Update</source>
-        <target state="new">Role / Update</target>
+        <target>Role / Update</target>
         <note>key: role.policy.role.update</note>
       </trans-unit>
       <trans-unit id="7153cdd53211bedab219659c1d1656693d3bb4ae" resname="role.policy.section">
         <source>Section</source>
-        <target state="new">Section</target>
+        <target>Section</target>
         <note>key: role.policy.section</note>
       </trans-unit>
       <trans-unit id="f5e387481bf702e73317dcbccff5d55fc111550e" resname="role.policy.section.all_functions">
         <source>Section / All functions</source>
-        <target state="new">Section / All functions</target>
+        <target>Section / All functions</target>
         <note>key: role.policy.section.all_functions</note>
       </trans-unit>
       <trans-unit id="2f63b236417b33905613e757497387c99e47a848" resname="role.policy.section.assign">
         <source>Section / Assign</source>
-        <target state="new">Section / Assign</target>
+        <target>Section / Assign</target>
         <note>key: role.policy.section.assign</note>
       </trans-unit>
       <trans-unit id="9ce67233e7377c7ac36c6ccbdf1a49a582aca59d" resname="role.policy.section.edit">
         <source>Section / Edit</source>
-        <target state="new">Section / Edit</target>
+        <target>Section / Edit</target>
         <note>key: role.policy.section.edit</note>
       </trans-unit>
       <trans-unit id="c80fb60940421ce0b94226255211ec10dc9208b4" resname="role.policy.section.view">
         <source>Section / View</source>
-        <target state="new">Section / View</target>
+        <target>Section / View</target>
         <note>key: role.policy.section.view</note>
       </trans-unit>
       <trans-unit id="5f165ef2e938f6710b56e2e8ee416414e430b77c" resname="role.policy.setting">
         <source>Setting</source>
-        <target state="new">Setting</target>
+        <target>Setting</target>
         <note>key: role.policy.setting</note>
       </trans-unit>
       <trans-unit id="8775d52b987252ee1ad0867fe4f9e23dec668b5b" resname="role.policy.setting.all_functions">
         <source>Setting / All functions</source>
-        <target state="new">Setting / All functions</target>
+        <target>Setting / All functions</target>
         <note>key: role.policy.setting.all_functions</note>
       </trans-unit>
       <trans-unit id="686f427740ca0cf4df247266b8a1300d747cf3a4" resname="role.policy.setting.create">
         <source>Setting / Create</source>
-        <target state="new">Setting / Create</target>
+        <target>Setting / Create</target>
         <note>key: role.policy.setting.create</note>
       </trans-unit>
       <trans-unit id="d41141e8fa3c214bc546a6925304c15ee9a28022" resname="role.policy.setting.remove">
         <source>Setting / Remove</source>
-        <target state="new">Setting / Remove</target>
+        <target>Setting / Remove</target>
         <note>key: role.policy.setting.remove</note>
       </trans-unit>
       <trans-unit id="14fa9c5afba9d51072c6a66dede46535b718f77e" resname="role.policy.setting.update">
         <source>Setting / Update</source>
-        <target state="new">Setting / Update</target>
+        <target>Setting / Update</target>
         <note>key: role.policy.setting.update</note>
       </trans-unit>
       <trans-unit id="33092ebd51699d4d3f598b8488e7bc5969038bff" resname="role.policy.setup">
         <source>Setup</source>
-        <target state="new">Setup</target>
+        <target>Setup</target>
         <note>key: role.policy.setup</note>
       </trans-unit>
       <trans-unit id="a72fa98205c4f68fc53506f9b57e645be450ce86" resname="role.policy.setup.administrate">
         <source>Setup / Administrate</source>
-        <target state="new">Setup / Administrate</target>
+        <target>Setup / Administrate</target>
         <note>key: role.policy.setup.administrate</note>
       </trans-unit>
       <trans-unit id="df52828e26336a4a6f3186e0d6eb75d98056aeaa" resname="role.policy.setup.all_functions">
         <source>Setup / All functions</source>
-        <target state="new">Setup / All functions</target>
+        <target>Setup / All functions</target>
         <note>key: role.policy.setup.all_functions</note>
       </trans-unit>
       <trans-unit id="32c1032c29386bcf41793f2542b3476887249bc5" resname="role.policy.setup.install">
         <source>Setup / Install</source>
-        <target state="new">Setup / Install</target>
+        <target>Setup / Install</target>
         <note>key: role.policy.setup.install</note>
       </trans-unit>
       <trans-unit id="4ce0aa17f80167751257ddb6e0cc8e06ca9c1bbb" resname="role.policy.setup.setup">
         <source>Setup / Setup</source>
-        <target state="new">Setup / Setup</target>
+        <target>Setup / Setup</target>
         <note>key: role.policy.setup.setup</note>
       </trans-unit>
       <trans-unit id="a77dcd2893dc76a7e94fe088b775045fde8651e4" resname="role.policy.setup.system_info">
         <source>Setup / System info</source>
-        <target state="new">Setup / System info</target>
+        <target>Setup / System info</target>
         <note>key: role.policy.setup.system_info</note>
       </trans-unit>
       <trans-unit id="012dce76ef569ba377ffe98ddbee8d3c3d270e15" resname="role.policy.state">
         <source>State</source>
-        <target state="new">State</target>
+        <target>State</target>
         <note>key: role.policy.state</note>
       </trans-unit>
       <trans-unit id="0dc3b2e6978f026be583bcf078e15c4157a51d19" resname="role.policy.state.administrate">
         <source>State / Administrate</source>
-        <target state="new">State / Administrate</target>
+        <target>State / Administrate</target>
         <note>key: role.policy.state.administrate</note>
       </trans-unit>
       <trans-unit id="5a57c4086c786d6c767dfca68486d64c60ec58bf" resname="role.policy.state.all_functions">
         <source>State / All functions</source>
-        <target state="new">State / All functions</target>
+        <target>State / All functions</target>
         <note>key: role.policy.state.all_functions</note>
       </trans-unit>
       <trans-unit id="8c144b2e58f6ba9388517a5929bfd12a0773ddd2" resname="role.policy.state.assign">
         <source>State / Assign</source>
-        <target state="new">State / Assign</target>
+        <target>State / Assign</target>
         <note>key: role.policy.state.assign</note>
       </trans-unit>
       <trans-unit id="78b9d0d52e636ef2d0d1f919de16154404c2be0f" resname="role.policy.user">
         <source>User</source>
-        <target state="new">User</target>
+        <target>User</target>
         <note>key: role.policy.user</note>
       </trans-unit>
       <trans-unit id="647dfa7992026277b6d73295b2ffaefe4cfa12d0" resname="role.policy.user.activation">
         <source>User / Activation</source>
-        <target state="new">User / Activation</target>
+        <target>User / Activation</target>
         <note>key: role.policy.user.activation</note>
       </trans-unit>
       <trans-unit id="d44ce8c33cbc780cff9ca6f05ad2f70002550cd0" resname="role.policy.user.all_functions">
         <source>User / All functions</source>
-        <target state="new">User / All functions</target>
+        <target>User / All functions</target>
         <note>key: role.policy.user.all_functions</note>
       </trans-unit>
       <trans-unit id="587199065d14880416b8061b73788e731a201c27" resname="role.policy.user.invite">
         <source>User / Invite</source>
-        <target state="new">User / Invite</target>
+        <target>User / Invite</target>
         <note>key: role.policy.user.invite</note>
       </trans-unit>
       <trans-unit id="f25505dc2f59df21e3125664c4fdad951d82df3b" resname="role.policy.user.login">
         <source>User / Login</source>
-        <target state="new">User / Login</target>
+        <target>User / Login</target>
         <note>key: role.policy.user.login</note>
       </trans-unit>
       <trans-unit id="d971078868184d3d233fb14032fda9ef614c2baa" resname="role.policy.user.password">
         <source>User / Password</source>
-        <target state="new">User / Password</target>
+        <target>User / Password</target>
         <note>key: role.policy.user.password</note>
       </trans-unit>
       <trans-unit id="28d15501824f89951d4068af32fbc52eb1412b8d" resname="role.policy.user.preferences">
         <source>User / Preferences</source>
-        <target state="new">User / Preferences</target>
+        <target>User / Preferences</target>
         <note>key: role.policy.user.preferences</note>
       </trans-unit>
       <trans-unit id="8f79f6008557e588c0a8b13ccdc42d6babc073c9" resname="role.policy.user.register">
         <source>User / Register</source>
-        <target state="new">User / Register</target>
+        <target>User / Register</target>
         <note>key: role.policy.user.register</note>
       </trans-unit>
       <trans-unit id="106b2a3fa38c660c838efe1905c904ce689a2d75" resname="role.policy.user.selfedit">
         <source>User / Selfedit</source>
-        <target state="new">User / Selfedit</target>
+        <target>User / Selfedit</target>
         <note>key: role.policy.user.selfedit</note>
       </trans-unit>
       <trans-unit id="caaf0c6eabe978a17eefcedf501b2506383a8267" resname="role.policy.user.update">
         <source>User / Update</source>
-        <target state="new">User / Update</target>
+        <target>User / Update</target>
         <note>key: role.policy.user.update</note>
       </trans-unit>
       <trans-unit id="b445a673ef3c893b783c58b6fd4b2469224a04db" resname="role.policy.user.view">
         <source>User / View</source>
-        <target state="new">User / View</target>
+        <target>User / View</target>
         <note>key: role.policy.user.view</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/messages.en.xlf
+++ b/src/bundle/Core/Resources/translations/messages.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-01-26T14:55:58Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -10,32 +10,26 @@
         <source>Enter login or email</source>
         <target>Enter login or email</target>
         <note>key: Enter login or email</note>
-        <jms:reference-file line="18">src/bundle/Core/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="570591c060a999e9ab1592763c74d881b7654ee1" resname="Enter password">
         <source>Enter password</source>
         <target>Enter password</target>
         <note>key: Enter password</note>
-        <jms:reference-file line="22">src/bundle/Core/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4e5a2893bdcc7d239c1db72e4c4ffbe4bea73174" resname="Login">
         <source>Login</source>
         <target>Login</target>
         <note>key: Login</note>
-        <jms:reference-file line="32">src/bundle/Core/Resources/views/Security/login.html.twig</jms:reference-file>
-        <jms:reference-file line="6">src/bundle/Core/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="be81ab98cb9ccf753975f50fa70cd32581a821fc" resname="Password:">
         <source>Password:</source>
         <target>Password:</target>
         <note>key: Password:</note>
-        <jms:reference-file line="21">src/bundle/Core/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="17dfb031e086e3415d71f3928e6ce08d6b1c1d4d" resname="Username:">
         <source>Username:</source>
         <target>Username:</target>
         <note>key: Username:</note>
-        <jms:reference-file line="17">src/bundle/Core/Resources/views/Security/login.html.twig</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/src/bundle/Core/Resources/translations/repository_exceptions.en.xlf
+++ b/src/bundle/Core/Resources/translations/repository_exceptions.en.xlf
@@ -1,242 +1,140 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-01-26T14:55:58Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
-      <trans-unit id="c2993e6873e928a2a635698ce582b4aba5748643" resname="'%actualValue%' is wrong value">
-        <source>'%actualValue%' is wrong value</source>
-        <target>'%actualValue%' is wrong value</target>
-        <note>key: '%actualValue%' is wrong value</note>
-        <jms:reference-file line="32">src/lib/Base/Exceptions/InvalidArgumentValue.php</jms:reference-file>
+      <trans-unit id="bdaae3444afba4eebebe2e0f684a0e56e81afafd" resname="'%actualValue%' is incorrect value">
+        <source>'%actualValue%' is incorrect value</source>
+        <target>'%actualValue%' is incorrect value</target>
+        <note>key: '%actualValue%' is incorrect value</note>
       </trans-unit>
-      <trans-unit id="7a87971cc45ac957c7db1a4907f8e7f4325e3e32" resname="'%actualValue%' is wrong value in class '%className%'">
-        <source>'%actualValue%' is wrong value in class '%className%'</source>
-        <target>'%actualValue%' is wrong value in class '%className%'</target>
-        <note>key: '%actualValue%' is wrong value in class '%className%'</note>
-        <jms:reference-file line="34">src/lib/Base/Exceptions/InvalidArgumentValue.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="894070fe84612fd5871c1b09bc79f85c2e17d384" resname="A value is set for non translatable field definition '%identifier%' with language '%languageCode%'">
-        <source>A value is set for non translatable field definition '%identifier%' with language '%languageCode%'</source>
-        <target>A value is set for non translatable field definition '%identifier%' with language '%languageCode%'</target>
-        <note>key: A value is set for non translatable field definition '%identifier%' with language '%languageCode%'</note>
-        <jms:reference-file line="1410">src/lib/Repository/ContentService.php</jms:reference-file>
-        <jms:reference-file line="770">src/lib/Repository/ContentService.php</jms:reference-file>
+      <trans-unit id="4769b7caf9489fa7d54ca298414c0f10a5f43a56" resname="'%actualValue%' is incorrect value in class '%className%'">
+        <source>'%actualValue%' is incorrect value in class '%className%'</source>
+        <target>'%actualValue%' is incorrect value in class '%className%'</target>
+        <note>key: '%actualValue%' is incorrect value in class '%className%'</note>
       </trans-unit>
       <trans-unit id="80e5a0a47ac1df407b0218c2283872a86aba0fc1" resname="Argument '%argumentName%' has a bad state: %whatIsWrong%">
         <source>Argument '%argumentName%' has a bad state: %whatIsWrong%</source>
         <target>Argument '%argumentName%' has a bad state: %whatIsWrong%</target>
         <note>key: Argument '%argumentName%' has a bad state: %whatIsWrong%</note>
-        <jms:reference-file line="34">src/lib/Base/Exceptions/BadStateException.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ec22a1547bcd0b3131346b94db7783d8ba4fc12f" resname="Argument '%argumentName%' is invalid: %whatIsWrong%">
         <source>Argument '%argumentName%' is invalid: %whatIsWrong%</source>
         <target>Argument '%argumentName%' is invalid: %whatIsWrong%</target>
         <note>key: Argument '%argumentName%' is invalid: %whatIsWrong%</note>
-        <jms:reference-file line="34">src/lib/Base/Exceptions/InvalidArgumentException.php</jms:reference-file>
       </trans-unit>
-      <trans-unit id="5184b29eed2fee5c130959375be31ea55010adb8" resname="Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%'">
-        <source>Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%'</source>
-        <target>Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%'</target>
-        <note>key: Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%'</note>
-        <jms:reference-file line="31">src/lib/Base/Exceptions/InvalidArgumentType.php</jms:reference-file>
+      <trans-unit id="ddc2eb42746874988689fbc618bce5487f245b5c" resname="Argument '%argumentName%' is invalid: value must be of type '%expectedType%'">
+        <source>Argument '%argumentName%' is invalid: value must be of type '%expectedType%'</source>
+        <target>Argument '%argumentName%' is invalid: value must be of type '%expectedType%'</target>
+        <note>key: Argument '%argumentName%' is invalid: value must be of type '%expectedType%'</note>
       </trans-unit>
-      <trans-unit id="77a999c48ddb299d4c8af74d195bdf44dda4883c" resname="Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%', got '%actualType%'">
-        <source>Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%', got '%actualType%'</source>
-        <target>Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%', got '%actualType%'</target>
-        <note>key: Argument '%argumentName%' is invalid: expected value to be of type '%expectedType%', got '%actualType%'</note>
-        <jms:reference-file line="33">src/lib/Base/Exceptions/InvalidArgumentType.php</jms:reference-file>
+      <trans-unit id="ea737c09fcf59eb54ff1a1caca4242bdb2afda03" resname="Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'">
+        <source>Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'</source>
+        <target>Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'</target>
+        <note>key: Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'</note>
       </trans-unit>
       <trans-unit id="6a5a5e4df0f09cc7587d11571aa90c31e68c15c6" resname="Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'">
         <source>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'</source>
         <target>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'</target>
         <note>key: Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'</note>
-        <jms:reference-file line="17">src/lib/IO/Exception/InvalidBinaryAbsolutePathException.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="0afe736d44da00b87ed3fe777775661ddf10a455" resname="Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?">
         <source>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?</source>
         <target>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?</target>
         <note>key: Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?</note>
-        <jms:reference-file line="17">src/lib/IO/Exception/InvalidBinaryPrefixException.php</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="e88ed78511f95299a41927e3ca7336fed174046b" resname="Content &quot;%contentName%&quot; fields did not validate: %errors%">
+        <source>Content "%contentName%" fields did not validate: %errors%</source>
+        <target>Content "%contentName%" fields did not validate: %errors%</target>
+        <note>key: Content "%contentName%" fields did not validate: %errors%</note>
+      </trans-unit>
+      <trans-unit id="d131d81a8ed3356159fd8a6f013268356ed5caec" resname="Content Type Field definitions did not validate">
+        <source>Content Type Field definitions did not validate</source>
+        <target>Content Type Field definitions did not validate</target>
+        <note>key: Content Type Field definitions did not validate</note>
       </trans-unit>
       <trans-unit id="8967aa151e1b84f60c505163d42350eb6a96e948" resname="Content fields did not validate">
         <source>Content fields did not validate</source>
         <target>Content fields did not validate</target>
         <note>key: Content fields did not validate</note>
-        <jms:reference-file line="45">src/lib/Base/Exceptions/ContentFieldValidationException.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="ebf71981c65ff4930b2b3f704b9e5383e92e06a6" resname="Content type cannot be unlinked from the only remaining group">
-        <source>Content type cannot be unlinked from the only remaining group</source>
-        <target>Content type cannot be unlinked from the only remaining group</target>
-        <note>key: Content type cannot be unlinked from the only remaining group</note>
-        <jms:reference-file line="857">src/lib/REST/Server/Controller/ContentType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="632a0a349b256b80469d59a604d24a52eea93c56" resname="Content type is already linked to provided group">
-        <source>Content type is already linked to provided group</source>
-        <target>Content type is already linked to provided group</target>
-        <note>key: Content type is already linked to provided group</note>
-        <jms:reference-file line="811">src/lib/REST/Server/Controller/ContentType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="1423a591f045a16c96d4b1c11d2c5bdc86ae19a6" resname="ContentType FieldDefinitions did not validate">
-        <source>ContentType FieldDefinitions did not validate</source>
-        <target>ContentType FieldDefinitions did not validate</target>
-        <note>key: ContentType FieldDefinitions did not validate</note>
-        <jms:reference-file line="45">src/lib/Base/Exceptions/ContentTypeFieldDefinitionValidationException.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="dbf0b883e33a6e7c433ffa9a536fd214cda39b5c" resname="Could not find %classType% class '%className%'">
         <source>Could not find %classType% class '%className%'</source>
         <target>Could not find %classType% class '%className%'</target>
         <note>key: Could not find %classType% class '%className%'</note>
-        <jms:reference-file line="41">src/lib/Base/Exceptions/MissingClass.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="ff3e1dacaa764a0e94a86b173f9c93509fcaadeb" resname="Could not find '%what%' with identifier '%identifier%'">
         <source>Could not find '%what%' with identifier '%identifier%'</source>
         <target>Could not find '%what%' with identifier '%identifier%'</target>
         <note>key: Could not find '%what%' with identifier '%identifier%'</note>
-        <jms:reference-file line="36">src/lib/Base/Exceptions/NotFoundException.php</jms:reference-file>
       </trans-unit>
       <trans-unit id="2b84fad03f5a98d0fa25c78b1d3717ba108835e6" resname="Could not find class '%className%'">
         <source>Could not find class '%className%'</source>
         <target>Could not find class '%className%'</target>
         <note>key: Could not find class '%className%'</note>
-        <jms:reference-file line="39">src/lib/Base/Exceptions/MissingClass.php</jms:reference-file>
       </trans-unit>
-      <trans-unit id="2f4e9f3ca70239ade7c9789a3da3c26b1216fb16" resname="Current version is already in status DRAFT">
-        <source>Current version is already in status DRAFT</source>
-        <target>Current version is already in status DRAFT</target>
-        <note>key: Current version is already in status DRAFT</note>
-        <jms:reference-file line="410">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
+      <trans-unit id="c6136a74d1562ea6d15321ee75b9b307fc787e79" resname="Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%">
+        <source>Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%</source>
+        <target>Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%</target>
+        <note>key: Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%</note>
       </trans-unit>
-      <trans-unit id="577ff380f946adc384c1ca853ac1e7c21a0cba41" resname="Empty content type draft cannot be published">
-        <source>Empty content type draft cannot be published</source>
-        <target>Empty content type draft cannot be published</target>
-        <note>key: Empty content type draft cannot be published</note>
-        <jms:reference-file line="708">src/lib/REST/Server/Controller/ContentType.php</jms:reference-file>
+      <trans-unit id="e709d874ef06d490889e00bb7765c720f18ddf5f" resname="Field definition '%identifier%' does not exist in given Content Type">
+        <source>Field definition '%identifier%' does not exist in given Content Type</source>
+        <target>Field definition '%identifier%' does not exist in given Content Type</target>
+        <note>key: Field definition '%identifier%' does not exist in given Content Type</note>
       </trans-unit>
-      <trans-unit id="64614c5387b9921b33bfe34d6a6d88283a97d119" resname="Field definition '%identifier%' does not exist in given ContentType">
-        <source>Field definition '%identifier%' does not exist in given ContentType</source>
-        <target>Field definition '%identifier%' does not exist in given ContentType</target>
-        <note>key: Field definition '%identifier%' does not exist in given ContentType</note>
-        <jms:reference-file line="1394">src/lib/Repository/ContentService.php</jms:reference-file>
-        <jms:reference-file line="756">src/lib/Repository/ContentService.php</jms:reference-file>
+      <trans-unit id="5cfc2b732a8368cdd7f3d64ca4ab90a1af2939fb" resname="Field definition '%identifier%' does not exist in the given Content Type">
+        <source>Field definition '%identifier%' does not exist in the given Content Type</source>
+        <target>Field definition '%identifier%' does not exist in the given Content Type</target>
+        <note>key: Field definition '%identifier%' does not exist in the given Content Type</note>
       </trans-unit>
-      <trans-unit id="097b8a2bc1db5e54deb4aa00b0e0483fe1af27a4" resname="FieldType '%fieldType%' not found, needs to be implemented or configured to use FieldType\Null\Type">
-        <source>FieldType '%fieldType%' not found, needs to be implemented or configured to use FieldType\Null\Type</source>
-        <target>FieldType '%fieldType%' not found, needs to be implemented or configured to use FieldType\Null\Type</target>
-        <note>key: FieldType '%fieldType%' not found, needs to be implemented or configured to use FieldType\Null\Type</note>
-        <jms:reference-file line="32">src/lib/Base/Exceptions/NotFound/FieldTypeNotFoundException.php</jms:reference-file>
+      <trans-unit id="c6f0fd742d6b8ce0686dc4e7a3a070efbf924204" resname="Invalid URL wildcards provided.">
+        <source>Invalid URL wildcards provided.</source>
+        <target>Invalid URL wildcards provided.</target>
+        <note>key: Invalid URL wildcards provided.</note>
       </trans-unit>
-      <trans-unit id="25f2ccabd8883a36aee5754ce43741c211cf378a" resname="FieldType '%identifier%' is singular and can't be repeated in a ContentType">
-        <source>FieldType '%identifier%' is singular and can't be repeated in a ContentType</source>
-        <target>FieldType '%identifier%' is singular and can't be repeated in a ContentType</target>
-        <note>key: FieldType '%identifier%' is singular and can't be repeated in a ContentType</note>
-      </trans-unit>
-      <trans-unit id="b592a161a19d303272498874fb27a71626461be7" resname="Limitation '%limitation%' not found, needs to be implemented or configured to use Limitation\BlockingLimitationType">
-        <source>Limitation '%limitation%' not found, needs to be implemented or configured to use Limitation\BlockingLimitationType</source>
-        <target>Limitation '%limitation%' not found, needs to be implemented or configured to use Limitation\BlockingLimitationType</target>
-        <note>key: Limitation '%limitation%' not found, needs to be implemented or configured to use Limitation\BlockingLimitationType</note>
-        <jms:reference-file line="32">src/lib/Base/Exceptions/NotFound/LimitationNotFoundException.php</jms:reference-file>
+      <trans-unit id="87d1caa3303a7197201d77b1bcb03ae38356097b" resname="Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%">
+        <source>Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</source>
+        <target>Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</target>
+        <note>key: Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</note>
       </trans-unit>
       <trans-unit id="71fd5f8839faaadfe7c61def7e4b42d429959952" resname="Limitations did not validate">
         <source>Limitations did not validate</source>
         <target>Limitations did not validate</target>
         <note>key: Limitations did not validate</note>
-        <jms:reference-file line="40">src/lib/Base/Exceptions/LimitationValidationException.php</jms:reference-file>
       </trans-unit>
-      <trans-unit id="f915c78ee350c1b4fb3d3adac7584a12fcc0cfdf" resname="Only empty content type groups can be deleted">
-        <source>Only empty content type groups can be deleted</source>
-        <target>Only empty content type groups can be deleted</target>
-        <note>key: Only empty content type groups can be deleted</note>
-        <jms:reference-file line="141">src/lib/REST/Server/Controller/ContentType.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="87b49727a4d83168066183cbed772c1bbdfb63f8" resname="Only version in status DRAFT can be published">
-        <source>Only version in status DRAFT can be published</source>
-        <target>Only version in status DRAFT can be published</target>
-        <note>key: Only version in status DRAFT can be published</note>
-        <jms:reference-file line="513">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="d75253ee3a0502ae44236a6556419822252f8849" resname="Only version in status DRAFT can be updated">
-        <source>Only version in status DRAFT can be updated</source>
-        <target>Only version in status DRAFT can be updated</target>
-        <note>key: Only version in status DRAFT can be updated</note>
-        <jms:reference-file line="461">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="3467ebb6448f4d8dd9f8a99cbea79415f25fa26d" resname="Path '%path%' already exists for the given context">
+      <trans-unit id="ef12e750e94380df0d1de86b1cc274b45dc94e94" resname="Path '%path%' already exists for the given context">
         <source>Path '%path%' already exists for the given context</source>
         <target>Path '%path%' already exists for the given context</target>
         <note>key: Path '%path%' already exists for the given context</note>
-        <jms:reference-file line="397">src/lib/Persistence/Legacy/Content/UrlAlias/Handler.php</jms:reference-file>
       </trans-unit>
-      <trans-unit id="b2d83ff8d535b64b36eaab04237a3091fc10ee5a" resname="Placeholders are not matching with wildcards.">
-        <source>Placeholders are not matching with wildcards.</source>
-        <target>Placeholders are not matching with wildcards.</target>
-        <note>key: Placeholders are not matching with wildcards.</note>
-        <jms:reference-file line="102">src/lib/Repository/URLWildcardService.php</jms:reference-file>
+      <trans-unit id="300b5656b51de352e89aa5d7dd4ec6abb173bf6f" resname="Placeholders do not match the wildcards.">
+        <source>Placeholders do not match the wildcards.</source>
+        <target>Placeholders do not match the wildcards.</target>
+        <note>key: Placeholders do not match the wildcards.</note>
       </trans-unit>
-      <trans-unit id="d750946e6e0689d003a701bf1db100b12a742c4f" resname="Provided content type does not contain ezuser field type">
-        <source>Provided content type does not contain ezuser field type</source>
-        <target>Provided content type does not contain ezuser field type</target>
-        <note>key: Provided content type does not contain ezuser field type</note>
-        <jms:reference-file line="422">src/lib/Repository/UserService.php</jms:reference-file>
+      <trans-unit id="1677f5311a0f3fc35be40d540553e892d187618e" resname="The User does not have the '%function%' '%module%' permission">
+        <source>The User does not have the '%function%' '%module%' permission</source>
+        <target>The User does not have the '%function%' '%module%' permission</target>
+        <note>key: The User does not have the '%function%' '%module%' permission</note>
       </trans-unit>
-      <trans-unit id="c13178e601c4bf79ad9ef57efe468ed438a9b167" resname="Relation is not of type COMMON">
-        <source>Relation is not of type COMMON</source>
-        <target>Relation is not of type COMMON</target>
-        <note>key: Relation is not of type COMMON</note>
-        <jms:reference-file line="645">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
+      <trans-unit id="250a16261172f0d2985c8bec3a2b06280f7c863b" resname="The User does not have the '%function%' '%module%' permission with: %with%">
+        <source>The User does not have the '%function%' '%module%' permission with: %with%</source>
+        <target>The User does not have the '%function%' '%module%' permission with: %with%</target>
+        <note>key: The User does not have the '%function%' '%module%' permission with: %with%</note>
       </trans-unit>
-      <trans-unit id="8da63ffae0f9707c46ca02d66e9074e7f9f538d6" resname="Relation of type COMMON can only be added to drafts">
-        <source>Relation of type COMMON can only be added to drafts</source>
-        <target>Relation of type COMMON can only be added to drafts</target>
-        <note>key: Relation of type COMMON can only be added to drafts</note>
-        <jms:reference-file line="684">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
+      <trans-unit id="27a77deaffe8551b169928675adc64ae8450937f" resname="User &quot;%login%&quot; already exists">
+        <source>User "%login%" already exists</source>
+        <target>User "%login%" already exists</target>
+        <note>key: User "%login%" already exists</note>
       </trans-unit>
-      <trans-unit id="388dae35f493b4e06e6458455f4837b1691fd72b" resname="Relation of type COMMON can only be removed from drafts">
-        <source>Relation of type COMMON can only be removed from drafts</source>
-        <target>Relation of type COMMON can only be removed from drafts</target>
-        <note>key: Relation of type COMMON can only be removed from drafts</note>
-        <jms:reference-file line="649">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="30ea10f44d07a5752ed9c57a8458b3579b8dd421" resname="Relation of type COMMON to selected destination content ID already exists">
-        <source>Relation of type COMMON to selected destination content ID already exists</source>
-        <target>Relation of type COMMON to selected destination content ID already exists</target>
-        <note>key: Relation of type COMMON to selected destination content ID already exists</note>
-        <jms:reference-file line="696">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="09683b2a73d28421548e01bfbd6cc468095fa29d" resname="User does not have access to '%function%' '%module%'">
-        <source>User does not have access to '%function%' '%module%'</source>
-        <target>User does not have access to '%function%' '%module%'</target>
-        <note>key: User does not have access to '%function%' '%module%'</note>
-        <jms:reference-file line="38">src/lib/Base/Exceptions/UnauthorizedException.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="649224015306dff4831eceb63d49e66d7c0c4f1b" resname="User does not have access to '%function%' '%module%' with: %with%'">
-        <source>User does not have access to '%function%' '%module%' with: %with%'</source>
-        <target>User does not have access to '%function%' '%module%' with: %with%'</target>
-        <note>key: User does not have access to '%function%' '%module%' with: %with%'</note>
-        <jms:reference-file line="42">src/lib/Base/Exceptions/UnauthorizedException.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="dfb77818edfca3ee72ed24e16c643a84203ecfa7" resname="Version in status PUBLISHED cannot be deleted">
-        <source>Version in status PUBLISHED cannot be deleted</source>
-        <target>Version in status PUBLISHED cannot be deleted</target>
-        <note>key: Version in status PUBLISHED cannot be deleted</note>
-        <jms:reference-file line="354">src/lib/REST/Server/Controller/Content.php</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="f80f674916004d986500fe18b36ff55286191490" resname="expected value to be of type '%expectedType%'">
-        <source>expected value to be of type '%expectedType%'</source>
-        <target>expected value to be of type '%expectedType%'</target>
-        <note>key: expected value to be of type '%expectedType%'</note>
-      </trans-unit>
-      <trans-unit id="5f722d4df65d72e23fbf62ea8a5adadaf249413c" resname="expected value to be of type '%expectedType%', got '%actualType%'">
-        <source>expected value to be of type '%expectedType%', got '%actualType%'</source>
-        <target>expected value to be of type '%expectedType%', got '%actualType%'</target>
-        <note>key: expected value to be of type '%expectedType%', got '%actualType%'</note>
-      </trans-unit>
-      <trans-unit id="9307ee9a550b5c318fbbd6f5750e95d1de1d3483" resname="non_verbose_error">
-        <source>An error has occurred. Please try again later or contact your Administrator.</source>
-        <target>An error has occurred. Please try again later or contact your Administrator.</target>
-        <note>key: non_verbose_error</note>
+      <trans-unit id="e37bafa4a8807f7a425f8d967cadc8e704c629b3" resname="You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'">
+        <source>You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'</source>
+        <target>You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'</target>
+        <note>key: You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'</note>
       </trans-unit>
     </body>
   </file>

--- a/src/lib/Base/Exceptions/ContentTypeValidationException.php
+++ b/src/lib/Base/Exceptions/ContentTypeValidationException.php
@@ -9,6 +9,7 @@ namespace Ibexa\Core\Base\Exceptions;
 use Ibexa\Contracts\Core\Repository\Exceptions\ContentTypeValidationException as APIContentTypeValidationException;
 use Ibexa\Core\Base\Translatable;
 use Ibexa\Core\Base\TranslatableBase;
+use JMS\TranslationBundle\Annotation\Ignore;
 
 /**
  * This Exception is thrown on create or update content type when content type is not valid.
@@ -25,8 +26,7 @@ class ContentTypeValidationException extends APIContentTypeValidationException i
      */
     public function __construct($messageTemplate, array $parameters = [])
     {
-        /** @Ignore */
-        $this->setMessageTemplate($messageTemplate);
+        $this->setMessageTemplate(/** @Ignore */$messageTemplate);
         $this->setParameters($parameters);
 
         parent::__construct($this->getBaseTranslation());

--- a/src/lib/Base/Exceptions/ContentValidationException.php
+++ b/src/lib/Base/Exceptions/ContentValidationException.php
@@ -9,6 +9,7 @@ namespace Ibexa\Core\Base\Exceptions;
 use Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException as APIContentValidationException;
 use Ibexa\Core\Base\Translatable;
 use Ibexa\Core\Base\TranslatableBase;
+use JMS\TranslationBundle\Annotation\Ignore;
 
 /**
  * This Exception is thrown on create or update content one or more given fields are not valid.
@@ -25,8 +26,7 @@ class ContentValidationException extends APIContentValidationException implement
      */
     public function __construct($messageTemplate, array $parameters = [])
     {
-        /** @Ignore */
-        $this->setMessageTemplate($messageTemplate);
+        $this->setMessageTemplate(/** @Ignore */$messageTemplate);
         $this->setParameters($parameters);
 
         parent::__construct($this->getBaseTranslation());

--- a/src/lib/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
+++ b/src/lib/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
@@ -7,6 +7,7 @@
 namespace Ibexa\Core\Helper\FieldsGroups;
 
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -39,6 +40,7 @@ final class ArrayTranslatorFieldsGroupsList implements FieldsGroupsList
 
         foreach ($this->groups as $groupIdentifier) {
             $translatedGroups[$groupIdentifier] = $this->translator->trans(
+                /** @Ignore */
                 $groupIdentifier,
                 [],
                 'ezplatform_fields_groups'

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/FileSizeExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/FileSizeExtension.php
@@ -8,6 +8,7 @@ namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Locale\LocaleConverterInterface;
+use JMS\TranslationBundle\Annotation\Ignore;
 use Locale;
 use NumberFormatter;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -110,7 +111,9 @@ class FileSizeExtension extends AbstractExtension
             $i = ($index - 1);
         }
         $formatter = new NumberFormatter($this->getLocale(), NumberFormatter::PATTERN_DECIMAL);
-        $formatter->setPattern($formatter->getPattern() . ' ' . $this->translator->trans($this->suffixes[$i]));
+        $formatter->setPattern(
+            $formatter->getPattern() . ' ' . $this->translator->trans(/** @Ignore */$this->suffixes[$i])
+        );
         $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $precision);
 
         return $formatter->format($number);

--- a/src/lib/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitor.php
+++ b/src/lib/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitor.php
@@ -6,13 +6,81 @@
  */
 namespace Ibexa\Core\MVC\Symfony\Translation;
 
+use Doctrine\Common\Annotations\DocParser;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\File\DefaultPhpFileExtractor;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeTraverser;
+use Psr\Log\LoggerInterface;
+use SplFileInfo;
 
 class ExceptionMessageTemplateFileVisitor extends DefaultPhpFileExtractor
 {
-    protected $methodsToExtractFrom = ['setmessagetemplate' => -1];
+    /** @var int[] */
+    protected $methodsToExtractFrom = ['setMessageTemplate' => -1];
 
-    protected $defaultDomain = 'repository_exceptions';
+    protected string $defaultDomain = 'repository_exceptions';
+
+    private FileSourceFactory $fileSourceFactory;
+
+    private NodeTraverser $traverser;
+
+    private SplFileInfo $file;
+
+    private MessageCatalogue $catalogue;
+
+    private LoggerInterface $logger;
+
+    public function __construct(DocParser $docParser, FileSourceFactory $fileSourceFactory)
+    {
+        parent::__construct($docParser, $fileSourceFactory);
+        $this->fileSourceFactory = $fileSourceFactory;
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor($this);
+    }
+
+    public function enterNode(Node $node): void
+    {
+        $methodCallNodeName = null;
+        if ($node instanceof Node\Expr\MethodCall) {
+            $methodCallNodeName = $node->name instanceof Node\Identifier ? $node->name->name : $node->name;
+        }
+        if (
+            !is_string($methodCallNodeName)
+            || !array_key_exists($methodCallNodeName, $this->methodsToExtractFrom)
+        ) {
+            return;
+        }
+
+        if (!$node->args[0]->value instanceof String_) {
+            $message = sprintf('Can only extract the translation id from a scalar string, but got "%s". Please refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
+
+            $this->logger->error($message);
+
+            return;
+        }
+
+        $id = $node->args[0]->value->value;
+
+        $message = new Message($id, $this->defaultDomain);
+        $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
+        $this->catalogue->add($message);
+    }
+
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast): void
+    {
+        $this->file = $file;
+        $this->catalogue = $catalogue;
+        $this->traverser->traverse($ast);
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
 }
 
 class_alias(ExceptionMessageTemplateFileVisitor::class, 'eZ\Publish\Core\MVC\Symfony\Translation\ExceptionMessageTemplateFileVisitor');

--- a/src/lib/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitor.php
+++ b/src/lib/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitor.php
@@ -14,12 +14,14 @@ use JMS\TranslationBundle\Translation\FileSourceFactory;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\NodeTraverser;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use SplFileInfo;
 
 class ExceptionMessageTemplateFileVisitor extends DefaultPhpFileExtractor
 {
-    /** @var int[] */
+    use LoggerAwareTrait;
+
+    /** @var array<string, int> */
     protected $methodsToExtractFrom = ['setMessageTemplate' => -1];
 
     protected string $defaultDomain = 'repository_exceptions';
@@ -31,8 +33,6 @@ class ExceptionMessageTemplateFileVisitor extends DefaultPhpFileExtractor
     private SplFileInfo $file;
 
     private MessageCatalogue $catalogue;
-
-    private LoggerInterface $logger;
 
     public function __construct(DocParser $docParser, FileSourceFactory $fileSourceFactory)
     {
@@ -75,11 +75,6 @@ class ExceptionMessageTemplateFileVisitor extends DefaultPhpFileExtractor
         $this->file = $file;
         $this->catalogue = $catalogue;
         $this->traverser->traverse($ast);
-    }
-
-    public function setLogger(LoggerInterface $logger): void
-    {
-        $this->logger = $logger;
     }
 }
 

--- a/tests/lib/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitorTest.php
+++ b/tests/lib/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitorTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Translation;
+
+use Doctrine\Common\Annotations\DocParser;
+use Ibexa\Core\MVC\Symfony\Translation\ExceptionMessageTemplateFileVisitor;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\FileSourceFactory;
+use PhpParser\Lexer;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use SplFileInfo;
+
+final class ExceptionMessageTemplateFileVisitorTest extends TestCase
+{
+    private const FIXTURES_DIR = __DIR__ . '/fixtures/';
+
+    private Parser $phpParser;
+
+    private ExceptionMessageTemplateFileVisitor $exceptionMessageTemplateFileVisitor;
+
+    protected function setUp(): void
+    {
+        $docParser = new DocParser();
+        $fileSourceFactory = new FileSourceFactory(
+            self::FIXTURES_DIR,
+        );
+        $lexer = new Lexer();
+        $factory = new ParserFactory();
+        $this->phpParser = $factory->create(ParserFactory::PREFER_PHP7, $lexer);
+        $this->exceptionMessageTemplateFileVisitor = new ExceptionMessageTemplateFileVisitor(
+            $docParser,
+            $fileSourceFactory
+        );
+    }
+
+    public function testExtractTranslation(): void
+    {
+        $messageCatalogue = new MessageCatalogue();
+        $file = self::FIXTURES_DIR . 'SetMessageTemplate.php';
+        $fileInfo = new SplFileInfo($file);
+
+        $ast = $this->phpParser->parse(file_get_contents($file));
+        $this->exceptionMessageTemplateFileVisitor->visitPhpFile(
+            $fileInfo,
+            $messageCatalogue,
+            $ast
+        );
+
+        $expectedMessage = new Message('Foo exception', 'repository_exceptions');
+
+        self::assertTrue(
+            $messageCatalogue->has($expectedMessage)
+        );
+    }
+
+    public function testNoTranslationToExtract(): void
+    {
+        $messageCatalogue = new MessageCatalogue();
+        $file = self::FIXTURES_DIR . 'NoTranslationToExtract.php';
+        $fileInfo = new SplFileInfo($file);
+
+        $ast = $this->phpParser->parse(file_get_contents($file));
+        $this->exceptionMessageTemplateFileVisitor->visitPhpFile(
+            $fileInfo,
+            $messageCatalogue,
+            $ast
+        );
+
+        self::assertEmpty($messageCatalogue->getDomains());
+    }
+
+    public function testWrongTranslationId(): void
+    {
+        $messageCatalogue = new MessageCatalogue();
+        $file = self::FIXTURES_DIR . 'WrongTranslationId.php';
+        $fileInfo = new SplFileInfo($file);
+
+        $ast = $this->phpParser->parse(file_get_contents($file));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('error');
+
+        $this->exceptionMessageTemplateFileVisitor->setLogger($logger);
+        $this->exceptionMessageTemplateFileVisitor->visitPhpFile(
+            $fileInfo,
+            $messageCatalogue,
+            $ast
+        );
+    }
+}

--- a/tests/lib/MVC/Symfony/Translation/fixtures/NoTranslationToExtract.php
+++ b/tests/lib/MVC/Symfony/Translation/fixtures/NoTranslationToExtract.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Translation\fixtures;
+
+use Exception;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException as APIInvalidArgumentException;
+use Ibexa\Core\Base\Translatable;
+use Ibexa\Core\Base\TranslatableBase;
+
+final class NoTranslationToExtract extends APIInvalidArgumentException implements Translatable
+{
+    use TranslatableBase;
+
+    public function __construct(?Exception $previous = null)
+    {
+        parent::__construct($this->getBaseTranslation(), 0, $previous);
+    }
+}

--- a/tests/lib/MVC/Symfony/Translation/fixtures/SetMessageTemplate.php
+++ b/tests/lib/MVC/Symfony/Translation/fixtures/SetMessageTemplate.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Translation\fixtures;
+
+use Exception;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException as APIInvalidArgumentException;
+use Ibexa\Core\Base\Translatable;
+use Ibexa\Core\Base\TranslatableBase;
+
+final class SetMessageTemplate extends APIInvalidArgumentException implements Translatable
+{
+    use TranslatableBase;
+
+    public function __construct(?Exception $previous = null)
+    {
+        $this->setMessageTemplate('Foo exception');
+
+        parent::__construct($this->getBaseTranslation(), 0, $previous);
+    }
+}

--- a/tests/lib/MVC/Symfony/Translation/fixtures/WrongTranslationId.php
+++ b/tests/lib/MVC/Symfony/Translation/fixtures/WrongTranslationId.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Translation\fixtures;
+
+use Exception;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException as APIInvalidArgumentException;
+use Ibexa\Core\Base\Translatable;
+use Ibexa\Core\Base\TranslatableBase;
+
+final class WrongTranslationId extends APIInvalidArgumentException implements Translatable
+{
+    use TranslatableBase;
+
+    public function __construct(?Exception $previous = null)
+    {
+        $this->setMessageTemplate(['foo']);
+
+        parent::__construct($this->getBaseTranslation(), 0, $previous);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

Because of this error wrong translation domain was created (messages) during the process of translation extraction in the `ibexa/seo` package. The correct domain should be `repository_exceptions`. The file in the `seo` package could be found here https://github.com/ibexa/seo/blob/main/src/bundle/Resources/translations/repository_exceptions.en.xliff. 

#### Checklist:
- [ ] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
