### PR TITLE
IBX-5705: Fixed handler as getTokenType returns object not id

### DIFF
--- a/src/lib/Persistence/Legacy/Token/Handler.php
+++ b/src/lib/Persistence/Legacy/Token/Handler.php
@@ -137,7 +137,7 @@ final class Handler implements HandlerInterface
     {
         try {
             if (null !== $tokenType) {
-                $typeId = $this->getTokenType($tokenType);
+                $typeId = $this->getTokenType($tokenType)->id;
             }
         } catch (NotFoundException $exception) {
             return;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5705](https://issues.ibexa.co/browse/IBX-5705)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

#### Checklist:
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
