### PR TITLE
Fixed deprecating `convertToEz` method

### DIFF
--- a/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
+++ b/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
@@ -29,8 +29,7 @@ interface LocaleConverterInterface
      * Converts a locale in POSIX format to Ibexa internal format.
      * Returns null if conversion cannot be made.
      *
-     * @deprecated use convertToRepository instead
-     * @see convertToRepository
+     * @deprecated 4.5.2 To be removed in 5.0. Use {@see convertToRepository()} instead.
      *
      * @param string $posixLocale
      *

--- a/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
+++ b/src/lib/MVC/Symfony/Locale/LocaleConverterInterface.php
@@ -19,9 +19,6 @@ interface LocaleConverterInterface
      * Converts a locale in Ibexa internal format to POSIX format.
      * Returns null if conversion cannot be made.
      *
-     * @deprecated use convertToRepository instead
-     * @see convertToRepository
-     *
      * @param string $ezpLocale
      *
      * @return string|null
@@ -31,6 +28,9 @@ interface LocaleConverterInterface
     /**
      * Converts a locale in POSIX format to Ibexa internal format.
      * Returns null if conversion cannot be made.
+     *
+     * @deprecated use convertToRepository instead
+     * @see convertToRepository
      *
      * @param string $posixLocale
      *


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | `bug`
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

As @adamwojs correctly observed, we need to mark a proper method as deprecated. This is a followup for https://github.com/ibexa/core/pull/245 where the wrong one was described as such.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
