### PR TITLE
Removed unused property from Image Storage

### DIFF
--- a/src/lib/FieldType/Image/ImageStorage.php
+++ b/src/lib/FieldType/Image/ImageStorage.php
@@ -11,7 +11,6 @@ use Ibexa\Contracts\Core\FieldType\StorageGatewayInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Field;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
-use Ibexa\Core\Base\Utils\DeprecationWarnerInterface as DeprecationWarner;
 use Ibexa\Core\IO\FilePathNormalizerInterface;
 use Ibexa\Core\IO\IOServiceInterface;
 use Ibexa\Core\IO\MetadataHandler;
@@ -30,9 +29,6 @@ class ImageStorage extends GatewayBasedStorage
     /** @var \Ibexa\Core\IO\MetadataHandler */
     protected $imageSizeMetadataHandler;
 
-    /** @var \Ibexa\Core\Base\Utils\DeprecationWarnerInterface */
-    private $deprecationWarner;
-
     /** @var \Ibexa\Core\FieldType\Image\AliasCleanerInterface */
     protected $aliasCleaner;
 
@@ -47,7 +43,6 @@ class ImageStorage extends GatewayBasedStorage
         IOServiceInterface $ioService,
         PathGenerator $pathGenerator,
         MetadataHandler $imageSizeMetadataHandler,
-        DeprecationWarner $deprecationWarner,
         AliasCleanerInterface $aliasCleaner,
         FilePathNormalizerInterface $filePathNormalizer
     ) {
@@ -55,7 +50,6 @@ class ImageStorage extends GatewayBasedStorage
         $this->ioService = $ioService;
         $this->pathGenerator = $pathGenerator;
         $this->imageSizeMetadataHandler = $imageSizeMetadataHandler;
-        $this->deprecationWarner = $deprecationWarner;
         $this->aliasCleaner = $aliasCleaner;
         $this->filePathNormalizer = $filePathNormalizer;
     }

--- a/src/lib/Resources/settings/fieldtype_external_storages.yml
+++ b/src/lib/Resources/settings/fieldtype_external_storages.yml
@@ -16,7 +16,6 @@ services:
             $ioService: '@Ibexa\Core\FieldType\Image\IO\Legacy'
             $pathGenerator: '@Ibexa\Core\FieldType\Image\PathGenerator\LegacyPathGenerator'
             $imageSizeMetadataHandler: '@Ibexa\Core\IO\MetadataHandler\ImageSize'
-            $deprecationWarner: '@Ibexa\Core\Base\Utils\DeprecationWarner'
             $aliasCleaner: '@Ibexa\Core\FieldType\Image\AliasCleanerInterface'
             $filePathNormalizer: '@Ibexa\Core\IO\FilePathNormalizerInterface'
         tags:

--- a/tests/integration/Core/Image/ImageStorage/ImageStorageTest.php
+++ b/tests/integration/Core/Image/ImageStorage/ImageStorageTest.php
@@ -12,7 +12,6 @@ use Ibexa\Contracts\Core\Persistence\Content\Field;
 use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
-use Ibexa\Core\Base\Utils\DeprecationWarnerInterface;
 use Ibexa\Core\FieldType\Image\AliasCleanerInterface;
 use Ibexa\Core\FieldType\Image\ImageStorage;
 use Ibexa\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage;

--- a/tests/integration/Core/Image/ImageStorage/ImageStorageTest.php
+++ b/tests/integration/Core/Image/ImageStorage/ImageStorageTest.php
@@ -39,9 +39,6 @@ final class ImageStorageTest extends BaseCoreFieldTypeIntegrationTest
     /** @var \Ibexa\Core\FieldType\Image\PathGenerator|\PHPUnit\Framework\MockObject\MockObject */
     private $pathGenerator;
 
-    /** @var \Ibexa\Core\Base\Utils\DeprecationWarnerInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $deprecationWarner;
-
     /** @var \Ibexa\Core\FieldType\Image\AliasCleanerInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $aliasCleaner;
 
@@ -62,7 +59,6 @@ final class ImageStorageTest extends BaseCoreFieldTypeIntegrationTest
         $this->gateway = new DoctrineStorage($this->redecorator, $this->getDatabaseConnection());
         $this->imageSizeMetadataHandler = $this->createMock(MetadataHandler::class);
         $this->pathGenerator = $this->createMock(PathGenerator::class);
-        $this->deprecationWarner = $this->createMock(DeprecationWarnerInterface::class);
         $this->aliasCleaner = $this->createMock(AliasCleanerInterface::class);
         $this->filePathNormalizer = $this->createMock(FilePathNormalizerInterface::class);
         $this->ioService = $this->createMock(IOServiceInterface::class);
@@ -71,7 +67,6 @@ final class ImageStorageTest extends BaseCoreFieldTypeIntegrationTest
             $this->ioService,
             $this->pathGenerator,
             $this->imageSizeMetadataHandler,
-            $this->deprecationWarner,
             $this->aliasCleaner,
             $this->filePathNormalizer,
         );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

`\Ibexa\Core\FieldType\Image\ImageStorage::$deprecationWarner` is reported as unused by static code analysis.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
