### PR TITLE
IBX-5705: Fixed InteractiveLoginToken using PostAuthenticationGuardToken

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12656,11 +12656,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Security\\\\InteractiveLoginToken\\:\\:__unserialize\\(\\) has parameter \\$serialized with no type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Security\\\\User\\:\\:__construct\\(\\) has parameter \\$roles with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/Security/User.php
@@ -63504,4 +63499,3 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Specification\\\\Content\\\\ContentTypeSpecificationTest\\:\\:providerForIsSatisfiedBy\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/lib/Specification/Content/ContentTypeSpecificationTest.php
-

--- a/src/lib/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/src/lib/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -139,6 +139,7 @@ class SecurityListener implements EventSubscriberInterface
             $providerKey,
             $token->getRoleNames()
         );
+        $interactiveToken->setToken($token);
         $interactiveToken->setAttributes($token->getAttributes());
         $this->tokenStorage->setToken($interactiveToken);
     }

--- a/src/lib/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/src/lib/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -139,7 +139,7 @@ class SecurityListener implements EventSubscriberInterface
             $providerKey,
             $token->getRoleNames()
         );
-        $interactiveToken->setToken($token);
+        $interactiveToken->setOriginalToken($token);
         $interactiveToken->setAttributes($token->getAttributes());
         $this->tokenStorage->setToken($interactiveToken);
     }

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -77,7 +77,7 @@ class InteractiveLoginToken extends UsernamePasswordToken
 
     public function isAuthenticated(): bool
     {
-        if ($this->originalToken instanceof TokenInterface) {
+        if (null !== $this->originalToken) {
             return $this->originalToken->isAuthenticated();
         }
 

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -33,9 +33,9 @@ class InteractiveLoginToken extends UsernamePasswordToken
 
     /**
      * @return array{
-     *     0: string,
-     *     1: mixed,
-     *     2: null|\Symfony\Component\Security\Core\Authentication\Token\TokenInterface
+     *     string,
+     *     mixed,
+     *     null|\Symfony\Component\Security\Core\Authentication\Token\TokenInterface
      * } $data
      */
     public function __serialize(): array

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -65,7 +65,7 @@ class InteractiveLoginToken extends UsernamePasswordToken
         parent::__unserialize($parentData);
     }
 
-    public function setToken(TokenInterface $token): void
+    public function setOriginalToken(TokenInterface $token): void
     {
         $this->originalToken = $token;
     }

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -7,6 +7,7 @@
 namespace Ibexa\Core\MVC\Symfony\Security;
 
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 
 /**
  * This token is used when a user has been matched by a foreign user provider.
@@ -40,6 +41,15 @@ class InteractiveLoginToken extends UsernamePasswordToken
     {
         [$this->originalTokenType, $parentStr] = $serialized;
         parent::__unserialize($parentStr);
+    }
+
+    public function isAuthenticated(): bool
+    {
+        if (PostAuthenticationGuardToken::class === $this->originalTokenType) {
+            return true;
+        }
+
+        return parent::isAuthenticated();
     }
 }
 

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -46,6 +46,11 @@ class InteractiveLoginToken extends UsernamePasswordToken
     public function isAuthenticated(): bool
     {
         if (PostAuthenticationGuardToken::class === $this->originalTokenType) {
+            /**
+             * This token is meant to be used after authentication success, so it is always authenticated
+             *
+             * @see https://github.com/symfony/security-guard/blob/72c53142533462fc6fda4a429c2a21c2b944a8cc/Token/PostAuthenticationGuardToken.php#L50-L51
+             */
             return true;
         }
 

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -51,7 +51,7 @@ class InteractiveLoginToken extends UsernamePasswordToken
      * @param array{
      *     0: string,
      *     1: mixed,
-     *     2?: \Symfony\Component\Security\Core\Authentication\Token\TokenInterface
+     *     2: \Symfony\Component\Security\Core\Authentication\Token\TokenInterface
      * } $data
      */
     public function __unserialize(array $data): void
@@ -70,7 +70,7 @@ class InteractiveLoginToken extends UsernamePasswordToken
         $this->originalToken = $token;
     }
 
-    public function getOriginalToken(): TokenInterface
+    public function getOriginalToken(): ?TokenInterface
     {
         return $this->originalToken;
     }

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -51,7 +51,7 @@ class InteractiveLoginToken extends UsernamePasswordToken
      * @param array{
      *     0: string,
      *     1: mixed,
-     *     2: \Symfony\Component\Security\Core\Authentication\Token\TokenInterface
+     *     2: null|\Symfony\Component\Security\Core\Authentication\Token\TokenInterface
      * } $data
      */
     public function __unserialize(array $data): void

--- a/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/src/lib/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -49,17 +49,17 @@ class InteractiveLoginToken extends UsernamePasswordToken
 
     /**
      * @param array{
-     *     0: string,
-     *     1: mixed,
-     *     2: null|\Symfony\Component\Security\Core\Authentication\Token\TokenInterface
+     *     string,
+     *     mixed,
+     *     2?: \Symfony\Component\Security\Core\Authentication\Token\TokenInterface
      * } $data
      */
     public function __unserialize(array $data): void
     {
-        if (count($data) < 3) {
-            [$this->originalTokenType, $parentData] = $data;
-        } else {
+        if (isset($data[2])) {
             [$this->originalTokenType, $parentData, $this->originalToken] = $data;
+        } else {
+            [$this->originalTokenType, $parentData] = $data;
         }
 
         parent::__unserialize($parentData);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5705](https://issues.ibexa.co/browse/IBX-5705)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

`InteractiveLoginToken` wrapping `PostAuthenticationGuardToken` has to be authenticated by default, otherwise it leads to unexpected Symfony behaviour.

Fixes issue in OAuth2 Server: https://github.com/ibexa/oauth2-server/pull/21

Symfony ref. https://github.com/symfony/security-guard/blob/5.4/Token/PostAuthenticationGuardToken.php#L50-L51

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
