### PR TITLE
IBX-6601: Fixed wrong documentation for Indexable/Unindexed

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10371,16 +10371,6 @@ parameters:
 			path: src/lib/FieldType/Time/Value.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\Unindexed\\:\\:getDefaultMatchField\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: src/lib/FieldType/Unindexed.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\Unindexed\\:\\:getDefaultSortField\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: src/lib/FieldType/Unindexed.php
-
-		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\:\\:\\$text\\.$#"
 			count: 1
 			path: src/lib/FieldType/Url/Type.php

--- a/src/contracts/FieldType/Indexable.php
+++ b/src/contracts/FieldType/Indexable.php
@@ -39,7 +39,7 @@ interface Indexable
      * implementation of this interface), this method is used to define default
      * field for matching. Default field is typically used by Field criterion.
      *
-     * @return string
+     * @return string|null
      */
     public function getDefaultMatchField();
 
@@ -50,7 +50,7 @@ interface Indexable
      * implementation of this interface), this method is used to define default
      * field for sorting. Default field is typically used by Field sort clause.
      *
-     * @return string
+     * @return string|null
      */
     public function getDefaultSortField();
 }

--- a/src/lib/FieldType/Unindexed.php
+++ b/src/lib/FieldType/Unindexed.php
@@ -11,7 +11,9 @@ use Ibexa\Contracts\Core\Persistence\Content\Field;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
 
 /**
- * Indexable definition for string field type.
+ * Empty implementation of \Ibexa\Contracts\Core\FieldType\Indexable.
+ *
+ * Used when field type doesn't contribute to search index.
  */
 class Unindexed implements Indexable
 {
@@ -31,8 +33,6 @@ class Unindexed implements Indexable
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
      * field for matching. Default field is typically used by Field criterion.
-     *
-     * @return string
      */
     public function getDefaultMatchField()
     {
@@ -45,8 +45,6 @@ class Unindexed implements Indexable
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
      * field for sorting. Default field is typically used by Field sort clause.
-     *
-     * @return string
      */
     public function getDefaultSortField()
     {

--- a/src/lib/Search/Common/FieldNameResolver.php
+++ b/src/lib/Search/Common/FieldNameResolver.php
@@ -263,6 +263,12 @@ class FieldNameResolver
         $indexDefinition = $indexFieldType->getIndexDefinition();
 
         // Should only happen by mistake, so let's throw if it does
+        if ($name === null) {
+            throw new RuntimeException(
+                "Undefined default sort or match field in '{$fieldTypeIdentifier}' Field Type's index definition"
+            );
+        }
+
         if (!isset($indexDefinition[$name])) {
             throw new RuntimeException(
                 "Could not find Field '{$name}' in '{$fieldTypeIdentifier}' Field Type's index definition"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6601](https://issues.ibexa.co/browse/IBX-6601)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`+
| **BC breaks**                          | no

Aligned `\Ibexa\Contracts\Core\FieldType\Indexable::{getDefaultMatchField, getDefaultSortField}` with existing implementations & 
fixed issues in `\Ibexa\Core\FieldType\Unindexed` class description as mentioned in JIRA issue.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
