### PR TITLE
Fixed PermissionResolver::canUser examples

### DIFF
--- a/src/contracts/Repository/PermissionResolver.php
+++ b/src/contracts/Repository/PermissionResolver.php
@@ -55,11 +55,11 @@ interface PermissionResolver
      * Indicates if the current user is allowed to perform an action given by the function on the given
      * objects.
      *
-     * Example: canUser( 'content', 'edit', $content, $location );
+     * Example: canUser( 'content', 'edit', $content, [$location] );
      *          This will check edit permission on content given the specific location, if skipped if will check on all
      *          locations.
      *
-     * Example2: canUser( 'section', 'assign', $content, $section );
+     * Example2: canUser( 'section', 'assign', $content, [$section] );
      *           Check if user has access to assign $content to $section.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.5`+
| **BC breaks**                          | no

The 4th parameter of `PermissionResolver::canUse` must be an array according to its signature, an array of `ValueObject` according to its phpDoc.

Tested with a controller extending `Ibexa\Core\MVC\Symfony\Controller\Controller`:
```php
$this->getRepository()->getPermissionResolver()->canUser('content', 'read', $content, $location);
```
It ends with error "`Ibexa\Core\Repository\Permission\CachedPermissionService::canUser(): Argument #4 ($targets) must be of type array, Ibexa\Core\Repository\Values\Content\Location given`"

The following quick fix seems to work but I didn't have a proper limitation to go with it as I could just pass an empty array or random strings in the array:
```php
$this->getRepository()->getPermissionResolver()->canUser('content', 'read', $content, [$location]);
```
 It needs a more proper/advanced test by someone else than me 😓
 
 See https://github.com/ibexa/documentation-developer/pull/2132 for doc counter-part.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
