### PR TITLE
IBX-6630: Allowed injecting view type into content preview controller

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11551,31 +11551,6 @@ parameters:
 			path: src/lib/MVC/Symfony/ConfigDumperInterface.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController\\:\\:previewContentAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Controller/Content/PreviewController.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController\\:\\:previewContentAction\\(\\) has parameter \\$contentId with no type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Controller/Content/PreviewController.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController\\:\\:previewContentAction\\(\\) has parameter \\$language with no type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Controller/Content/PreviewController.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController\\:\\:previewContentAction\\(\\) has parameter \\$siteAccessName with no type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Controller/Content/PreviewController.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController\\:\\:previewContentAction\\(\\) has parameter \\$versionNo with no type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Controller/Content/PreviewController.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\QueryController\\:\\:runPagingQuery\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/Controller/Content/QueryController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46506,36 +46506,6 @@ parameters:
 			path: tests/lib/MVC/Symfony/Component/Serializer/Stubs/SerializerStub.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Controller\\\\Content\\\\PreviewControllerTest\\:\\:testPreview\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Controller\\\\Content\\\\PreviewControllerTest\\:\\:testPreviewCanUserFail\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Controller\\\\Content\\\\PreviewControllerTest\\:\\:testPreviewDefaultSiteaccess\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Controller\\\\Content\\\\PreviewControllerTest\\:\\:testPreviewUnauthorized\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
-
-		-
-			message: "#^Parameter \\#7 \\$controllerChecker of class Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController constructor expects Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\View\\\\CustomLocationControllerChecker, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Component\\\\Security\\\\Core\\\\Authorization\\\\AuthorizationCheckerInterface given\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Controller\\\\Content\\\\PreviewControllerTest\\:\\:\\$controllerChecker \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Component\\\\Security\\\\Core\\\\Authorization\\\\AuthorizationCheckerInterface\\) does not accept Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\View\\\\CustomLocationControllerChecker&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\ControllerTest\\:\\:testRender\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/MVC/Symfony/Controller/ControllerTest.php

--- a/src/bundle/Core/Resources/config/routing/internal.yml
+++ b/src/bundle/Core/Resources/config/routing/internal.yml
@@ -20,7 +20,7 @@ ibexa.content.view:
 
 ibexa.version.preview:
     path: /content/versionview/{contentId}/{versionNo}/{language}/site_access/{siteAccessName}
-    defaults: { _controller: ibexa.controller.content.preview:previewContentAction }
+    controller: ibexa.controller.content.preview:previewContentAction
     methods:  [GET]
 
 ibexa.content.preview.default:

--- a/tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
+++ b/tests/lib/MVC/Symfony/Controller/Controller/Content/PreviewControllerTest.php
@@ -129,7 +129,7 @@ final class PreviewControllerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{SiteAccess|null, int, string, int, int|null}>
+     * @return iterable<string, array{SiteAccess|null, int, string, int, int|null, string|null}>
      */
     public static function getDataForTestPreview(): iterable
     {
@@ -139,6 +139,7 @@ final class PreviewControllerTest extends TestCase
             'eng-GB',
             3, // versionNo
             null, // secondary Location Id
+            null,
         ];
 
         yield 'with default SiteAccess, main Location' => [
@@ -147,6 +148,7 @@ final class PreviewControllerTest extends TestCase
             'ger-DE',
             1, // versionNo
             null, // secondary Location Id
+            null,
         ];
 
         yield 'with different SiteAccess, secondary Location' => [
@@ -155,6 +157,7 @@ final class PreviewControllerTest extends TestCase
             'eng-GB',
             11, // versionNo
             220, // secondary Location Id
+            null,
         ];
 
         yield 'with default SiteAccess, secondary Location' => [
@@ -163,6 +166,16 @@ final class PreviewControllerTest extends TestCase
             'ger-DE',
             1, // versionNo
             221, // secondary Location Id
+            null,
+        ];
+
+        yield 'with different SiteAccess and different viewType' => [
+            new SiteAccess('test', 'preview'),
+            789, // contentId
+            'eng-GB',
+            9, // versionNo
+            null,
+            'foo_view_type',
         ];
     }
 
@@ -176,7 +189,8 @@ final class PreviewControllerTest extends TestCase
         int $contentId,
         string $language,
         int $versionNo,
-        ?int $locationId
+        ?int $locationId,
+        ?string $viewType = null
     ): void {
         $content = $this->createMock(Content::class);
         $location = $this->getMockBuilder(Location::class)
@@ -200,6 +214,9 @@ final class PreviewControllerTest extends TestCase
 
         $request = new Request();
         $request->attributes->set('semanticPathinfo', '/foo/bar');
+        if (null !== $viewType) {
+            $request->query->set('viewType', $viewType);
+        }
 
         $this->configurePreviewHelper(
             $content,
@@ -212,7 +229,8 @@ final class PreviewControllerTest extends TestCase
             $location,
             $content,
             $previewSiteAccess ?? $originalSiteAccess,
-            $language
+            $language,
+            $viewType
         );
 
         // the actual assertion happens here, checking if the forward request params are correct
@@ -240,7 +258,8 @@ final class PreviewControllerTest extends TestCase
         Location $location,
         Content $content,
         SiteAccess $previewSiteAccess,
-        string $language
+        string $language,
+        ?string $viewType
     ): array {
         return [
             '_controller' => 'ibexa_content::viewAction',
@@ -251,7 +270,7 @@ final class PreviewControllerTest extends TestCase
             ],
             'location' => $location,
             'content' => $content,
-            'viewType' => 'full',
+            'viewType' => $viewType ?? 'full',
             'layout' => true,
             'params' => [
                 'content' => $content,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6630](https://issues.ibexa.co/browse/IBX-6630)
| **Required by**                            | ibexa/page-builder#273
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This PR allows passing optional `{viewType}` ~route attribute~ query parameter for core content preview controller (`ibexa.controller.content.preview:previewContentAction`). 

Preview Controller builds parameters for `ViewController::viewAction` and forwards request to that controller. It seems `full` view type is hardcoded there. Till now it was enough because type of template for preview was based solely on a SiteAccess and the same was used both for view and preview.

However, there are some cases, like back-office customizable Dashboard when we have 2 types of content views needed: regular AdminUI content/location view and the actual dashboard page preview also displayed in the context of admin SiteAccess. This enhancement adds more flexibility to other use cases apart from closed-source Dashboard.

**Update**

For a good beginning of the weekend, I refactored `PreviewControllerTest` to actually test what it's supposed to test, in a more compact and modern way. I recommend either reviewing the whole test class or just the diff for the test of the essence of the current changes ([6ed7e4e](https://github.com/ibexa/core/pull/285/commits/6ed7e4e1b795fe4896e83412fddb67a111eb4d10)).

### TODO
- [x] Update `\Ibexa\Tests\Core\MVC\Symfony\Controller\Controller\Content\PreviewControllerTest`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
