### PR TITLE
Improved exception message for a non-unique language code

### DIFF
--- a/src/lib/Repository/LanguageService.php
+++ b/src/lib/Repository/LanguageService.php
@@ -90,7 +90,10 @@ class LanguageService implements LanguageServiceInterface
 
         try {
             if ($this->loadLanguage($languageCreateStruct->languageCode) !== null) {
-                throw new InvalidArgumentException('languageCreateStruct', 'language with the specified language code already exists');
+                throw new InvalidArgumentException(
+                    'languageCreateStruct',
+                    sprintf('language with the "%s" language code already exists', $languageCreateStruct->languageCode)
+                );
             }
         } catch (APINotFoundException $e) {
             // Do nothing

--- a/tests/integration/Core/Repository/LanguageServiceTest.php
+++ b/tests/integration/Core/Repository/LanguageServiceTest.php
@@ -128,7 +128,7 @@ class LanguageServiceTest extends BaseTest
     public function testCreateLanguageThrowsInvalidArgumentException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument \'languageCreateStruct\' is invalid: language with the specified language code already exists');
+        $this->expectExceptionMessage('Argument \'languageCreateStruct\' is invalid: language with the "nor-NO" language code already exists');
 
         $repository = $this->getRepository();
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6+`
| **BC breaks**                          | no

Added language code to exception message if provided value is non-unique.

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
