### PR TITLE
Improved specificity for View's template identifier Closure

### DIFF
--- a/src/lib/MVC/Symfony/View/BaseView.php
+++ b/src/lib/MVC/Symfony/View/BaseView.php
@@ -12,7 +12,11 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 abstract class BaseView implements View
 {
-    /** @var string|\Closure */
+    /**
+     * @phpstan-var string|(\Closure(array<string, mixed>):string)
+     *
+     * @var string|\Closure
+     */
     protected $templateIdentifier;
 
     /** @var array */
@@ -34,6 +38,8 @@ abstract class BaseView implements View
     private $isCacheEnabled = true;
 
     /**
+     * @phpstan-param string|(\Closure(array<string, mixed>):string) $templateIdentifier
+     *
      * @param string|\Closure $templateIdentifier Valid path to the template. Can also be a closure.
      * @param string $viewType
      * @param array $parameters Hash of parameters to pass to the template/closure.
@@ -108,6 +114,8 @@ abstract class BaseView implements View
     }
 
     /**
+     * @phpstan-param string|(\Closure(array<string, mixed>):string) $templateIdentifier
+     *
      * @param string|\Closure $templateIdentifier
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
@@ -123,6 +131,8 @@ abstract class BaseView implements View
 
     /**
      * @return string|\Closure
+     *
+     * @phpstan-return string|(\Closure(array<string, mixed>):string)
      */
     public function getTemplateIdentifier()
     {

--- a/src/lib/MVC/Symfony/View/View.php
+++ b/src/lib/MVC/Symfony/View/View.php
@@ -31,6 +31,8 @@ interface View
      *
      * @param string|\Closure $templateIdentifier
      *
+     * @phpstan-param string|(\Closure(array<string, mixed>):string) $templateIdentifier
+     *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
     public function setTemplateIdentifier($templateIdentifier);
@@ -39,6 +41,8 @@ interface View
      * Returns the registered template identifier.
      *
      * @return string|\Closure
+     *
+     * @phpstan-return string|(\Closure(array<string, mixed>):string)
      */
     public function getTemplateIdentifier();
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

This PR increases specificity for PHPStan declarations for `Closure` that can be used instead of a `string` for template identifier parameter.

This helps with [checkMissingCallableSignature](https://phpstan.org/config-reference#vague-typehints) PHPStan's option.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
