### PR TITLE
IBX-6032: Undeprecated single object relation field type

### DIFF
--- a/src/lib/FieldType/Relation/Type.php
+++ b/src/lib/FieldType/Relation/Type.php
@@ -25,8 +25,6 @@ use Ibexa\Core\Repository\Validator\TargetContentValidatorInterface;
  *
  * hash format ({@see fromhash()}, {@see toHash()}):
  * array( 'destinationContentId' => (int)$destinationContentId );
- *
- * @deprecated Since 7.0 and will be removed in 8.0. Use `RelationList\Type` instead.
  */
 class Type extends FieldType
 {

--- a/src/lib/FieldType/Relation/Value.php
+++ b/src/lib/FieldType/Relation/Value.php
@@ -10,8 +10,6 @@ use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
  * Value for Relation field type.
- *
- * @deprecated Since 7.0 and will be removed in 8.0. Use `RelationList\Value` instead.
  */
 class Value extends BaseValue
 {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6032](https://issues.ibexa.co/browse/IBX-6032)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Single object relation field type is deprecated since eZ Platform 2.0. However after reconsideration we decided to keep it in the code base, as it's might be great foundation for custom specialized field types. 

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
