### PR TITLE
IBX-5915: Added way to revoke existing token

### DIFF
--- a/src/bundle/Core/Resources/config/storage/legacy/schema.yaml
+++ b/src/bundle/Core/Resources/config/storage/legacy/schema.yaml
@@ -663,3 +663,4 @@ tables:
             identifier: { type: string, nullable: true, length: 128 }
             created: { type: integer, nullable: false, options: { default: '0' } }
             expires: { type: integer, nullable: false, options: { default: '0' } }
+            revoked: { type: boolean, nullable: false, options: { default: '0' } }

--- a/src/contracts/Persistence/Token/Handler.php
+++ b/src/contracts/Persistence/Token/Handler.php
@@ -29,6 +29,8 @@ interface Handler
 
     public function createToken(CreateStruct $createStruct): Token;
 
+    public function revokeTokenById(int $tokenId): void;
+
     public function deleteToken(Token $token): void;
 
     public function deleteTokenById(int $tokenId): void;

--- a/src/contracts/Persistence/Token/Handler.php
+++ b/src/contracts/Persistence/Token/Handler.php
@@ -31,6 +31,8 @@ interface Handler
 
     public function revokeTokenById(int $tokenId): void;
 
+    public function revokeTokenByIdentifier(string $tokenType, ?string $identifier): void;
+
     public function deleteToken(Token $token): void;
 
     public function deleteTokenById(int $tokenId): void;

--- a/src/contracts/Persistence/Token/Token.php
+++ b/src/contracts/Persistence/Token/Token.php
@@ -26,4 +26,6 @@ final class Token extends ValueObject
     public int $created;
 
     public int $expires;
+
+    public bool $revoked;
 }

--- a/src/contracts/Repository/Decorator/TokenServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/TokenServiceDecorator.php
@@ -67,6 +67,11 @@ abstract class TokenServiceDecorator implements TokenService
         $this->innerService->revokeToken($token);
     }
 
+    public function revokeTokenByIdentifier(string $tokenType, ?string $identifier): void
+    {
+        $this->innerService->revokeTokenByIdentifier($tokenType, $identifier);
+    }
+
     public function deleteToken(Token $token): void
     {
         $this->innerService->deleteToken($token);

--- a/src/contracts/Repository/Decorator/TokenServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/TokenServiceDecorator.php
@@ -62,6 +62,11 @@ abstract class TokenServiceDecorator implements TokenService
         );
     }
 
+    public function revokeToken(Token $token): void
+    {
+        $this->innerService->revokeToken($token);
+    }
+
     public function deleteToken(Token $token): void
     {
         $this->innerService->deleteToken($token);

--- a/src/contracts/Repository/Events/Token/BeforeRevokeTokenByIdentifierEvent.php
+++ b/src/contracts/Repository/Events/Token/BeforeRevokeTokenByIdentifierEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Events\Token;
+
+use Ibexa\Contracts\Core\Repository\Event\AfterEvent;
+
+final class BeforeRevokeTokenByIdentifierEvent extends AfterEvent
+{
+    private string $tokenType;
+
+    private ?string $identifier;
+
+    public function __construct(string $tokenType, ?string $identifier)
+    {
+        $this->tokenType = $tokenType;
+        $this->identifier = $identifier;
+    }
+
+    public function getTokenType(): string
+    {
+        return $this->tokenType;
+    }
+
+    public function getIdentifier(): ?string
+    {
+        return $this->identifier;
+    }
+}

--- a/src/contracts/Repository/Events/Token/BeforeRevokeTokenEvent.php
+++ b/src/contracts/Repository/Events/Token/BeforeRevokeTokenEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Events\Token;
+
+use Ibexa\Contracts\Core\Repository\Event\BeforeEvent;
+use Ibexa\Contracts\Core\Repository\Values\Token\Token;
+
+final class BeforeRevokeTokenEvent extends BeforeEvent
+{
+    private Token $token;
+
+    public function __construct(Token $token)
+    {
+        $this->token = $token;
+    }
+
+    public function getToken(): Token
+    {
+        return $this->token;
+    }
+}

--- a/src/contracts/Repository/Events/Token/RevokeTokenByIdentifierEvent.php
+++ b/src/contracts/Repository/Events/Token/RevokeTokenByIdentifierEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Events\Token;
+
+use Ibexa\Contracts\Core\Repository\Event\AfterEvent;
+
+final class RevokeTokenByIdentifierEvent extends AfterEvent
+{
+    private string $tokenType;
+
+    private ?string $identifier;
+
+    public function __construct(string $tokenType, ?string $identifier)
+    {
+        $this->tokenType = $tokenType;
+        $this->identifier = $identifier;
+    }
+
+    public function getTokenType(): string
+    {
+        return $this->tokenType;
+    }
+
+    public function getIdentifier(): ?string
+    {
+        return $this->identifier;
+    }
+}

--- a/src/contracts/Repository/Events/Token/RevokeTokenEvent.php
+++ b/src/contracts/Repository/Events/Token/RevokeTokenEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Events\Token;
+
+use Ibexa\Contracts\Core\Repository\Event\AfterEvent;
+use Ibexa\Contracts\Core\Repository\Values\Token\Token;
+
+final class RevokeTokenEvent extends AfterEvent
+{
+    private Token $token;
+
+    public function __construct(Token $token)
+    {
+        $this->token = $token;
+    }
+
+    public function getToken(): Token
+    {
+        return $this->token;
+    }
+}

--- a/src/contracts/Repository/TokenService.php
+++ b/src/contracts/Repository/TokenService.php
@@ -36,5 +36,7 @@ interface TokenService
         ?TokenGeneratorInterface $tokenGenerator = null
     ): Token;
 
+    public function revokeToken(Token $token): void;
+
     public function deleteToken(Token $token): void;
 }

--- a/src/contracts/Repository/TokenService.php
+++ b/src/contracts/Repository/TokenService.php
@@ -38,5 +38,7 @@ interface TokenService
 
     public function revokeToken(Token $token): void;
 
+    public function revokeTokenByIdentifier(string $tokenType, ?string $identifier): void;
+
     public function deleteToken(Token $token): void;
 }

--- a/src/contracts/Repository/Values/Token/Token.php
+++ b/src/contracts/Repository/Values/Token/Token.php
@@ -27,13 +27,16 @@ final class Token extends ValueObject
 
     private DateTimeImmutable $expires;
 
+    private bool $revoked;
+
     public function __construct(
         int $id,
         string $type,
         string $token,
         ?string $identifier,
         DateTimeImmutable $created,
-        DateTimeImmutable $expires
+        DateTimeImmutable $expires,
+        bool $revoked
     ) {
         parent::__construct();
 
@@ -43,6 +46,7 @@ final class Token extends ValueObject
         $this->identifier = $identifier;
         $this->created = $created;
         $this->expires = $expires;
+        $this->revoked = $revoked;
     }
 
     public function getId(): int
@@ -73,6 +77,11 @@ final class Token extends ValueObject
     public function getExpires(): DateTimeImmutable
     {
         return $this->expires;
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revoked;
     }
 
     public function __toString(): string

--- a/src/lib/Event/TokenService.php
+++ b/src/lib/Event/TokenService.php
@@ -13,11 +13,13 @@ use Ibexa\Contracts\Core\Repository\Events\Token\BeforeCheckTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\BeforeDeleteTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\BeforeGenerateTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\BeforeGetTokenEvent;
+use Ibexa\Contracts\Core\Repository\Events\Token\BeforeRevokeTokenByIdentifierEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\BeforeRevokeTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\CheckTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\DeleteTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\GenerateTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\GetTokenEvent;
+use Ibexa\Contracts\Core\Repository\Events\Token\RevokeTokenByIdentifierEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\RevokeTokenEvent;
 use Ibexa\Contracts\Core\Repository\TokenService as TokenServiceInterface;
 use Ibexa\Contracts\Core\Repository\Values\Token\Token;
@@ -147,6 +149,24 @@ final class TokenService extends TokenServiceDecorator
 
         $this->eventDispatcher->dispatch(
             new RevokeTokenEvent(...$eventData)
+        );
+    }
+
+    public function revokeTokenByIdentifier(string $tokenType, ?string $identifier): void
+    {
+        $eventData = [$tokenType, $identifier];
+
+        $beforeEvent = new BeforeRevokeTokenByIdentifierEvent(...$eventData);
+
+        $this->eventDispatcher->dispatch($beforeEvent);
+        if ($beforeEvent->isPropagationStopped()) {
+            return;
+        }
+
+        $this->innerService->revokeTokenByIdentifier($tokenType, $identifier);
+
+        $this->eventDispatcher->dispatch(
+            new RevokeTokenByIdentifierEvent(...$eventData)
         );
     }
 }

--- a/src/lib/Event/TokenService.php
+++ b/src/lib/Event/TokenService.php
@@ -13,10 +13,12 @@ use Ibexa\Contracts\Core\Repository\Events\Token\BeforeCheckTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\BeforeDeleteTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\BeforeGenerateTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\BeforeGetTokenEvent;
+use Ibexa\Contracts\Core\Repository\Events\Token\BeforeRevokeTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\CheckTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\DeleteTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\GenerateTokenEvent;
 use Ibexa\Contracts\Core\Repository\Events\Token\GetTokenEvent;
+use Ibexa\Contracts\Core\Repository\Events\Token\RevokeTokenEvent;
 use Ibexa\Contracts\Core\Repository\TokenService as TokenServiceInterface;
 use Ibexa\Contracts\Core\Repository\Values\Token\Token;
 use Ibexa\Contracts\Core\Token\TokenGeneratorInterface;
@@ -127,6 +129,24 @@ final class TokenService extends TokenServiceDecorator
 
         $this->eventDispatcher->dispatch(
             new DeleteTokenEvent(...$eventData)
+        );
+    }
+
+    public function revokeToken(Token $token): void
+    {
+        $eventData = [$token];
+
+        $beforeEvent = new BeforeRevokeTokenEvent(...$eventData);
+
+        $this->eventDispatcher->dispatch($beforeEvent);
+        if ($beforeEvent->isPropagationStopped()) {
+            return;
+        }
+
+        $this->innerService->revokeToken($token);
+
+        $this->eventDispatcher->dispatch(
+            new RevokeTokenEvent(...$eventData)
         );
     }
 }

--- a/src/lib/Persistence/Legacy/Token/Gateway/Token/Doctrine/DoctrineGateway.php
+++ b/src/lib/Persistence/Legacy/Token/Gateway/Token/Doctrine/DoctrineGateway.php
@@ -30,6 +30,8 @@ final class DoctrineGateway extends AbstractGateway implements Gateway
     public const COLUMN_IDENTIFIER = 'identifier';
     public const COLUMN_CREATED = 'created';
     public const COLUMN_EXPIRES = 'expires';
+
+    public const COLUMN_REVOKED = 'revoked';
     public const TOKEN_SEQ = 'ibexa_token_id_seq';
 
     private Connection $connection;
@@ -48,6 +50,7 @@ final class DoctrineGateway extends AbstractGateway implements Gateway
             self::COLUMN_IDENTIFIER,
             self::COLUMN_CREATED,
             self::COLUMN_EXPIRES,
+            self::COLUMN_REVOKED,
         ];
     }
 
@@ -66,15 +69,33 @@ final class DoctrineGateway extends AbstractGateway implements Gateway
                 self::COLUMN_IDENTIFIER => $identifier,
                 self::COLUMN_CREATED => $now,
                 self::COLUMN_EXPIRES => $now + $ttl,
+                self::COLUMN_REVOKED => false,
             ],
             [
                 self::COLUMN_TYPE_ID => ParameterType::INTEGER,
                 self::COLUMN_CREATED => ParameterType::INTEGER,
                 self::COLUMN_EXPIRES => ParameterType::INTEGER,
+                self::COLUMN_REVOKED => ParameterType::BOOLEAN,
             ]
         );
 
         return (int)$this->connection->lastInsertId(self::TOKEN_SEQ);
+    }
+
+    public function revoke(int $tokenId): void
+    {
+        $this->connection->update(
+            self::TABLE_NAME,
+            [
+                self::COLUMN_REVOKED => true,
+            ],
+            [
+                self::COLUMN_ID => $tokenId,
+            ],
+            [
+                self::COLUMN_REVOKED => ParameterType::BOOLEAN,
+            ]
+        );
     }
 
     public function delete(int $tokenId): void

--- a/src/lib/Persistence/Legacy/Token/Gateway/Token/Doctrine/DoctrineGateway.php
+++ b/src/lib/Persistence/Legacy/Token/Gateway/Token/Doctrine/DoctrineGateway.php
@@ -30,8 +30,8 @@ final class DoctrineGateway extends AbstractGateway implements Gateway
     public const COLUMN_IDENTIFIER = 'identifier';
     public const COLUMN_CREATED = 'created';
     public const COLUMN_EXPIRES = 'expires';
-
     public const COLUMN_REVOKED = 'revoked';
+
     public const TOKEN_SEQ = 'ibexa_token_id_seq';
 
     private Connection $connection;

--- a/src/lib/Persistence/Legacy/Token/Gateway/Token/Doctrine/DoctrineGateway.php
+++ b/src/lib/Persistence/Legacy/Token/Gateway/Token/Doctrine/DoctrineGateway.php
@@ -98,6 +98,23 @@ final class DoctrineGateway extends AbstractGateway implements Gateway
         );
     }
 
+    public function revokeByIdentifier(int $typeId, ?string $identifier): void
+    {
+        $this->connection->update(
+            self::TABLE_NAME,
+            [
+                self::COLUMN_REVOKED => true,
+            ],
+            [
+                self::COLUMN_TYPE_ID => $typeId,
+                self::COLUMN_IDENTIFIER => $identifier,
+            ],
+            [
+                self::COLUMN_REVOKED => ParameterType::BOOLEAN,
+            ]
+        );
+    }
+
     public function delete(int $tokenId): void
     {
         $this->connection->delete(

--- a/src/lib/Persistence/Legacy/Token/Gateway/Token/Gateway.php
+++ b/src/lib/Persistence/Legacy/Token/Gateway/Token/Gateway.php
@@ -20,6 +20,8 @@ interface Gateway
         int $ttl
     ): int;
 
+    public function revoke(int $tokenId): void;
+
     /**
      * @throws \Doctrine\DBAL\Exception
      */

--- a/src/lib/Persistence/Legacy/Token/Gateway/Token/Gateway.php
+++ b/src/lib/Persistence/Legacy/Token/Gateway/Token/Gateway.php
@@ -22,6 +22,11 @@ interface Gateway
 
     public function revoke(int $tokenId): void;
 
+    public function revokeByIdentifier(
+        int $typeId,
+        ?string $identifier
+    ): void;
+
     /**
      * @throws \Doctrine\DBAL\Exception
      */

--- a/src/lib/Persistence/Legacy/Token/Handler.php
+++ b/src/lib/Persistence/Legacy/Token/Handler.php
@@ -104,6 +104,11 @@ final class Handler implements HandlerInterface
         );
     }
 
+    public function revokeTokenById(int $tokenId): void
+    {
+        $this->tokenGateway->revoke($tokenId);
+    }
+
     public function deleteToken(Token $token): void
     {
         $this->deleteTokenById($token->id);

--- a/src/lib/Persistence/Legacy/Token/Handler.php
+++ b/src/lib/Persistence/Legacy/Token/Handler.php
@@ -109,6 +109,20 @@ final class Handler implements HandlerInterface
         $this->tokenGateway->revoke($tokenId);
     }
 
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \Doctrine\DBAL\Driver\Exception
+     */
+    public function revokeTokenByIdentifier(string $tokenType, ?string $identifier): void
+    {
+        $type = $this->getTokenType($tokenType);
+        $this->tokenGateway->revokeByIdentifier(
+            $type->id,
+            $identifier
+        );
+    }
+
     public function deleteToken(Token $token): void
     {
         $this->deleteTokenById($token->id);

--- a/src/lib/Persistence/Legacy/Token/Mapper.php
+++ b/src/lib/Persistence/Legacy/Token/Mapper.php
@@ -25,6 +25,7 @@ final class Mapper
             'identifier' => $tokenRow['identifier'] === null ? null : (string)$tokenRow['identifier'],
             'created' => (int)$tokenRow['created'],
             'expires' => (int)$tokenRow['expires'],
+            'revoked' => (bool)$tokenRow['revoked'],
         ]);
     }
 

--- a/src/lib/Repository/TokenService.php
+++ b/src/lib/Repository/TokenService.php
@@ -109,6 +109,11 @@ final class TokenService implements TokenServiceInterface
         $this->persistenceHandler->revokeTokenById($token->getId());
     }
 
+    public function revokeTokenByIdentifier(string $tokenType, ?string $identifier): void
+    {
+        $this->persistenceHandler->revokeTokenByIdentifier($tokenType, $identifier);
+    }
+
     public function deleteToken(Token $token): void
     {
         $this->persistenceHandler->deleteTokenById($token->getId());

--- a/src/lib/Repository/TokenService.php
+++ b/src/lib/Repository/TokenService.php
@@ -65,9 +65,9 @@ final class TokenService implements TokenServiceInterface
         ?string $identifier = null
     ): bool {
         try {
-            $this->getToken($tokenType, $token, $identifier);
+            $token = $this->getToken($tokenType, $token, $identifier);
 
-            return true;
+            return !$token->isRevoked();
         } catch (NotFoundException|UnauthorizedException $exception) {
             return false;
         }
@@ -104,6 +104,11 @@ final class TokenService implements TokenServiceInterface
         );
     }
 
+    public function revokeToken(Token $token): void
+    {
+        $this->persistenceHandler->revokeTokenById($token->getId());
+    }
+
     public function deleteToken(Token $token): void
     {
         $this->persistenceHandler->deleteTokenById($token->getId());
@@ -122,7 +127,8 @@ final class TokenService implements TokenServiceInterface
             $token->token,
             $token->identifier,
             new DateTimeImmutable('@' . $token->created),
-            new DateTimeImmutable('@' . $token->expires)
+            new DateTimeImmutable('@' . $token->expires),
+            $token->revoked
         );
     }
 }

--- a/tests/integration/Core/Repository/TokenServiceTest.php
+++ b/tests/integration/Core/Repository/TokenServiceTest.php
@@ -49,6 +49,7 @@ final class TokenServiceTest extends IbexaKernelTestCase
         self::assertSame($type, $token->getType());
         self::assertSame($identifier, $token->getIdentifier());
         self::assertSame($length, strlen($token->getToken()));
+        self::assertFalse($token->isRevoked());
     }
 
     /**
@@ -117,6 +118,37 @@ final class TokenServiceTest extends IbexaKernelTestCase
         self::assertEquals(
             $token,
             $this->tokenService->getToken($type, $token->getToken(), $identifier)
+        );
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testRevokeToken(): void
+    {
+        $token = $this->tokenService->generateToken(
+            self::TOKEN_TYPE,
+            self::TOKEN_TTL,
+            self::TOKEN_IDENTIFIER
+        );
+
+        $this->tokenService->revokeToken($token);
+
+        self::assertSame(
+            $token,
+            $this->tokenService->getToken(
+                $token->getType(),
+                $token->getToken(),
+                $token->getIdentifier()
+            )
+        );
+
+        self::assertFalse(
+            $this->tokenService->checkToken(
+                $token->getType(),
+                $token->getToken(),
+                $token->getIdentifier()
+            )
         );
     }
 

--- a/tests/integration/Core/Repository/TokenServiceTest.php
+++ b/tests/integration/Core/Repository/TokenServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Integration\Core\Repository;
 
 use Ibexa\Contracts\Core\Repository\TokenService;
+use Ibexa\Contracts\Core\Repository\Values\Token\Token;
 use Ibexa\Contracts\Core\Test\IbexaKernelTestCase;
 use Ibexa\Core\Base\Exceptions\TokenLengthException;
 
@@ -134,23 +135,63 @@ final class TokenServiceTest extends IbexaKernelTestCase
 
         $this->tokenService->revokeToken($token);
 
-        $revokedToken = $this->tokenService->getToken(
-            $token->getType(),
-            $token->getToken(),
-            $token->getIdentifier()
+        $this->assertRevokedToken($token);
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testRevokeAllTokensByIdentifier(): void
+    {
+        $tokens = [
+            $this->tokenService->generateToken(
+                self::TOKEN_TYPE,
+                self::TOKEN_TTL,
+                self::TOKEN_IDENTIFIER
+            ),
+            $this->tokenService->generateToken(
+                self::TOKEN_TYPE,
+                self::TOKEN_TTL,
+                self::TOKEN_IDENTIFIER
+            ),
+            $this->tokenService->generateToken(
+                self::TOKEN_TYPE,
+                self::TOKEN_TTL,
+                self::TOKEN_IDENTIFIER
+            ),
+        ];
+
+        $differentToken = $this->tokenService->generateToken(
+            self::TOKEN_TYPE,
+            self::TOKEN_TTL,
+            'different'
         );
 
-        self::assertSame($token->getType(), $revokedToken->getType());
-        self::assertSame($token->getToken(), $revokedToken->getToken());
-        self::assertSame($token->getIdentifier(), $revokedToken->getIdentifier());
-        self::assertTrue($revokedToken->isRevoked());
+        $tokenWithoutIdentifier = $this->tokenService->generateToken(
+            self::TOKEN_TYPE,
+            self::TOKEN_TTL
+        );
+
+        $this->tokenService->revokeTokenByIdentifier(self::TOKEN_TYPE, self::TOKEN_IDENTIFIER);
+
+        foreach ($tokens as $token) {
+            $this->assertRevokedToken($token);
+        }
 
         self::assertFalse(
-            $this->tokenService->checkToken(
-                $token->getType(),
-                $token->getToken(),
-                $token->getIdentifier()
-            )
+            $this->tokenService->getToken(
+                $differentToken->getType(),
+                $differentToken->getToken(),
+                $differentToken->getIdentifier()
+            )->isRevoked()
+        );
+
+        self::assertFalse(
+            $this->tokenService->getToken(
+                $tokenWithoutIdentifier->getType(),
+                $tokenWithoutIdentifier->getToken(),
+                $tokenWithoutIdentifier->getIdentifier()
+            )->isRevoked()
         );
     }
 
@@ -227,5 +268,27 @@ final class TokenServiceTest extends IbexaKernelTestCase
             self::TOKEN_TTL,
             null,
         ];
+    }
+
+    private function assertRevokedToken(Token $token): void
+    {
+        $revokedToken = $this->tokenService->getToken(
+            $token->getType(),
+            $token->getToken(),
+            $token->getIdentifier()
+        );
+
+        self::assertSame($token->getType(), $revokedToken->getType());
+        self::assertSame($token->getToken(), $revokedToken->getToken());
+        self::assertSame($token->getIdentifier(), $revokedToken->getIdentifier());
+        self::assertTrue($revokedToken->isRevoked());
+
+        self::assertFalse(
+            $this->tokenService->checkToken(
+                $token->getType(),
+                $token->getToken(),
+                $token->getIdentifier()
+            )
+        );
     }
 }

--- a/tests/integration/Core/Repository/TokenServiceTest.php
+++ b/tests/integration/Core/Repository/TokenServiceTest.php
@@ -134,14 +134,16 @@ final class TokenServiceTest extends IbexaKernelTestCase
 
         $this->tokenService->revokeToken($token);
 
-        self::assertSame(
-            $token,
-            $this->tokenService->getToken(
-                $token->getType(),
-                $token->getToken(),
-                $token->getIdentifier()
-            )
+        $revokedToken = $this->tokenService->getToken(
+            $token->getType(),
+            $token->getToken(),
+            $token->getIdentifier()
         );
+
+        self::assertSame($token->getType(), $revokedToken->getType());
+        self::assertSame($token->getToken(), $revokedToken->getToken());
+        self::assertSame($token->getIdentifier(), $revokedToken->getIdentifier());
+        self::assertTrue($revokedToken->isRevoked());
 
         self::assertFalse(
             $this->tokenService->checkToken(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5915](https://issues.ibexa.co/browse/IBX-5915)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This will allow OAuth2 server implementation (but not only) to handle token revocation. Revoked token may be handled in a different way (yet behaves similar as deleted) by internal and 3rd party implementations. 

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
- [x] Installer upgrade scripts. (ref: https://github.com/ibexa/installer/pull/109)
