### PR TITLE
IBX-5705: Use SecurityPass to define Guard authentication provider

### DIFF
--- a/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
@@ -10,6 +10,7 @@ use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\AnonymousAuthenticationProvider;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\DefaultAuthenticationSuccessHandler;
+use Ibexa\Core\MVC\Symfony\Security\Authentication\GuardRepositoryAuthenticationProvider;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\RememberMeRepositoryAuthenticationProvider;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\RepositoryAuthenticationProvider;
 use Ibexa\Core\MVC\Symfony\Security\HttpUtils;
@@ -32,6 +33,7 @@ class SecurityPass implements CompilerPassInterface
     {
         if (!($container->hasDefinition('security.authentication.provider.dao') &&
               $container->hasDefinition('security.authentication.provider.rememberme') &&
+              $container->hasDefinition('security.authentication.provider.guard') &&
               $container->hasDefinition('security.authentication.provider.anonymous'))) {
             return;
         }
@@ -69,6 +71,13 @@ class SecurityPass implements CompilerPassInterface
         $rememberMeAuthenticationProviderDef = $container->findDefinition('security.authentication.provider.rememberme');
         $rememberMeAuthenticationProviderDef->setClass(RememberMeRepositoryAuthenticationProvider::class);
         $rememberMeAuthenticationProviderDef->addMethodCall(
+            'setPermissionResolver',
+            [$permissionResolverRef]
+        );
+
+        $guardAuthenticationProviderDef = $container->findDefinition('security.authentication.provider.guard');
+        $guardAuthenticationProviderDef->setClass(GuardRepositoryAuthenticationProvider::class);
+        $guardAuthenticationProviderDef->addMethodCall(
             'setPermissionResolver',
             [$permissionResolverRef]
         );

--- a/src/bundle/Core/Resources/config/security.yml
+++ b/src/bundle/Core/Resources/config/security.yml
@@ -53,11 +53,6 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    Ibexa\Core\MVC\Symfony\Security\Authentication\GuardRepositoryAuthenticationProvider:
-        decorates: security.authentication.provider.guard
-        calls:
-            - ['setPermissionResolver', ['@Ibexa\Contracts\Core\Repository\PermissionResolver']]
-
     ibexa.security.user_provider: '@Ibexa\Core\MVC\Symfony\Security\User\UsernameProvider'
     ibexa.security.user_provider.username: '@Ibexa\Core\MVC\Symfony\Security\User\UsernameProvider'
     ibexa.security.user_provider.email: '@Ibexa\Core\MVC\Symfony\Security\User\EmailProvider'

--- a/tests/bundle/Core/DependencyInjection/Compiler/SecurityPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/SecurityPassTest.php
@@ -22,6 +22,7 @@ class SecurityPassTest extends AbstractCompilerPassTestCase
         parent::setUp();
         $this->setDefinition('security.authentication.provider.dao', new Definition());
         $this->setDefinition('security.authentication.provider.rememberme', new Definition());
+        $this->setDefinition('security.authentication.provider.guard', new Definition());
         $this->setDefinition('security.authentication.provider.anonymous', new Definition());
         $this->setDefinition('security.http_utils', new Definition());
         $this->setDefinition('security.authentication.success_handler', new Definition());
@@ -51,6 +52,11 @@ class SecurityPassTest extends AbstractCompilerPassTestCase
         );
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'security.authentication.provider.rememberme',
+            'setPermissionResolver',
+            [new Reference(PermissionResolver::class)]
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'security.authentication.provider.guard',
             'setPermissionResolver',
             [new Reference(PermissionResolver::class)]
         );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5705](https://issues.ibexa.co/browse/IBX-5705)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

Due to voodoo black magic things happening in Symfony service layer, we cannot use decorator for guard providers. If it is not directly overriden in compiler pass, some of Symfony compiler passes register original service anyway and it has higher priority during resolve resulting in Unauthorized Access anyway.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
