### PR TITLE
IBX-6195: Made `URL_ALIAS_ROUTE_NAME` calls inside `MVC\Symfony\Routing\UrlAliasRouter` static

### DIFF
--- a/src/lib/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/src/lib/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -109,7 +109,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
             }
 
             $params = [
-                '_route' => self::URL_ALIAS_ROUTE_NAME,
+                '_route' => static::URL_ALIAS_ROUTE_NAME,
             ];
             switch ($urlAlias->type) {
                 case URLAlias::LOCATION:
@@ -305,7 +305,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
         }
 
         // Normal route name
-        if ($name === self::URL_ALIAS_ROUTE_NAME) {
+        if ($name === static::URL_ALIAS_ROUTE_NAME) {
             if (isset($parameters['location']) || isset($parameters['locationId'])) {
                 // Check if location is a valid Location object
                 if (isset($parameters['location']) && !$parameters['location'] instanceof Location) {
@@ -379,7 +379,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
      */
     public function supports($name)
     {
-        return $name === self::URL_ALIAS_ROUTE_NAME || $this->supportsObject($name);
+        return $name === static::URL_ALIAS_ROUTE_NAME || $this->supportsObject($name);
     }
 
     private function supportsObject($object): bool


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6195](https://issues.ibexa.co/browse/IBX-6195)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Classes that extend the core's `UrlAliasRouter` should properly handle their own route names (like https://github.com/ibexa/compatibility-layer/blob/main/src/lib/Routing/UrlAliasRouter.php).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
