### PR TITLE
IBX-5817: Exposed UserService::getUserContentTypeIdentifiers public API

### DIFF
--- a/src/contracts/Repository/Decorator/UserServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/UserServiceDecorator.php
@@ -245,6 +245,11 @@ abstract class UserServiceDecorator implements UserService
     {
         return $this->innerService->getPasswordInfo($user);
     }
+
+    public function getUserContentTypeIdentifiers(): array
+    {
+        return $this->innerService->getUserContentTypeIdentifiers();
+    }
 }
 
 class_alias(UserServiceDecorator::class, 'eZ\Publish\SPI\Repository\Decorator\UserServiceDecorator');

--- a/src/contracts/Repository/UserService.php
+++ b/src/contracts/Repository/UserService.php
@@ -406,6 +406,13 @@ interface UserService
      * @return \Ibexa\Contracts\Core\Repository\Values\User\PasswordInfo
      */
     public function getPasswordInfo(User $user): PasswordInfo;
+
+    /**
+     * Returns configured list of User Content Type identifiers.
+     *
+     * @return array<string>
+     */
+    public function getUserContentTypeIdentifiers(): array;
 }
 
 class_alias(UserService::class, 'eZ\Publish\API\Repository\UserService');

--- a/src/lib/Repository/SiteAccessAware/UserService.php
+++ b/src/lib/Repository/SiteAccessAware/UserService.php
@@ -227,6 +227,11 @@ class UserService implements UserServiceInterface
     {
         return $this->service->getPasswordInfo($user);
     }
+
+    public function getUserContentTypeIdentifiers(): array
+    {
+        return $this->service->getUserContentTypeIdentifiers();
+    }
 }
 
 class_alias(UserService::class, 'eZ\Publish\Core\Repository\SiteAccessAware\UserService');

--- a/src/lib/Repository/UserService.php
+++ b/src/lib/Repository/UserService.php
@@ -1394,10 +1394,7 @@ class UserService implements UserServiceInterface
         return null;
     }
 
-    /**
-     * @return string[]
-     */
-    private function getUserContentTypeIdentifiers(): array
+    public function getUserContentTypeIdentifiers(): array
     {
         return $this->configResolver->getParameter('user_content_type_identifier');
     }

--- a/tests/integration/Core/Repository/UserServiceTest.php
+++ b/tests/integration/Core/Repository/UserServiceTest.php
@@ -3265,6 +3265,12 @@ class UserServiceTest extends BaseTest
         $this->assertEquals(new PasswordInfo($expectedPasswordExpirationDate, null), $passwordInfo);
     }
 
+    public function testGetUserContentTypeIdentifiers(): void
+    {
+        $userService = $this->getRepository()->getUserService();
+        self::assertEquals(['user'], $userService->getUserContentTypeIdentifiers());
+    }
+
     public function createTestUser(ContentType $contentType): User
     {
         return $this->createTestUserWithPassword(self::EXAMPLE_PASSWORD, $contentType);

--- a/tests/lib/Repository/SiteAccessAware/UserServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/UserServiceTest.php
@@ -80,6 +80,8 @@ class UserServiceTest extends AbstractServiceTest
             ['checkUserCredentials', [$user, 'H@xi0r!']],
             ['validatePassword', ['H@xi0r!', $passwordValidationContext], []],
             ['getPasswordInfo', [$user], new PasswordInfo()],
+
+            ['getUserContentTypeIdentifiers', [], ['user']],
         ];
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5817](https://issues.ibexa.co/browse/IBX-5817)
| **Required by**                            | https://github.com/ibexa/corporate-account/pull/194
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no, consumer API changes

This PR exposes pre-existing private `UserService::getUserContentTypeIdentifiers` as public API. It could be helpful when implementing [IBX-5817](https://issues.ibexa.co/browse/IBX-5817) to build proper query from within the package. The package should have no knowledge which configuration setting returns that information. Exposing dedicated API was quick and made more sense.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
