### PR TITLE
IBX-6649: Added support for spell checking

### DIFF
--- a/src/contracts/Repository/Values/Content/Query.php
+++ b/src/contracts/Repository/Values/Content/Query.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Spellcheck;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 /**
@@ -91,11 +92,9 @@ class Query extends ValueObject
     public $limit = 25;
 
     /**
-     * If true spellcheck suggestions are returned.
-     *
-     * @var bool
+     * Spellcheck suggestions are returned.
      */
-    public $spellcheck;
+    public ?Spellcheck $spellcheck = null;
 
     /**
      * If true, search engine should perform count even if that means extra lookup.

--- a/src/contracts/Repository/Values/Content/Query/Spellcheck.php
+++ b/src/contracts/Repository/Values/Content/Query/Spellcheck.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query;
+
+use Ibexa\Contracts\Core\Repository\Values\ValueObject;
+
+final class Spellcheck extends ValueObject
+{
+    private string $query;
+
+    public function __construct(string $query)
+    {
+        $this->query = $query;
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+}

--- a/src/contracts/Repository/Values/Content/Search/SearchResult.php
+++ b/src/contracts/Repository/Values/Content/Search/SearchResult.php
@@ -44,8 +44,12 @@ class SearchResult extends ValueObject implements IteratorAggregate, Aggregation
      * criterions the wrong spelled value is replaced by a corrected one (TBD).
      *
      * @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion
+     *
+     * @deprecated since Ibexa 4.6.0, to be removed in Ibexa 5.0.0.
      */
     public $spellSuggestion;
+
+    public ?SpellcheckResult $spellcheck = null;
 
     /**
      * The duration of the search processing in ms.
@@ -69,7 +73,10 @@ class SearchResult extends ValueObject implements IteratorAggregate, Aggregation
     public $maxScore;
 
     /**
-     * The total number of searchHits.
+     * The total number of searchHits.    public function getSpellSuggestion(): ?SpellcheckResult.
+    {
+        return $this->spellSuggestion;
+    }
      *
      * `null` if Query->performCount was set to false and search engine avoids search lookup.
      *
@@ -84,6 +91,11 @@ class SearchResult extends ValueObject implements IteratorAggregate, Aggregation
         }
 
         parent::__construct($properties);
+    }
+
+    public function getSpellcheck(): ?SpellcheckResult
+    {
+        return $this->spellcheck;
     }
 
     public function getAggregations(): ?AggregationResultCollection

--- a/src/contracts/Repository/Values/Content/Search/SearchResult.php
+++ b/src/contracts/Repository/Values/Content/Search/SearchResult.php
@@ -73,10 +73,7 @@ class SearchResult extends ValueObject implements IteratorAggregate, Aggregation
     public $maxScore;
 
     /**
-     * The total number of searchHits.    public function getSpellSuggestion(): ?SpellcheckResult.
-    {
-        return $this->spellSuggestion;
-    }
+     * The total number of searchHits.
      *
      * `null` if Query->performCount was set to false and search engine avoids search lookup.
      *

--- a/src/contracts/Repository/Values/Content/Search/SpellcheckResult.php
+++ b/src/contracts/Repository/Values/Content/Search/SpellcheckResult.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Search;
+
+final class SpellcheckResult
+{
+    /**
+     * Query with applied corrections.
+     */
+    private ?string $query;
+
+    /**
+     * Flag indicating that corrections has been applied to input query.
+     */
+    private bool $incorrect;
+
+    public function __construct(?string $query, bool $incorrect = true)
+    {
+        $this->query = $query;
+        $this->incorrect = $incorrect;
+    }
+
+    public function getQuery(): ?string
+    {
+        return $this->query;
+    }
+
+    public function isIncorrect(): bool
+    {
+        return $this->incorrect;
+    }
+}

--- a/src/contracts/Repository/Values/Content/Search/SpellcheckResult.php
+++ b/src/contracts/Repository/Values/Content/Search/SpellcheckResult.php
@@ -16,7 +16,7 @@ final class SpellcheckResult
     private ?string $query;
 
     /**
-     * Flag indicating that corrections has been applied to input query.
+     * Flag indicating that corrections have been applied to input query.
      */
     private bool $incorrect;
 

--- a/tests/integration/Core/Repository/SearchServiceTest.php
+++ b/tests/integration/Core/Repository/SearchServiceTest.php
@@ -4668,14 +4668,14 @@ class SearchServiceTest extends BaseTest
         }
 
         $query = new Query();
-        // Search phrase with typo: "Ibexa Platfomr" instead of "Ibexa Platform":
-        $query->spellcheck = new Query\Spellcheck('Ibexa Platfomr');
+        // Search phrase with typo: "Contatc Us" instead of "Contact Us":
+        $query->spellcheck = new Query\Spellcheck('Contatc Us');
 
         $results = $searchService->findContent($query);
 
         self::assertNotNull($results->spellcheck);
         self::assertTrue($results->spellcheck->isIncorrect());
-        self::assertEquals('Ibexa Platform', $results->spellcheck->getQuery());
+        self::assertEquals('Contact Us', $results->spellcheck->getQuery());
     }
 
     public function testSpellcheckWithCorrectQuery(): void
@@ -4688,13 +4688,13 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query();
         // Search phrase without typo
-        $query->spellcheck = new Query\Spellcheck('Ibexa Platform');
+        $query->spellcheck = new Query\Spellcheck('Contact Us');
 
         $results = $searchService->findContent($query);
 
         self::assertNotNull($results->spellcheck);
         self::assertFalse($results->spellcheck->isIncorrect());
-        self::assertEquals('Ibexa Platform', $results->spellcheck->getQuery());
+        self::assertEquals('Contact Us', $results->spellcheck->getQuery());
     }
 
     /**

--- a/tests/integration/Core/Repository/SearchServiceTest.php
+++ b/tests/integration/Core/Repository/SearchServiceTest.php
@@ -4688,13 +4688,13 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query();
         // Search phrase without typo
-        $query->spellcheck = new Query\Spellcheck('Contact Us');
+        $query->spellcheck = new Query\Spellcheck('Ibexa Platform');
 
         $results = $searchService->findContent($query);
 
         self::assertNotNull($results->spellcheck);
         self::assertFalse($results->spellcheck->isIncorrect());
-        self::assertEqualsIgnoringCase('Contact Us', $results->spellcheck->getQuery());
+        self::assertEqualsIgnoringCase('Ibexa Platform', $results->spellcheck->getQuery());
     }
 
     /**

--- a/tests/integration/Core/Repository/SearchServiceTest.php
+++ b/tests/integration/Core/Repository/SearchServiceTest.php
@@ -4675,7 +4675,7 @@ class SearchServiceTest extends BaseTest
 
         self::assertNotNull($results->spellcheck);
         self::assertTrue($results->spellcheck->isIncorrect());
-        self::assertEquals('Contact Us', $results->spellcheck->getQuery());
+        self::assertEqualsIgnoringCase('Contact Us', $results->spellcheck->getQuery());
     }
 
     public function testSpellcheckWithCorrectQuery(): void
@@ -4694,7 +4694,7 @@ class SearchServiceTest extends BaseTest
 
         self::assertNotNull($results->spellcheck);
         self::assertFalse($results->spellcheck->isIncorrect());
-        self::assertEquals('Contact Us', $results->spellcheck->getQuery());
+        self::assertEqualsIgnoringCase('Contact Us', $results->spellcheck->getQuery());
     }
 
     /**


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-6649](https://issues.ibexa.co/browse/IBX-6649) |
| **Type**                 | feature                                             |
| **Target Ibexa version** | `v4.6`                                              |
| **BC breaks**            | no                                                  |

### Introduction

Added API to execute spell checking on search phrase and suggest potential alternatives for the user. Typical use case for this API is is "Did you mean X ?" functionality: 

![image](https://github.com/ibexa/core/assets/211967/0a76d5d1-ea8e-4d6c-9d8b-515262622b9d)

Similar feature implementation in Ibexa DXP:

* https://github.com/ibexa/search/pull/32 
* https://github.com/ibexa/admin-ui/pull/923

### Usage example

```php 
// "Ibexa Platfrom" is user input with typo
$input = "Ibexa Platfrom";

$query = new Query();
$query->query = new FullText($input);
$query->spellcheck = new Spellcheck($input);

$results = $searchService->findContent($query);

if ($results->spellcheck->isIncorrect()) {
    $suggestion = $results->getSpellcheck()->getQuery();

    // Display link with suggested search phrase 
} 
```

### API changes summary

* Introduced `\Ibexa\Contracts\Core\Repository\Values\Content\Query\Spellcheck` and `\Ibexa\Contracts\Core\Repository\Values\Content\Search\SpellcheckResult` classes
* Deprecated `\Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult::$spellSuggestion` property. 
* Changed `\Ibexa\Contracts\Core\Repository\Values\Content\Query::$spellcheck` property type from `bool` to `\Ibexa\Contracts\Core\Repository\Values\Content\Query\Spellcheck|null`. 

### Supported search engines 

Spellcheck API is supported by `solr` and `elasticsearch` search engines. However suggestions might be differ between search engines and highly depends on search engine settings. More details in search engine specific PRs:

* https://github.com/ibexa/solr/pull/52
* https://github.com/ibexa/elasticsearch/pull/28


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
