### PR TITLE
IBX-6481: Fixed keys in array returned by VersionValidator::validate

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7071,11 +7071,6 @@ parameters:
 			path: src/contracts/Repository/Validator/ContentValidator.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Validator\\\\ContentValidator\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Repository/Validator/ContentValidator.php
-
-		-
 			message: "#^Class Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Bookmark\\\\BookmarkList implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: src/contracts/Repository/Values/Bookmark/BookmarkList.php
@@ -7497,11 +7492,6 @@ parameters:
 
 		-
 			message: "#^Interface Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinitionCollection extends generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/contracts/Repository/Values/ContentType/FieldDefinitionCollection.php
-
-		-
-			message: "#^Interface Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinitionCollection extends generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: src/contracts/Repository/Values/ContentType/FieldDefinitionCollection.php
 
@@ -21406,11 +21396,6 @@ parameters:
 			path: src/lib/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\Strategy\\\\ContentValidator\\\\ContentValidatorStrategy\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
-
-		-
 			message: "#^Property Ibexa\\\\Core\\\\Repository\\\\Strategy\\\\ContentValidator\\\\ContentValidatorStrategy\\:\\:\\$contentValidators \\(array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Validator\\\\ContentValidator\\>\\) does not accept iterable\\.$#"
 			count: 1
 			path: src/lib/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
@@ -21671,22 +21656,12 @@ parameters:
 			path: src/lib/Repository/Validator/ContentCreateStructValidator.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\Validator\\\\ContentCreateStructValidator\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/Validator/ContentCreateStructValidator.php
-
-		-
 			message: "#^Cannot access property \\$value on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\|null\\.$#"
 			count: 2
 			path: src/lib/Repository/Validator/ContentUpdateStructValidator.php
 
 		-
 			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\Validator\\\\ContentUpdateStructValidator\\:\\:validate\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/Validator/ContentUpdateStructValidator.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\Validator\\\\ContentUpdateStructValidator\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Repository/Validator/ContentUpdateStructValidator.php
 
@@ -21719,16 +21694,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Core\\\\Repository\\\\Validator\\\\UserPasswordValidator\\:\\:\\$constraints type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Repository/Validator/UserPasswordValidator.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\Validator\\\\VersionValidator\\:\\:validate\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/Validator/VersionValidator.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\Validator\\\\VersionValidator\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/Validator/VersionValidator.php
 
 		-
 			message: "#^Call to method getValue\\(\\) on an unknown class eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\Content\\\\Field\\.$#"
@@ -56727,11 +56692,6 @@ parameters:
 
 		-
 			message: "#^Method class@anonymous/tests/lib/Repository/ContentValidator/ContentValidatorStrategyTest\\.php\\:87\\:\\:validate\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Repository/ContentValidator/ContentValidatorStrategyTest.php
-
-		-
-			message: "#^Method class@anonymous/tests/lib/Repository/ContentValidator/ContentValidatorStrategyTest\\.php\\:87\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/lib/Repository/ContentValidator/ContentValidatorStrategyTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8106,11 +8106,6 @@ parameters:
 			path: src/lib/Base/Exceptions/ContentFieldValidationException.php
 
 		-
-			message: "#^Parameter \\#2 \\$array of function implode expects array\\<string\\>, array\\<Ibexa\\\\Core\\\\FieldType\\\\ValidationError\\|string\\> given\\.$#"
-			count: 1
-			path: src/lib/Base/Exceptions/ContentFieldValidationException.php
-
-		-
 			message: "#^Property Ibexa\\\\Core\\\\Base\\\\Exceptions\\\\ContentFieldValidationException\\:\\:\\$messageTemplate has no type specified\\.$#"
 			count: 1
 			path: src/lib/Base/Exceptions/ContentFieldValidationException.php
@@ -20206,6 +20201,11 @@ parameters:
 			path: src/lib/Repository/ContentService.php
 
 		-
+			message: "#^Parameter \\#5 \\$fieldDefinitionId of method Ibexa\\\\Core\\\\Repository\\\\Helper\\\\RelationProcessor\\:\\:appendFieldRelations\\(\\) expects string, int given\\.$#"
+			count: 2
+			path: src/lib/Repository/ContentService.php
+
+		-
 			message: "#^Property Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\Content\\\\MetadataUpdateStruct\\:\\:\\$publicationDate \\(int\\) does not accept int\\|null\\.$#"
 			count: 1
 			path: src/lib/Repository/ContentService.php
@@ -21602,11 +21602,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$contentType of method Ibexa\\\\Core\\\\Repository\\\\UserService\\:\\:getUserFieldDefinition\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\ContentType, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\ContentType\\|null given\\.$#"
-			count: 1
-			path: src/lib/Repository/UserService.php
-
-		-
-			message: "#^Parameter \\#1 \\$errors of static method Ibexa\\\\Core\\\\Base\\\\Exceptions\\\\ContentFieldValidationException\\:\\:createNewWithMultiline\\(\\) expects array\\<array\\<string, Ibexa\\\\Core\\\\FieldType\\\\ValidationError\\>\\>, array\\<int\\|string, array\\<string, array\\<Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\ValidationError\\>\\>\\> given\\.$#"
 			count: 1
 			path: src/lib/Repository/UserService.php
 

--- a/src/contracts/Repository/Validator/ContentValidator.php
+++ b/src/contracts/Repository/Validator/ContentValidator.php
@@ -30,7 +30,7 @@ interface ContentValidator
      * >
      *
      * @return array Grouped validation errors by field definition ID and language code, in format:
-     *           $returnValue[string|int $fieldDefinitionId][string $languageCode] = $fieldErrors;
+     *           $returnValue[int $fieldDefinitionId][string $languageCode] = $fieldErrors;
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */

--- a/src/contracts/Repository/Validator/ContentValidator.php
+++ b/src/contracts/Repository/Validator/ContentValidator.php
@@ -22,7 +22,7 @@ interface ContentValidator
      *                      case of full validation. Empty identifiers array is equal to no validation.
      *
      * @phpstan-return array<
-     *     int|string,
+     *     int,
      *     array<
      *         string,
      *         \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]

--- a/src/contracts/Repository/Validator/ContentValidator.php
+++ b/src/contracts/Repository/Validator/ContentValidator.php
@@ -21,7 +21,15 @@ interface ContentValidator
      * @param string[]|null $fieldIdentifiers List of field identifiers for partial validation or null for
      *                      case of full validation. Empty identifiers array is equal to no validation.
      *
-     * @return array Grouped validation errors by field definition and language code, in format:
+     * @phpstan-return array<
+     *     int|string,
+     *     array<
+     *         string,
+     *         \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]
+     *     >
+     * >
+     *
+     * @return array Grouped validation errors by field definition ID and language code, in format:
      *           $returnValue[string|int $fieldDefinitionId][string $languageCode] = $fieldErrors;
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException

--- a/src/contracts/Repository/Values/ContentType/FieldDefinition.php
+++ b/src/contracts/Repository/Values/ContentType/FieldDefinition.php
@@ -17,7 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  *
  * @property-read array $fieldSettings calls getFieldSettings()
  * @property-read array $validatorConfiguration calls getValidatorConfiguration()
- * @property-read mixed $id the id of the field definition
+ * @property-read int $id the id of the field definition
  * @property-read string $identifier the identifier of the field definition
  * @property-read string $fieldGroup the field group name
  * @property-read int $position the position of the field definition in the content type
@@ -35,7 +35,7 @@ abstract class FieldDefinition extends ValueObject implements MultiLanguageName,
     /**
      * the unique id of this field definition.
      *
-     * @var mixed
+     * @var int
      */
     protected $id;
 

--- a/src/contracts/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/src/contracts/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -13,6 +13,9 @@ use Closure;
 use Countable;
 use IteratorAggregate;
 
+/**
+ * @phpstan-extends \IteratorAggregate<\Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition>
+ */
 interface FieldDefinitionCollection extends Countable, IteratorAggregate, ArrayAccess
 {
     /**

--- a/src/lib/Base/Exceptions/ContentFieldValidationException.php
+++ b/src/lib/Base/Exceptions/ContentFieldValidationException.php
@@ -25,10 +25,10 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      * Example:
      * <code>
      *  $fieldErrors = $exception->getFieldErrors();
-     *  $fieldErrors["43"]["eng-GB"]->getTranslatableMessage();
+     *  $fieldErrors[43]["eng-GB"]->getTranslatableMessage();
      * </code>
      *
-     * @var array<array-key, array<string, \Ibexa\Core\FieldType\ValidationError>>
+     * @var array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>>
      */
     protected $errors;
 
@@ -40,7 +40,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *
      * Also sets the given $fieldErrors to the internal property, retrievable by getFieldErrors()
      *
-     * @param array<array-key, array<string, \Ibexa\Core\FieldType\ValidationError>> $errors
+     * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
      */
     public function __construct(array $errors)
     {
@@ -52,7 +52,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     /**
      * Generates: Content fields did not validate exception with additional information on affected fields.
      *
-     * @param array<array-key, array<string, \Ibexa\Core\FieldType\ValidationError>> $errors
+     * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
      */
     public static function createNewWithMultiline(array $errors, ?string $contentName = null): self
     {
@@ -72,7 +72,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     /**
      * Returns an array of field validation error messages.
      *
-     * @return array<array-key, array<string, \Ibexa\Core\FieldType\ValidationError>>
+     * @return array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>>
      */
     public function getFieldErrors()
     {
@@ -89,11 +89,17 @@ class ContentFieldValidationException extends APIContentFieldValidationException
             $validationErrors[] = sprintf('Limit: %d of validation errors has been exceeded.', $maxMessagesNumber);
         }
 
+        /** @var callable(string|\Ibexa\Contracts\Core\Repository\Values\Translation): string $convertToString */
+        $convertToString = function ($error): string {
+            return (string)$error;
+        };
+        $validationErrors = array_map($convertToString, $validationErrors);
+
         return "\n- " . implode("\n- ", $validationErrors);
     }
 
     /**
-     * @return array<\Ibexa\Core\FieldType\ValidationError>
+     * @return array<\Ibexa\Contracts\Core\Repository\Values\Translation>
      */
     private function collectValidationErrors(): array
     {

--- a/src/lib/Base/Exceptions/ContentFieldValidationException.php
+++ b/src/lib/Base/Exceptions/ContentFieldValidationException.php
@@ -90,7 +90,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
         }
 
         /** @var callable(string|\Ibexa\Contracts\Core\Repository\Values\Translation): string $convertToString */
-        $convertToString = function ($error): string {
+        $convertToString = static function ($error): string {
             return (string)$error;
         };
         $validationErrors = array_map($convertToString, $validationErrors);

--- a/src/lib/Repository/Validator/VersionValidator.php
+++ b/src/lib/Repository/Validator/VersionValidator.php
@@ -73,7 +73,7 @@ final class VersionValidator implements ContentValidator
 
                 if ($fieldType->isEmptyValue($fieldValue)) {
                     if ($fieldDefinition->isRequired) {
-                        $allFieldErrors[$fieldDefinition->identifier][$languageCode] = new ValidationError(
+                        $allFieldErrors[$fieldDefinition->id][$languageCode] = new ValidationError(
                             "Value for required field definition '%identifier%' with language '%languageCode%' is empty",
                             null,
                             ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode],

--- a/src/lib/Repository/Validator/VersionValidator.php
+++ b/src/lib/Repository/Validator/VersionValidator.php
@@ -86,7 +86,7 @@ final class VersionValidator implements ContentValidator
                         $fieldValue
                     );
                     if (!empty($fieldErrors)) {
-                        $allFieldErrors[$fieldDefinition->identifier][$languageCode] = $fieldErrors;
+                        $allFieldErrors[$fieldDefinition->id][$languageCode] = $fieldErrors;
                     }
                 }
             }

--- a/src/lib/Repository/Validator/VersionValidator.php
+++ b/src/lib/Repository/Validator/VersionValidator.php
@@ -35,6 +35,12 @@ final class VersionValidator implements ContentValidator
         return $object instanceof VersionInfo;
     }
 
+    /**
+     * @phpstan-param array{
+     *     content?: \Ibexa\Contracts\Core\Repository\Values\Content\Content,
+     *     translations?: string[],
+     * } $context
+     */
     public function validate(
         ValueObject $object,
         array $context = [],


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6481](https://issues.ibexa.co/browse/IBX-6481)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

Change the return array key of VersionValidator:validate() so it is consistent with the PHP doc for the function

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
