### PR TITLE
Fixed incorrect type-hint for Repository Exceptions contracts

### DIFF
--- a/src/contracts/Persistence/Content/UrlAlias/Handler.php
+++ b/src/contracts/Persistence/Content/UrlAlias/Handler.php
@@ -204,7 +204,7 @@ interface Handler
      *
      * @param int $locationId
      *
-     * @throws \Ibexa\Core\Base\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
      */
     public function repairBrokenUrlAliasesForLocation(int $locationId);
 }

--- a/src/contracts/Repository/UserPreferenceService.php
+++ b/src/contracts/Repository/UserPreferenceService.php
@@ -24,7 +24,7 @@ interface UserPreferenceService
      * @param \Ibexa\Contracts\Core\Repository\Values\UserPreference\UserPreferenceSetStruct[] $userPreferenceSetStructs
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to set user preference
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException If the $userPreferenceSetStruct is invalid
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the $userPreferenceSetStruct is invalid
      */
     public function setUserPreference(array $userPreferenceSetStructs): void;
 

--- a/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
@@ -121,7 +121,7 @@ class RepositoryFactory implements ContainerAwareInterface
      * @param \Ibexa\Contracts\Core\Repository\Repository $repository
      * @param string $serviceName
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      *
      * @return mixed
      */


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.5`+
| **BC breaks**                          | no

I've noticed by accident that type-hints on some contract-level services don't type-hint throwing Exception contracts, but rather implementation, which then causes incorrect PHPDoc block being generated by IDE for API usages.

There's more to it, but I focused on contracts for now.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
