### PR TITLE
IBX-6738: Fixed content type group deletion when it contains orphaned content type drafts 

### DIFF
--- a/src/lib/Repository/ContentTypeService.php
+++ b/src/lib/Repository/ContentTypeService.php
@@ -297,8 +297,8 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         $this->repository->beginTransaction();
         try {
-            $ContentTypesDrafts = $this->contentTypeHandler->loadContentTypes($contentTypeGroup->id, SPIContentType::STATUS_DRAFT);
-            foreach ($ContentTypesDrafts as $contentTypeDraft) {
+            $contentTypesDrafts = $this->contentTypeHandler->loadContentTypes($contentTypeGroup->id, SPIContentType::STATUS_DRAFT);
+            foreach ($contentTypesDrafts as $contentTypeDraft) {
                 $this->contentTypeHandler->delete($contentTypeDraft->id, SPIContentType::STATUS_DRAFT);
             }
 

--- a/src/lib/Repository/ContentTypeService.php
+++ b/src/lib/Repository/ContentTypeService.php
@@ -297,6 +297,11 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         $this->repository->beginTransaction();
         try {
+            $ContentTypesDrafts = $this->contentTypeHandler->loadContentTypes($contentTypeGroup->id, SPIContentType::STATUS_DRAFT);
+            foreach ($ContentTypesDrafts as $contentTypeDraft) {
+                $this->contentTypeHandler->delete($contentTypeDraft->id, SPIContentType::STATUS_DRAFT);
+            }
+
             $this->contentTypeHandler->deleteGroup(
                 $loadedContentTypeGroup->id
             );

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -600,6 +600,40 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $this->fail('Content type group not deleted.');
     }
 
+    public function testDeleteContentTypeGroupWithOrphanedContentTypeDrafts(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $contentTypeService = $repository->getContentTypeService();
+
+        $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
+            'new-group'
+        );
+        $contentTypeService->createContentTypeGroup($groupCreate);
+
+        $group = $contentTypeService->loadContentTypeGroupByIdentifier('new-group');
+        for ($i = 0; $i < 3; ++$i) {
+            $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('content_type_draft_' . $i);
+            $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+            $contentTypeCreateStruct->names = [
+                'eng-GB' => 'content_type_draft_' . $i,
+            ];
+
+            $contentTypeService->createContentType($contentTypeCreateStruct, [$group]);
+        }
+
+        $contentTypeService->deleteContentTypeGroup($group);
+        /* END: Use Case */
+
+        // loadContentTypeGroup should throw NotFoundException
+        $contentTypeService->loadContentTypeGroup($group->id);
+
+        $this->fail('Content type group not deleted.');
+    }
+
     /**
      * Test for the newContentTypeCreateStruct() method.
      *

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -602,11 +602,8 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
     public function testDeleteContentTypeGroupWithOrphanedContentTypeDrafts(): void
     {
-        $this->expectException(NotFoundException::class);
-
         $repository = $this->getRepository();
 
-        /* BEGIN: Use Case */
         $contentTypeService = $repository->getContentTypeService();
 
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
@@ -626,12 +623,11 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         }
 
         $contentTypeService->deleteContentTypeGroup($group);
-        /* END: Use Case */
 
         // loadContentTypeGroup should throw NotFoundException
-        $contentTypeService->loadContentTypeGroup($group->id);
+        $this->expectException(NotFoundException::class);
 
-        $this->fail('Content type group not deleted.');
+        $contentTypeService->loadContentTypeGroup($group->id);
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6738](https://issues.ibexa.co/browse/IBX-6738)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5+`
| **BC breaks**                          | no

Added logic to delete orphaned content type drafts together with deleted content type group in `\Ibexa\Contracts\Core\Repository\ContentTypeService::deleteContentTypeGroup` method.

Failing build: https://github.com/ibexa/core/actions/runs/6486424456/job/17614585158?pr=282

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
