### PR TITLE
IBX-4929: Fix PhpDoc

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5006,11 +5006,6 @@ parameters:
 			path: src/contracts/Container/Encore/ConfigurationDumper.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Container\\\\Encore\\\\ConfigurationDumper\\:\\:dumpCustomConfiguration\\(\\) has parameter \\$webpackConfigNames with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Container\\\\Encore\\\\ConfigurationDumper\\:\\:locateConfigurationFiles\\(\\) has parameter \\$bundlesMetadata with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Container/Encore/ConfigurationDumper.php
@@ -5022,11 +5017,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Container\\\\Encore\\\\ConfigurationDumper\\:\\:locateConfigurationFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(array\\<string, array\\<string, array\\{\\?'deprecated'\\: bool, \\?'alternative'\\: string\\}\\>\\> \\$webpackConfigNames\\)\\: Unexpected token \"\\:\", expected '\\}' at offset 65$#"
 			count: 1
 			path: src/contracts/Container/Encore/ConfigurationDumper.php
 

--- a/src/contracts/Container/Encore/ConfigurationDumper.php
+++ b/src/contracts/Container/Encore/ConfigurationDumper.php
@@ -31,7 +31,7 @@ final class ConfigurationDumper
     }
 
     /**
-     * @param array<string, array<string, array{?'deprecated': bool, ?'alternative': string}>> $webpackConfigNames
+     * @phpstam-param array<string, array<string, array{?'deprecated': bool, ?'alternative': string}>> $webpackConfigNames
      *
      * @throws \JsonException
      */

--- a/src/contracts/Container/Encore/ConfigurationDumper.php
+++ b/src/contracts/Container/Encore/ConfigurationDumper.php
@@ -31,7 +31,7 @@ final class ConfigurationDumper
     }
 
     /**
-     * @phpstam-param array<string, array<string, array{?'deprecated': bool, ?'alternative': string}>> $webpackConfigNames
+     * @phpstan-param array<string, array<string, array{?'deprecated': bool, ?'alternative': string}>> $webpackConfigNames
      *
      * @throws \JsonException
      */

--- a/src/contracts/Container/Encore/ConfigurationDumper.php
+++ b/src/contracts/Container/Encore/ConfigurationDumper.php
@@ -31,7 +31,7 @@ final class ConfigurationDumper
     }
 
     /**
-     * @phpstan-param array<string, array<string, array{?'deprecated': bool, ?'alternative': string}>> $webpackConfigNames
+     * @phpstan-param array<string, array<string, array{'deprecated'?: bool, 'alternative'?: string}>> $webpackConfigNames
      *
      * @throws \JsonException
      */

--- a/src/contracts/Container/Encore/ConfigurationDumper.php
+++ b/src/contracts/Container/Encore/ConfigurationDumper.php
@@ -31,7 +31,7 @@ final class ConfigurationDumper
     }
 
     /**
-     * @phpstan-param array<string, array<string, array{'deprecated'?: bool, 'alternative'?: string}>> $webpackConfigNames
+     * @param array<string, array<string, array{'deprecated'?: bool, 'alternative'?: string}>> $webpackConfigNames
      *
      * @throws \JsonException
      */

--- a/src/contracts/Repository/LocationService.php
+++ b/src/contracts/Repository/LocationService.php
@@ -30,8 +30,8 @@ interface LocationService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException If the current user user does not have read access to the whole source subtree
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the target location is a sub location of the given location
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $subtree - the subtree denoted by the location to copy
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $targetParentLocation - the target parent location for the copy operation
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $subtree the subtree denoted by the location to copy
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $targetParentLocation the target parent location for the copy operation
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Location The newly created location of the copied subtree
      */

--- a/src/contracts/Search/Handler.php
+++ b/src/contracts/Search/Handler.php
@@ -24,7 +24,7 @@ interface Handler
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter a map of language related filters specifying languages query will be performed on.
      *        Also used to define which field languages are loaded for the returned content.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
@@ -41,7 +41,7 @@ interface Handler
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion $filter
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter a map of language related filters specifying languages query will be performed on.
      *        Also used to define which field languages are loaded for the returned content.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
@@ -54,7 +54,7 @@ interface Handler
      * Finds locations for the given $query.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter a map of language related filters specifying languages query will be performed on.
      *        Also used to define which field languages are loaded for the returned content.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**                                   | improvement
| **Target Ibexa version**         | `v4.6`
| **BC breaks**                          | no

- Fix [optional array keys syntax](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes) in `ConfigurationDumper`. (note: phpDocumentor 3 parse the file even if it respects the `@internal` tag and doesn't display it in the resulting reference.)
  - Remove fixed errors from phpstan-baseline.neon
- Fix description Markdown: remove unneeded list item bullets.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
