### PR TITLE
IBX-6827: Aggregation API improvements 

### DIFF
--- a/src/contracts/Repository/Values/Content/Query/Aggregation/DateMetadataRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/DateMetadataRangeAggregation.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
+
 final class DateMetadataRangeAggregation extends AbstractRangeAggregation
 {
     public const MODIFIED = 'modified';
@@ -26,6 +29,19 @@ final class DateMetadataRangeAggregation extends AbstractRangeAggregation
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public static function fromGenerator(
+        string $name,
+        string $type,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new self($name, $type, $ranges);
     }
 }
 

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
@@ -10,8 +10,6 @@ namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\FieldAggregation;
-use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
-use Traversable;
 
 abstract class AbstractFieldRangeAggregation extends AbstractRangeAggregation implements FieldAggregation
 {
@@ -27,20 +25,6 @@ abstract class AbstractFieldRangeAggregation extends AbstractRangeAggregation im
 
         $this->contentTypeIdentifier = $contentTypeIdentifier;
         $this->fieldDefinitionIdentifier = $fieldDefinitionIdentifier;
-    }
-
-    public static function fromGenerator(
-        string $name,
-        string $contentTypeIdentifier,
-        string $fieldDefinitionIdentifier,
-        RangesGeneratorInterface $generator
-    ): self {
-        $ranges = $generator->generate();
-        if ($ranges instanceof Traversable) {
-            $ranges = iterator_to_array($ranges);
-        }
-
-        return new static($name, $contentTypeIdentifier, $fieldDefinitionIdentifier, $ranges);
     }
 }
 

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
@@ -10,6 +10,8 @@ namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\FieldAggregation;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
 
 abstract class AbstractFieldRangeAggregation extends AbstractRangeAggregation implements FieldAggregation
 {
@@ -25,6 +27,20 @@ abstract class AbstractFieldRangeAggregation extends AbstractRangeAggregation im
 
         $this->contentTypeIdentifier = $contentTypeIdentifier;
         $this->fieldDefinitionIdentifier = $fieldDefinitionIdentifier;
+    }
+
+    public static function fromGenerator(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new static($name, $contentTypeIdentifier, $fieldDefinitionIdentifier, $ranges);
     }
 }
 

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Field/DateRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Field/DateRangeAggregation.php
@@ -8,8 +8,24 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
+
 final class DateRangeAggregation extends AbstractFieldRangeAggregation
 {
+    public static function fromGenerator(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new self($name, $contentTypeIdentifier, $fieldDefinitionIdentifier, $ranges);
+    }
 }
 
 class_alias(DateRangeAggregation::class, 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation');

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Field/DateTimeRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Field/DateTimeRangeAggregation.php
@@ -8,8 +8,24 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
+
 final class DateTimeRangeAggregation extends AbstractFieldRangeAggregation
 {
+    public static function fromGenerator(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new self($name, $contentTypeIdentifier, $fieldDefinitionIdentifier, $ranges);
+    }
 }
 
 class_alias(DateTimeRangeAggregation::class, 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateTimeRangeAggregation');

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Field/FloatRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Field/FloatRangeAggregation.php
@@ -8,8 +8,24 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
+
 final class FloatRangeAggregation extends AbstractFieldRangeAggregation
 {
+    public static function fromGenerator(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new self($name, $contentTypeIdentifier, $fieldDefinitionIdentifier, $ranges);
+    }
 }
 
 class_alias(FloatRangeAggregation::class, 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\FloatRangeAggregation');

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Field/IntegerRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Field/IntegerRangeAggregation.php
@@ -8,8 +8,24 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
+
 final class IntegerRangeAggregation extends AbstractFieldRangeAggregation
 {
+    public static function fromGenerator(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new static($name, $contentTypeIdentifier, $fieldDefinitionIdentifier, $ranges);
+    }
 }
 
 class_alias(IntegerRangeAggregation::class, 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\IntegerRangeAggregation');

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Field/TimeRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Field/TimeRangeAggregation.php
@@ -8,8 +8,24 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Field;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
+
 final class TimeRangeAggregation extends AbstractFieldRangeAggregation
 {
+    public static function fromGenerator(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new self($name, $contentTypeIdentifier, $fieldDefinitionIdentifier, $ranges);
+    }
 }
 
 class_alias(TimeRangeAggregation::class, 'eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\TimeRangeAggregation');

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
@@ -27,12 +27,15 @@ final class Range extends ValueObject
      */
     private $to;
 
-    public function __construct($from, $to)
+    private ?string $label;
+
+    public function __construct($from, $to, ?string $label = null)
     {
         parent::__construct();
 
         $this->from = $from;
         $this->to = $to;
+        $this->label = $label;
     }
 
     public function getFrom()
@@ -45,8 +48,27 @@ final class Range extends ValueObject
         return $this->to;
     }
 
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?string $label): void
+    {
+        $this->label = $label;
+    }
+
     public function __toString(): string
     {
+        if ($this->label !== null) {
+            return sprintf(
+                '%s:[%s;%s)',
+                $this->label,
+                $this->getRangeValueAsString($this->from),
+                $this->getRangeValueAsString($this->to)
+            );
+        }
+
         return sprintf(
             '[%s;%s)',
             $this->getRangeValueAsString($this->from),

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
@@ -13,6 +13,8 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 final class Range extends ValueObject
 {
+    public const INF = null;
+
     /**
      * Beginning of the range (included).
      *

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
@@ -80,7 +80,7 @@ final class Range extends ValueObject
 
     public function equalsTo(Range $value): bool
     {
-        return $this->from === $value->from && $this->to === $value->to;
+        return $this->from == $value->from && $this->to == $value->to;
     }
 
     private function getRangeValueAsString($value): string

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Range.php
@@ -78,6 +78,11 @@ final class Range extends ValueObject
         );
     }
 
+    public function equalsTo(Range $value): bool
+    {
+        return $this->from === $value->from && $this->to === $value->to;
+    }
+
     private function getRangeValueAsString($value): string
     {
         if ($value === null) {

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGenerator.php
@@ -26,7 +26,6 @@ final class DateTimeStepRangesGenerator implements RangesGeneratorInterface
 
     private bool $isRightOpen = true;
 
-
     public function __construct(DateTimeInterface $start, DateTimeInterface $end)
     {
         $this->start = $start;
@@ -97,6 +96,12 @@ final class DateTimeStepRangesGenerator implements RangesGeneratorInterface
      */
     public function generate(): array
     {
+        if ($this->start == $this->end && $this->isLeftOpen && $this->isRightOpen) {
+            return [
+                new Range(Range::INF, Range::INF),
+            ];
+        }
+
         $ranges = [];
 
         if ($this->isLeftOpen) {
@@ -109,7 +114,7 @@ final class DateTimeStepRangesGenerator implements RangesGeneratorInterface
             $current = DateTimeImmutable::createFromMutable($current);
         }
 
-        while ($current <= $this->end) {
+        while ($current < $this->end) {
             $next = $current->add($this->step);
             $ranges[] = Range::ofDateTime($current, $next);
             $current = $next;

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGenerator.php
@@ -12,7 +12,6 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
 
 final class DateTimeStepRangesGenerator implements RangesGeneratorInterface

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGenerator.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges;
+
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
+
+final class DateTimeStepRangesGenerator implements RangesGeneratorInterface
+{
+    private DateTimeInterface $start;
+
+    private DateTimeInterface $end;
+
+    private DateInterval $step;
+
+    private bool $isLeftOpen = true;
+
+    private bool $isRightOpen = true;
+
+
+    public function __construct(DateTimeInterface $start, DateTimeInterface $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+        $this->step = new DateInterval('P1D');
+    }
+
+    public function getStart(): DateTimeInterface
+    {
+        return $this->start;
+    }
+
+    public function setStart(DateTimeInterface $start): self
+    {
+        $this->start = $start;
+
+        return $this;
+    }
+
+    public function getEnd(): DateTimeInterface
+    {
+        return $this->end;
+    }
+
+    public function setEnd(DateTimeInterface $end): self
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    public function getStep(): DateInterval
+    {
+        return $this->step;
+    }
+
+    public function setStep(DateInterval $step): self
+    {
+        $this->step = $step;
+
+        return $this;
+    }
+
+    public function isLeftOpen(): bool
+    {
+        return $this->isLeftOpen;
+    }
+
+    public function setLeftOpen(bool $isLeftOpen): void
+    {
+        $this->isLeftOpen = $isLeftOpen;
+    }
+
+    public function isRightOpen(): bool
+    {
+        return $this->isRightOpen;
+    }
+
+    public function setRightOpen(bool $isRightOpen): self
+    {
+        $this->isRightOpen = $isRightOpen;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[]
+     */
+    public function generate(): array
+    {
+        $ranges = [];
+
+        if ($this->isLeftOpen) {
+            $ranges[] = Range::ofDateTime(Range::INF, $this->start);
+        }
+
+        /** @var \DateTimeImmutable $current */
+        $current = $this->start;
+        if ($current instanceof DateTime) {
+            $current = DateTimeImmutable::createFromMutable($current);
+        }
+
+        while ($current <= $this->end) {
+            $next = $current->add($this->step);
+            $ranges[] = Range::ofDateTime($current, $next);
+            $current = $next;
+        }
+
+        if ($this->isRightOpen) {
+            $ranges[] = Range::ofDateTime($this->end, Range::INF);
+        }
+
+        return $ranges;
+    }
+}

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGenerator.php
@@ -106,7 +106,7 @@ final class FloatStepRangesGenerator implements RangesGeneratorInterface
         }
 
         $values = range($this->start, $this->end, $this->step);
-        for ($i = 1; $i < count($values); ++$i) {
+        for ($i = 1, $count = count($values); $i < $count; ++$i) {
             $ranges[] = Range::ofFloat($values[$i - 1], $values[$i]);
         }
 

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGenerator.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
+
+final class FloatStepRangesGenerator implements RangesGeneratorInterface
+{
+    private float $start;
+
+    private float $end;
+
+    private float $step = 1;
+
+    private bool $isLeftOpen = true;
+
+    private bool $isRightOpen = true;
+
+    public function __construct(float $start, float $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    public function getStart(): float
+    {
+        return $this->start;
+    }
+
+    public function setStart(float $start): self
+    {
+        $this->start = $start;
+
+        return $this;
+    }
+
+    public function getEnd(): float
+    {
+        return $this->end;
+    }
+
+    public function setEnd(float $end): self
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    public function getStep(): float
+    {
+        return $this->step;
+    }
+
+    public function setStep(float $step): self
+    {
+        $this->step = $step;
+
+        return $this;
+    }
+
+    public function isLeftOpen(): bool
+    {
+        return $this->isLeftOpen;
+    }
+
+    public function setLeftOpen(bool $isLeftOpen): void
+    {
+        $this->isLeftOpen = $isLeftOpen;
+    }
+
+    public function isRightOpen(): bool
+    {
+        return $this->isRightOpen;
+    }
+
+    public function setRightOpen(bool $isRightOpen): self
+    {
+        $this->isRightOpen = $isRightOpen;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[]
+     */
+    public function generate(): array
+    {
+        $ranges = [];
+
+        if ($this->isLeftOpen) {
+            $ranges[] = Range::ofFloat(Range::INF, $this->start);
+        }
+
+        $values = range($this->start, $this->end, $this->step);
+        for ($i = 1; $i < count($values); ++$i) {
+            $ranges[] = Range::ofFloat($values[$i - 1], $values[$i]);
+        }
+
+        if ($this->isRightOpen) {
+            $ranges[] = Range::ofFloat($this->end, Range::INF);
+        }
+
+        return $ranges;
+    }
+}

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGenerator.php
@@ -69,9 +69,11 @@ final class FloatStepRangesGenerator implements RangesGeneratorInterface
         return $this->isLeftOpen;
     }
 
-    public function setLeftOpen(bool $isLeftOpen): void
+    public function setLeftOpen(bool $isLeftOpen): self
     {
         $this->isLeftOpen = $isLeftOpen;
+
+        return $this;
     }
 
     public function isRightOpen(): bool
@@ -91,6 +93,12 @@ final class FloatStepRangesGenerator implements RangesGeneratorInterface
      */
     public function generate(): array
     {
+        if ($this->start === $this->end && $this->isLeftOpen && $this->isRightOpen) {
+            return [
+                new Range(Range::INF, Range::INF),
+            ];
+        }
+
         $ranges = [];
 
         if ($this->isLeftOpen) {

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
@@ -105,7 +105,7 @@ final class IntegerStepRangesGenerator implements RangesGeneratorInterface
         }
 
         $values = range($this->start, $this->end, $this->step);
-        for ($i = 1; $i < count($values); ++$i) {
+        for ($i = 1, $count = count($values); $i < $count; ++$i) {
             yield Range::ofInt($values[$i - 1], $values[$i]);
         }
 

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
+
+final class IntegerStepRangesGenerator implements RangesGeneratorInterface
+{
+    private int $start;
+
+    private int $end;
+
+    private int $step = 1;
+
+    private bool $isLeftOpen = true;
+
+    private bool $isRightOpen = true;
+
+    public function __construct(int $start, int $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    public function getStart(): int
+    {
+        return $this->start;
+    }
+
+    public function setStart(int $start): self
+    {
+        $this->start = $start;
+
+        return $this;
+    }
+
+    public function getEnd(): int
+    {
+        return $this->end;
+    }
+
+    public function setEnd(int $end): self
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    public function getStep(): int
+    {
+        return $this->step;
+    }
+
+    public function setStep(int $step): self
+    {
+        $this->step = $step;
+
+        return $this;
+    }
+
+    public function isLeftOpen(): bool
+    {
+        return $this->isLeftOpen;
+    }
+
+    public function setLeftOpen(bool $isLeftOpen): void
+    {
+        $this->isLeftOpen = $isLeftOpen;
+    }
+
+    public function isRightOpen(): bool
+    {
+        return $this->isRightOpen;
+    }
+
+    public function setRightOpen(bool $isRightOpen): self
+    {
+        $this->isRightOpen = $isRightOpen;
+
+        return $this;
+    }
+
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[]
+     */
+    public function generate(): \Generator
+    {
+        if ($this->isLeftOpen) {
+            yield Range::ofInt(Range::INF, $this->start);
+        }
+
+        $values = range($this->start, $this->end, $this->step);
+        for ($i = 1; $i < count($values); ++$i) {
+            yield Range::ofInt($values[$i - 1], $values[$i]);
+        }
+
+        if ($this->isRightOpen) {
+            yield Range::ofInt($this->end, Range::INF);
+        }
+    }
+}

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
@@ -90,7 +90,7 @@ final class IntegerStepRangesGenerator implements RangesGeneratorInterface
     }
 
     /**
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[]
+     * @return \Generator<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range>
      */
     public function generate(): Generator
     {

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGenerator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges;
 
+use Generator;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
 
 final class IntegerStepRangesGenerator implements RangesGeneratorInterface
@@ -69,9 +70,11 @@ final class IntegerStepRangesGenerator implements RangesGeneratorInterface
         return $this->isLeftOpen;
     }
 
-    public function setLeftOpen(bool $isLeftOpen): void
+    public function setLeftOpen(bool $isLeftOpen): self
     {
         $this->isLeftOpen = $isLeftOpen;
+
+        return $this;
     }
 
     public function isRightOpen(): bool
@@ -89,8 +92,14 @@ final class IntegerStepRangesGenerator implements RangesGeneratorInterface
     /**
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[]
      */
-    public function generate(): \Generator
+    public function generate(): Generator
     {
+        if ($this->start === $this->end && $this->isLeftOpen && $this->isRightOpen) {
+            yield new Range(Range::INF, Range::INF);
+
+            return;
+        }
+
         if ($this->isLeftOpen) {
             yield Range::ofInt(Range::INF, $this->start);
         }

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/RangesGeneratorInterface.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/RangesGeneratorInterface.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges;

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/RangesGeneratorInterface.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/Ranges/RangesGeneratorInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges;
+
+interface RangesGeneratorInterface
+{
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[]
+     */
+    public function generate(): iterable;
+}

--- a/src/contracts/Repository/Values/Content/Query/Aggregation/RawRangeAggregation.php
+++ b/src/contracts/Repository/Values/Content/Query/Aggregation/RawRangeAggregation.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\RangesGeneratorInterface;
+use Traversable;
+
 final class RawRangeAggregation extends AbstractRangeAggregation implements RawAggregation
 {
     /** @var string */
@@ -23,6 +26,19 @@ final class RawRangeAggregation extends AbstractRangeAggregation implements RawA
     public function getFieldName(): string
     {
         return $this->fieldName;
+    }
+
+    public static function fromGenerator(
+        string $name,
+        string $fieldName,
+        RangesGeneratorInterface $generator
+    ): self {
+        $ranges = $generator->generate();
+        if ($ranges instanceof Traversable) {
+            $ranges = iterator_to_array($ranges);
+        }
+
+        return new self($name, $fieldName, $ranges);
     }
 }
 

--- a/src/contracts/Repository/Values/Content/Search/AggregationResult/RangeAggregationResult.php
+++ b/src/contracts/Repository/Values/Content/Search/AggregationResult/RangeAggregationResult.php
@@ -59,6 +59,18 @@ final class RangeAggregationResult extends AggregationResult implements Iterator
         return $this->getEntry($key) !== null;
     }
 
+    /**
+     * Return available keys (ranges).
+     *
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range>
+     */
+    public function getKeys(): iterable
+    {
+        foreach ($this->entries as $entry) {
+            yield $entry->getKey();
+        }
+    }
+
     public function count(): int
     {
         return count($this->entries);

--- a/src/contracts/Repository/Values/Content/Search/AggregationResult/TermAggregationResult.php
+++ b/src/contracts/Repository/Values/Content/Search/AggregationResult/TermAggregationResult.php
@@ -62,6 +62,18 @@ class TermAggregationResult extends AggregationResult implements IteratorAggrega
         return $this->getEntry($key) !== null;
     }
 
+    /**
+     * Returns available keys (terms).
+     *
+     * @return iterable<object|string|int>
+     */
+    public function getKeys(): iterable
+    {
+        foreach ($this->entries as $entry) {
+            yield $entry->getKey();
+        }
+    }
+
     public function count(): int
     {
         return count($this->entries);

--- a/tests/integration/Core/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGeneratorTest.php
+++ b/tests/integration/Core/Repository/Values/Content/Query/Aggregation/Ranges/DateTimeStepRangesGeneratorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\Values\Content\Query\Aggregation\Ranges;
+
+use DateInterval;
+use DateTimeImmutable;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\DateTimeStepRangesGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class DateTimeStepRangesGeneratorTest extends TestCase
+{
+    public function testGenerateOpenRangesSequence(): void
+    {
+        self::assertGeneratorResults(
+            [
+                $this->createRange(Range::INF, '01-01-2023'),
+                $this->createRange('01-01-2023', '02-01-2023'),
+                $this->createRange('02-01-2023', '03-01-2023'),
+                $this->createRange('03-01-2023', Range::INF),
+            ],
+            new DateTimeStepRangesGenerator(
+                new DateTimeImmutable('01-01-2023 00:00:00'),
+                new DateTimeImmutable('03-01-2023 00:00:00')
+            )
+        );
+    }
+
+    public function testGenerateCloseRangesSequence(): void
+    {
+        $generator = new DateTimeStepRangesGenerator(
+            new DateTimeImmutable('01-01-2023 00:00:00'),
+            new DateTimeImmutable('03-01-2023 00:00:00')
+        );
+        $generator->setLeftOpen(false);
+        $generator->setRightOpen(false);
+
+        self::assertGeneratorResults(
+            [
+                $this->createRange('01-01-2023', '02-01-2023'),
+                $this->createRange('02-01-2023', '03-01-2023'),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateRangesWithCustomStep(): void
+    {
+        $generator = new DateTimeStepRangesGenerator(
+            new DateTimeImmutable('01-01-2023 00:00:00'),
+            new DateTimeImmutable('05-01-2023 00:00:00')
+        );
+        $generator->setStep(new DateInterval('P2D'));
+
+        self::assertGeneratorResults(
+            [
+                $this->createRange(Range::INF, '01-01-2023'),
+                $this->createRange('01-01-2023', '03-01-2023'),
+                $this->createRange('03-01-2023', '05-01-2023'),
+                $this->createRange('05-01-2023', Range::INF),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateInfRangesSequence(): void
+    {
+        $generator = new DateTimeStepRangesGenerator(
+            new DateTimeImmutable('01-01-1970 00:00:00'),
+            new DateTimeImmutable('01-01-1970 00:00:00'),
+        );
+
+        self::assertGeneratorResults(
+            [
+                Range::ofDateTime(Range::INF, Range::INF),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateEmptyRangesSequence(): void
+    {
+        $generator = new DateTimeStepRangesGenerator(
+            new DateTimeImmutable('01-01-1970 00:00:00'),
+            new DateTimeImmutable('01-01-1970 00:00:00'),
+        );
+        $generator->setLeftOpen(false);
+        $generator->setRightOpen(false);
+
+        self::assertGeneratorResults([], $generator);
+    }
+
+    private function createRange(?string $start, ?string $end): Range
+    {
+        return Range::ofDateTime(
+            $start !== null ? new DateTimeImmutable($start . ' 00:00:00') : null,
+            $end !== null ? new DateTimeImmutable($end . ' 00:00:00') : null
+        );
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[] $expectedResult
+     */
+    private static function assertGeneratorResults(array $expectedResult, DateTimeStepRangesGenerator $generator): void
+    {
+        self::assertEquals($expectedResult, $generator->generate());
+    }
+}

--- a/tests/integration/Core/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGeneratorTest.php
+++ b/tests/integration/Core/Repository/Values/Content/Query/Aggregation/Ranges/FloatStepRangesGeneratorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\Values\Content\Query\Aggregation\Ranges;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\FloatStepRangesGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class FloatStepRangesGeneratorTest extends TestCase
+{
+    public function testGenerateOpenRangesSequence(): void
+    {
+        self::assertGeneratorResults(
+            [
+                Range::ofFloat(Range::INF, 1.0),
+                Range::ofFloat(1.0, 2.0),
+                Range::ofFloat(2.0, 3.0),
+                Range::ofFloat(3.0, Range::INF),
+            ],
+            new FloatStepRangesGenerator(1.0, 3.0)
+        );
+    }
+
+    public function testGenerateCloseRangesSequence(): void
+    {
+        $generator = new FloatStepRangesGenerator(1.0, 3.0);
+        $generator->setLeftOpen(false);
+        $generator->setRightOpen(false);
+
+        self::assertGeneratorResults(
+            [
+                Range::ofFloat(1.0, 2.0),
+                Range::ofFloat(2.0, 3.0),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateRangesWithCustomStep(): void
+    {
+        $generator = new FloatStepRangesGenerator(1.0, 10.0);
+        $generator->setStep(2.0);
+
+        self::assertGeneratorResults(
+            [
+                Range::ofFloat(Range::INF, 1.0),
+                Range::ofFloat(1.0, 3.0),
+                Range::ofFloat(3.0, 5.0),
+                Range::ofFloat(5.0, 7.0),
+                Range::ofFloat(7.0, 9.0),
+                Range::ofFloat(10.0, Range::INF),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateInfRangesSequence(): void
+    {
+        $generator = new FloatStepRangesGenerator(0.0, 0.0);
+
+        self::assertGeneratorResults(
+            [
+                Range::ofFloat(Range::INF, Range::INF),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateEmptyRangesSequence(): void
+    {
+        $generator = new FloatStepRangesGenerator(0.0, 0.0);
+        $generator->setLeftOpen(false);
+        $generator->setRightOpen(false);
+
+        self::assertGeneratorResults([], $generator);
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[] $expectedResult
+     */
+    private static function assertGeneratorResults(array $expectedResult, FloatStepRangesGenerator $generator): void
+    {
+        self::assertEquals($expectedResult, $generator->generate());
+    }
+}

--- a/tests/integration/Core/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGeneratorTest.php
+++ b/tests/integration/Core/Repository/Values/Content/Query/Aggregation/Ranges/IntegerStepRangesGeneratorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\Values\Content\Query\Aggregation\Ranges;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Ranges\IntegerStepRangesGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class IntegerStepRangesGeneratorTest extends TestCase
+{
+    public function testGenerateOpenRangesSequence(): void
+    {
+        self::assertGeneratorResults(
+            [
+                Range::ofInt(Range::INF, 1),
+                Range::ofInt(1, 2),
+                Range::ofInt(2, 3),
+                Range::ofInt(3, Range::INF),
+            ],
+            new IntegerStepRangesGenerator(1, 3)
+        );
+    }
+
+    public function testGenerateCloseRangesSequence(): void
+    {
+        $generator = new IntegerStepRangesGenerator(1, 3);
+        $generator->setLeftOpen(false);
+        $generator->setRightOpen(false);
+
+        self::assertGeneratorResults(
+            [
+                Range::ofInt(1, 2),
+                Range::ofInt(2, 3),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateRangesWithCustomStep(): void
+    {
+        $generator = new IntegerStepRangesGenerator(1, 10);
+        $generator->setStep(2);
+
+        self::assertGeneratorResults(
+            [
+                Range::ofInt(Range::INF, 1),
+                Range::ofInt(1, 3),
+                Range::ofInt(3, 5),
+                Range::ofInt(5, 7),
+                Range::ofInt(7, 9),
+                Range::ofInt(10, Range::INF),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateInfRangesSequence(): void
+    {
+        $generator = new IntegerStepRangesGenerator(0, 0);
+
+        self::assertGeneratorResults(
+            [
+                Range::ofInt(Range::INF, Range::INF),
+            ],
+            $generator
+        );
+    }
+
+    public function testGenerateEmptyRangesSequence(): void
+    {
+        $generator = new IntegerStepRangesGenerator(0, 0);
+        $generator->setLeftOpen(false);
+        $generator->setRightOpen(false);
+
+        self::assertGeneratorResults([], $generator);
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range[] $expectedResult
+     */
+    private static function assertGeneratorResults(array $expectedResult, IntegerStepRangesGenerator $generator): void
+    {
+        self::assertEquals(
+            $expectedResult,
+            iterator_to_array($generator->generate())
+        );
+    }
+}

--- a/tests/lib/Repository/Values/Content/Query/Aggregation/RangeTest.php
+++ b/tests/lib/Repository/Values/Content/Query/Aggregation/RangeTest.php
@@ -71,6 +71,69 @@ final class RangeTest extends TestCase
         $this->assertEquals(new Range($a, $b), Range::ofDateTime($a, $b));
         $this->assertEquals(new Range($a, null), Range::ofDateTime($a, null));
     }
+
+    /**
+     * @dataProvider dataProviderForEqualsTo
+     */
+    public function testEqualsTo(Range $rangeA, Range $rangeB, bool $expectedResult): void
+    {
+        self::assertEquals($expectedResult, $rangeA->equalsTo($rangeB));
+        self::assertEquals($expectedResult, $rangeB->equalsTo($rangeA));
+    }
+
+    /**
+     * @return iterable<string, array{Range, Range, bool}>
+     */
+    public function dataProviderForEqualsTo(): iterable
+    {
+        yield 'int (true)' => [
+            Range::ofInt(1, 10),
+            Range::ofInt(1, 10),
+            true,
+        ];
+
+        yield 'int (false)' => [
+            Range::ofInt(1, 10),
+            Range::ofInt(1, 100),
+            false,
+        ];
+
+        yield 'float (true)' => [
+            Range::ofFloat(1.0, 10.0),
+            Range::ofFloat(1.0, 10.0),
+            true,
+        ];
+
+        yield 'float (false)' => [
+            Range::ofFloat(1.0, 10.0),
+            Range::ofFloat(1.0, 100.0),
+            false,
+        ];
+
+        yield 'data & time (true)' => [
+            Range::ofDateTime(
+                new DateTimeImmutable('2023-01-01 00:00:00'),
+                new DateTimeImmutable('2023-12-01 00:00:00')
+            ),
+            Range::ofDateTime(
+                new DateTimeImmutable('2023-01-01 00:00:00'),
+                new DateTimeImmutable('2023-12-01 00:00:00')
+            ),
+            true,
+        ];
+
+        yield 'data & time (false)' => [
+            Range::ofDateTime(
+                new DateTimeImmutable('2023-01-01 00:00:00'),
+                new DateTimeImmutable('2023-12-01 00:00:00')
+            ),
+            Range::ofDateTime(
+                new DateTimeImmutable('2024-01-01 00:00:00'),
+                new DateTimeImmutable('2024-12-01 00:00:00')
+            ),
+            false,
+        ];
+    }
 }
 
 class_alias(RangeTest::class, 'eZ\Publish\API\Repository\Tests\Values\Content\Query\Aggregation\RangeTest');


### PR DESCRIPTION
| Question                                 | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                           | [IBX-6827](https://issues.ibexa.co/browse/IBX-6827)
| **Required by** | ibexa/solr#56, ibexa/elasticsearch#31
| **Type**                                 | feature
| **Target Ibexa version**                 | `v4.6`
| **BC breaks**                            | no

This PR introduces several small Aggregation API improvements (DX).

### Range::INF

`Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range::INF` const allows developers to be more verbose when defining open ranges: 

```php
// Before:
new Range(null, 100)

// After:
new Range(Range::INF, 100)
```

### Range labels

Added `label` property with accessors to `\Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range` class. 


```php
new Range(Range::INF, new DateTime("01-01-2023"), "Published before 2023")
```

Labels can used latter on to render aggregation results.

### Simplified access to Term & Range Aggregations Result keys

It's very common to use term aggregations to get top N terms e.g 10 most popular categories. 

```php
$aggregation = new TaxonomyEntryIdAggregation('most_popular_categories');
$aggregation->setLimit(10);
```

In this use case we are not interested into how many object belongs to specific bucket. `\Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult::getKeys` method allows to retrieve terms without need to manually iterate over result entries.

### Ranges generators

#### Step generators

```php
$generator = new DateTimeStepRangesGenerator(new DateTime('2023-01-01'), new DateTime('2023-12-31'));
$generator->setStep(new DateInterval("P1M"));
$generator->setRightOpen(false);
$generator->setLeftOpen(true);

$aggregation = new DateRangeAggregation('enent_by_date', 'event', 'date', $generator->generate());
```

### Related PRs:

* https://github.com/ibexa/solr/pull/56
* https://github.com/ibexa/elasticsearch/pull/31


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
