### PR TITLE
IBX-4853: Deprecated `Ibexa\Core\MVC\Symfony\Locale::convertToEz` method

### DIFF
--- a/src/lib/MVC/Symfony/Locale/LocaleConverter.php
+++ b/src/lib/MVC/Symfony/Locale/LocaleConverter.php
@@ -58,6 +58,9 @@ class LocaleConverter implements LocaleConverterInterface
      * Converts a locale in POSIX format to Ibexa internal format.
      * Returns null if conversion cannot be made.
      *
+     * @deprecated use convertToRepository instead
+     * @see convertToRepository
+     *
      * @param string $posixLocale
      *
      * @return string|null
@@ -68,6 +71,17 @@ class LocaleConverter implements LocaleConverterInterface
             $this->logger->warning("Could not convert locale '$posixLocale' to Ibexa format. Please check your locale configuration in ezplatform.yml");
 
             return;
+        }
+
+        return $this->reverseConversionMap[$posixLocale];
+    }
+
+    public function convertToRepository(string $posixLocale): ?string
+    {
+        if (!isset($this->reverseConversionMap[$posixLocale])) {
+            $this->logger->warning("Could not convert locale '$posixLocale' to Repository format. Please check your locale configuration in ibexa.yaml");
+
+            return null;
         }
 
         return $this->reverseConversionMap[$posixLocale];

--- a/src/lib/MVC/Symfony/Locale/LocaleConverter.php
+++ b/src/lib/MVC/Symfony/Locale/LocaleConverter.php
@@ -58,9 +58,6 @@ class LocaleConverter implements LocaleConverterInterface
      * Converts a locale in POSIX format to Ibexa internal format.
      * Returns null if conversion cannot be made.
      *
-     * @deprecated use convertToRepository instead
-     * @see convertToRepository
-     *
      * @param string $posixLocale
      *
      * @return string|null

--- a/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
+++ b/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
@@ -34,6 +34,12 @@ interface LocaleConverterInterface
      * @return string|null
      */
     public function convertToEz($posixLocale);
+
+    /**
+     * Converts a locale in POSIX format to Repository internal format.
+     * Returns null if conversion cannot be made.
+     */
+    public function convertToRepository(string $posixLocale): ?string;
 }
 
 class_alias(LocaleConverterInterface::class, 'eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverterInterface');

--- a/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
+++ b/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
@@ -19,6 +19,9 @@ interface LocaleConverterInterface
      * Converts a locale in Ibexa internal format to POSIX format.
      * Returns null if conversion cannot be made.
      *
+     * @deprecated use convertToRepository instead
+     * @see convertToRepository
+     *
      * @param string $ezpLocale
      *
      * @return string|null

--- a/tests/lib/MVC/Symfony/Locale/LocaleConverterTest.php
+++ b/tests/lib/MVC/Symfony/Locale/LocaleConverterTest.php
@@ -13,19 +13,27 @@ use Psr\Log\LoggerInterface;
 /**
  * @covers \Ibexa\Core\MVC\Symfony\Locale\LocaleConverter
  */
-class LocaleConverterTest extends TestCase
+final class LocaleConverterTest extends TestCase
 {
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\LocaleConverter */
-    private $localeConverter;
+    private LocaleConverter $localeConverter;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private $logger;
+    /** @var \Psr\Log\LoggerInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private LoggerInterface $logger;
 
-    private $conversionMap;
+    /**
+     * @var array{
+     *   array{
+     *     string,
+     *     string|null,
+     *   }
+     * }
+     */
+    private array $conversionMap;
 
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->conversionMap = [
             'eng-GB' => 'en_GB',
             'eng-US' => 'en_US',
@@ -41,11 +49,8 @@ class LocaleConverterTest extends TestCase
 
     /**
      * @dataProvider convertToPOSIXProvider
-     *
-     * @param $ezpLocale
-     * @param $expected
      */
-    public function testConvertToPOSIX($ezpLocale, $expected)
+    public function testConvertToPOSIX(string $ezpLocale, ?string $expected): void
     {
         if ($expected === null) {
             $this->logger
@@ -53,10 +58,10 @@ class LocaleConverterTest extends TestCase
                 ->method('warning');
         }
 
-        $this->assertSame($expected, $this->localeConverter->convertToPOSIX($ezpLocale));
+        self::assertSame($expected, $this->localeConverter->convertToPOSIX($ezpLocale));
     }
 
-    public function convertToPOSIXProvider()
+    public function convertToPOSIXProvider(): array
     {
         return [
             ['eng-GB', 'en_GB'],
@@ -69,12 +74,9 @@ class LocaleConverterTest extends TestCase
     }
 
     /**
-     * @dataProvider convertToEzProvider
-     *
-     * @param $posixLocale
-     * @param $expected
+     * @dataProvider convertToRepositoryProvider
      */
-    public function testConvertToEz($posixLocale, $expected)
+    public function testConvertToEz(string $posixLocale, ?string $expected): void
     {
         if ($expected === null) {
             $this->logger
@@ -82,10 +84,32 @@ class LocaleConverterTest extends TestCase
                 ->method('warning');
         }
 
-        $this->assertSame($expected, $this->localeConverter->convertToEz($posixLocale));
+        self::assertSame($expected, $this->localeConverter->convertToEz($posixLocale));
     }
 
-    public function convertToEzProvider()
+    /**
+     * @dataProvider convertToRepositoryProvider
+     */
+    public function testConvertToRepository(string $posixLocale, ?string $expected): void
+    {
+        if ($expected === null) {
+            $this->logger
+                ->expects($this->once())
+                ->method('warning');
+        }
+
+        self::assertSame($expected, $this->localeConverter->convertToRepository($posixLocale));
+    }
+
+    /**
+     * @return array{
+     *   array{
+     *     string,
+     *     string|null,
+     *   }
+     * }
+     */
+    public function convertToRepositoryProvider(): array
     {
         return [
             ['en_GB', 'eng-GB'],

--- a/tests/lib/MVC/Symfony/Locale/LocaleConverterTest.php
+++ b/tests/lib/MVC/Symfony/Locale/LocaleConverterTest.php
@@ -50,7 +50,7 @@ final class LocaleConverterTest extends TestCase
     /**
      * @dataProvider convertToPOSIXProvider
      */
-    public function testConvertToPOSIX(string $ezpLocale, ?string $expected): void
+    public function testConvertToPOSIX(string $repositoryLocale, ?string $expected): void
     {
         if ($expected === null) {
             $this->logger
@@ -58,7 +58,7 @@ final class LocaleConverterTest extends TestCase
                 ->method('warning');
         }
 
-        self::assertSame($expected, $this->localeConverter->convertToPOSIX($ezpLocale));
+        self::assertSame($expected, $this->localeConverter->convertToPOSIX($repositoryLocale));
     }
 
     public function convertToPOSIXProvider(): array


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4853](https://issues.ibexa.co/browse/IBX-4853)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`, `4.6`
| **BC breaks**                          | no

I also took the liberty to refactor corresponding test case a little.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
