### PR TITLE
IBX-6257: Fixed the issue regarding  identifier extraction for specific pattern

### DIFF
--- a/src/lib/Repository/NameSchema/SchemaIdentifierExtractor.php
+++ b/src/lib/Repository/NameSchema/SchemaIdentifierExtractor.php
@@ -27,7 +27,7 @@ final class SchemaIdentifierExtractor implements SchemaIdentifierExtractorInterf
      */
     public function extract(string $schemaString): array
     {
-        $allTokens = '/[<|\(]?([\w\d:_]+)[>\)]?/';
+        $allTokens = '/[<\(]([\w\d:_]+(?:[|><\(\)\s][\w\d:_]+)*)[\)\>]*/';
 
         if (false === preg_match_all($allTokens, $schemaString, $matches)) {
             return [];
@@ -35,7 +35,7 @@ final class SchemaIdentifierExtractor implements SchemaIdentifierExtractorInterf
 
         $strategyIdentifiers = [];
         foreach ($matches[1] as $tokenExpression) {
-            $tokens = explode('|', $tokenExpression);
+            $tokens = preg_split('/[\s\|><\(\)]+/', trim($tokenExpression));
             foreach ($tokens as $token) {
                 $strategyToken = explode(':', $token, 2);
 

--- a/tests/lib/Repository/NameSchema/SchemaIdentifierExtractorTest.php
+++ b/tests/lib/Repository/NameSchema/SchemaIdentifierExtractorTest.php
@@ -81,17 +81,26 @@ final class SchemaIdentifierExtractorTest extends TestCase
         yield $schemaString => [
             $schemaString,
             [
-                'field' => ['specification', 'name', 'image1', 'baz', 'bar'],
+                'field' => ['specification', 'name', 'image1', 'bar', 'baz'],
                 'custom' => ['bar'],
             ],
         ];
 
         $schemaString = '<description|(<attribute:mouse_type> <attribute:mouse_weight>)>';
         yield $schemaString => [
+             $schemaString,
+             [
+                 'field' => ['description'],
+                 'attribute' => ['mouse_type', 'mouse_weight'],
+             ],
+         ];
+
+        $schemaString = '<abc|(<xyz> <name>)><abc|(<attribute:color> <attribute:color>)>';
+        yield $schemaString => [
             $schemaString,
             [
-                'field' => ['description'],
-                'attribute' => ['mouse_type', 'mouse_weight'],
+                'field' => ['abc', 'xyz', 'name'],
+                'attribute' => ['color'],
             ],
         ];
     }
@@ -108,7 +117,6 @@ final class SchemaIdentifierExtractorTest extends TestCase
      */
     public function testExtract(string $schemaString, array $expectedStrategyIdentifierMap): void
     {
-        $extracted = $this->extractor->extract($schemaString);
-        self::assertSame($expectedStrategyIdentifierMap, $extracted);
+        self::assertSame($expectedStrategyIdentifierMap, $this->extractor->extract($schemaString));
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6257](https://issues.ibexa.co/browse/IBX-6257)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This pull request addresses an issue with special characters in the pattern strategy used for parsing. The previous implementation of the pattern strategy allowed special characters in placeholder values when inputting a specific pattern, leading to ambiguity and incorrect parsing results for pattern ```<abc|(<xyz> <name>)><abc|(<attribute:color> <attribute:color>)>```

Key Changes:

- Refactored the regular expression pattern to handle special characters and nested placeholders more effectively.
- Ensured the regular expression was robust enough to handle various input scenarios and edge cases.
- Test cases cover different combinations of placeholders, and various input strings

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
