### PR TITLE
IBX-5936: Added `ContentTypeHandler::loadContentTypesByFieldDefinitionIdentifier` method

### DIFF
--- a/src/bundle/Core/Resources/config/storage/legacy/schema.yaml
+++ b/src/bundle/Core/Resources/config/storage/legacy/schema.yaml
@@ -141,6 +141,7 @@ tables:
     ezcontentclass_attribute:
         indexes:
             ezcontentclass_attr_ccid: { fields: [contentclass_id] }
+            ezcontentclass_attr_dts: { fields: [data_type_string] }
         id:
             id: { type: integer, nullable: false, options: { autoincrement: true } }
             version: { type: integer, nullable: false, options: { default: '0' } }

--- a/src/contracts/Persistence/Content/Type/Handler.php
+++ b/src/contracts/Persistence/Content/Type/Handler.php
@@ -92,6 +92,11 @@ interface Handler
     public function loadContentTypeList(array $contentTypeIds): array;
 
     /**
+     * @return \Ibexa\Contracts\Core\Persistence\Content\Type[]
+     */
+    public function loadContentTypesByFieldDefinitionIdentifier(string $identifier): array;
+
+    /**
      * Loads a content type by id and status.
      *
      * Note: This method is responsible of having the Field Definitions of the loaded ContentType sorted by placement.

--- a/src/lib/Persistence/Cache/ContentTypeHandler.php
+++ b/src/lib/Persistence/Cache/ContentTypeHandler.php
@@ -304,9 +304,6 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function loadContentTypesByFieldDefinitionIdentifier(string $identifier): array
     {
         return $this->getListCacheValue(

--- a/src/lib/Persistence/Cache/ContentTypeHandler.php
+++ b/src/lib/Persistence/Cache/ContentTypeHandler.php
@@ -26,6 +26,7 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
     private const BY_IDENTIFIER_SUFFIX = 'by_identifier_suffix';
     private const CONTENT_TYPE_LIST_BY_GROUP_IDENTIFIER = 'content_type_list_by_group';
     private const BY_REMOTE_SUFFIX = 'by_remote_suffix';
+    private const CONTENT_TYPE_LIST_BY_FIELD_DEFINITION_IDENTIFIER = 'content_type_list_by_field_definition_identifier';
     private const TYPE_MAP_IDENTIFIER = 'type_map';
     private const CONTENT_FIELDS_TYPE_IDENTIFIER = 'content_fields_type';
     private const TYPE_WITHOUT_VALUE_IDENTIFIER = 'type_without_value';
@@ -300,6 +301,23 @@ class ContentTypeHandler extends AbstractInMemoryPersistenceHandler implements C
             $this->getTypeTags,
             $this->getTypeKeys,
             '-' . $this->cacheIdentifierGenerator->generateKey(self::BY_REMOTE_SUFFIX)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadContentTypesByFieldDefinitionIdentifier(string $identifier): array
+    {
+        return $this->getListCacheValue(
+            $this->cacheIdentifierGenerator->generateKey(self::CONTENT_TYPE_LIST_BY_FIELD_DEFINITION_IDENTIFIER, [$identifier], true),
+            function () use ($identifier): array {
+                return $this->persistenceHandler->contentTypeHandler()->loadContentTypesByFieldDefinitionIdentifier($identifier);
+            },
+            $this->getTypeTags,
+            $this->getTypeKeys,
+            null,
+            [$identifier]
         );
     }
 

--- a/src/lib/Persistence/Legacy/Content/Type/Gateway.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Gateway.php
@@ -116,6 +116,8 @@ abstract class Gateway
      */
     abstract public function loadTypesListData(array $typeIds): array;
 
+    abstract public function loadTypesDataByFieldDefinitionIdentifier(string $identifier): array;
+
     abstract public function loadTypeData(int $typeId, int $status): array;
 
     abstract public function loadTypeDataByIdentifier(string $identifier, int $status): array;

--- a/src/lib/Persistence/Legacy/Content/Type/Gateway.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Gateway.php
@@ -116,6 +116,9 @@ abstract class Gateway
      */
     abstract public function loadTypesListData(array $typeIds): array;
 
+    /**
+     * @return array<mixed>
+     */
     abstract public function loadTypesDataByFieldDefinitionIdentifier(string $identifier): array;
 
     abstract public function loadTypeData(int $typeId, int $status): array;

--- a/src/lib/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -953,7 +953,7 @@ final class DoctrineDatabase extends Gateway
     {
         $query = $this->getLoadTypeQueryBuilder();
         $query
-            ->where(
+            ->andWhere(
                 $query->expr()->eq(
                     'a.data_type_string',
                     $query->createNamedParameter($identifier)

--- a/src/lib/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -949,6 +949,20 @@ final class DoctrineDatabase extends Gateway
         return $query->execute()->fetchAll();
     }
 
+    public function loadTypesDataByFieldDefinitionIdentifier(string $identifier): array
+    {
+        $query = $this->getLoadTypeQueryBuilder();
+        $query
+            ->where(
+                $query->expr()->eq(
+                    'a.data_type_string',
+                    $query->createNamedParameter($identifier)
+                )
+            );
+
+        return $query->execute()->fetchAllAssociative();
+    }
+
     public function loadTypeData(int $typeId, int $status): array
     {
         $query = $this->getLoadTypeQueryBuilder();

--- a/src/lib/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -245,6 +245,15 @@ final class ExceptionConversion extends Gateway
         }
     }
 
+    public function loadTypesDataByFieldDefinitionIdentifier(string $identifier): array
+    {
+        try {
+            return $this->innerGateway->loadTypesDataByFieldDefinitionIdentifier($identifier);
+        } catch (PDOException $e) {
+            throw DatabaseException::wrap($e);
+        }
+    }
+
     public function countInstancesOfType(int $typeId): int
     {
         try {

--- a/src/lib/Persistence/Legacy/Content/Type/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Handler.php
@@ -196,6 +196,16 @@ class Handler implements BaseContentTypeHandler
     }
 
     /**
+     * @return \Ibexa\Contracts\Core\Persistence\Content\Type[]
+     */
+    public function loadContentTypesByFieldDefinitionIdentifier(string $identifier): array
+    {
+        return $this->mapper->extractTypesFromRows(
+            $this->contentTypeGateway->loadTypesDataByFieldDefinitionIdentifier($identifier)
+        );
+    }
+
+    /**
      * Loads a content type by id and status.
      *
      * Note: This method is responsible of having the Field Definitions of the loaded ContentType sorted by placement.

--- a/src/lib/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -189,6 +189,22 @@ class MemoryCachingHandler implements BaseContentTypeHandler
     /**
      * {@inheritdoc}
      */
+    public function loadContentTypesByFieldDefinitionIdentifier(string $identifier): array
+    {
+        $cacheKey = 'ibx-ctlbfdi-' . $identifier;
+
+        $types = $this->cache->get($cacheKey);
+        if ($types === null) {
+            $types = $this->innerHandler->loadContentTypesByFieldDefinitionIdentifier($identifier);
+            $this->storeTypeCache($types, $cacheKey);
+        }
+
+        return $types;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function load($contentTypeId, $status = Type::STATUS_DEFINED)
     {
         $contentType = $this->cache->get('ez-content-type-' . $contentTypeId . '-' . $status);

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -125,6 +125,7 @@ parameters:
         content_type_group: 'ctg-%s'
         content_type_group_with_id_suffix: 'ctg-%s-bi'
         content_type_group_with_by_remote_suffix: 'ctg-%s-br'
+        content_type_list_by_field_definition_identifier: 'ctlbfdi-%s'
         content_type_group_list: 'ctgl-%s'
         content_type_list_by_group: 'ctlbg-%s'
         image_variation: 'ig'

--- a/tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
@@ -204,6 +204,7 @@ class ContentTypeHandlerTest extends AbstractInMemoryCacheHandlerTest
             ],
             ['loadAllGroups', [], 'ibx-ctgl', null, null, [['content_type_group_list', [], true]], ['ibx-ctgl'], [3 => $group]],
             ['loadContentTypes', [3, 0], 'ibx-ctlbg-3', null, null, [['content_type_list_by_group', [3], true]], ['ibx-ctlbg-3'], [$type]],
+            ['loadContentTypesByFieldDefinitionIdentifier', [3, 0], 'ibx-ctlbfdi-3', null, null, [['content_type_list_by_field_definition_identifier', [3], true]], ['ibx-ctlbfdi-3'], [$type]],
             ['loadContentTypeList', [[5]], 'ibx-ct-5', null, null, [['content_type', [], true]], ['ibx-ct'], [5 => $type], true],
             ['load', [5, 0], 'ibx-ct-5', null, null, [['content_type', [], true]], ['ibx-ct'], $type],
             [

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -284,6 +284,30 @@ class ContentTypeHandlerTest extends TestCase
         );
     }
 
+    public function testLoadContentTypesByFieldDefinitionIdentifier(): void
+    {
+        $gatewayMock = $this->getGatewayMock();
+        $gatewayMock->expects($this->once())
+            ->method('loadTypesDataByFieldDefinitionIdentifier')
+            ->with(self::equalTo('ezstring'))
+            ->willReturn([]);
+
+        $mapperMock = $this->getMapperMock();
+        $mapperMock->expects(self::once())
+            ->method('extractTypesFromRows')
+            ->with($this->equalTo([]))
+            ->willReturn([23 => new Type()]);
+
+        $handler = $this->getHandler();
+        $types = $handler->loadContentTypesByFieldDefinitionIdentifier('ezstring');
+
+        self::assertEquals(
+            [23 => new Type()],
+            $types,
+            'Types not loaded correctly'
+        );
+    }
+
     public function testLoad()
     {
         $gatewayMock = $this->getGatewayMock();

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -289,13 +289,13 @@ class ContentTypeHandlerTest extends TestCase
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())
             ->method('loadTypesDataByFieldDefinitionIdentifier')
-            ->with(self::equalTo('ezstring'))
+            ->with('ezstring')
             ->willReturn([]);
 
         $mapperMock = $this->getMapperMock();
         $mapperMock->expects(self::once())
             ->method('extractTypesFromRows')
-            ->with($this->equalTo([]))
+            ->with([])
             ->willReturn([23 => new Type()]);
 
         $handler = $this->getHandler();


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5936](https://issues.ibexa.co/browse/IBX-5936)
| **Type**                                   |bug
| **Target Ibexa version** | `v4.5`, `main`
| **BC breaks**                          | no

Added mentioned method to be utilized within https://github.com/ibexa/product-catalog/pull/1034.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
