### PR TITLE
IBX-6875: Implemented IsPreview View Matcher

### DIFF
--- a/src/lib/MVC/Symfony/Matcher/ContentBased/IsPreview.php
+++ b/src/lib/MVC/Symfony/Matcher/ContentBased/IsPreview.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\Matcher\ContentBased;
+
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Ibexa\Core\MVC\Symfony\Controller\Content\PreviewController;
+use Ibexa\Core\MVC\Symfony\Matcher\ViewMatcherInterface;
+use Ibexa\Core\MVC\Symfony\View\View;
+
+/**
+ * @internal
+ */
+final class IsPreview implements ViewMatcherInterface
+{
+    private bool $isPreview;
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function setMatchingConfig($matchingConfig): void
+    {
+        if (!is_bool($matchingConfig)) {
+            throw new InvalidArgumentException(
+                '$matchConfig',
+                sprintf(
+                    'IsPreview matcher expects true or false value, got a value of %s type',
+                    gettype($matchingConfig)
+                )
+            );
+        }
+
+        $this->isPreview = $matchingConfig;
+    }
+
+    public function match(View $view): bool
+    {
+        $isPreview = $view->hasParameter(PreviewController::PREVIEW_PARAMETER_NAME)
+            && $view->getParameter(PreviewController::PREVIEW_PARAMETER_NAME);
+
+        return $this->isPreview === $isPreview;
+    }
+}

--- a/src/lib/MVC/Symfony/Matcher/ContentBased/IsPreview.php
+++ b/src/lib/MVC/Symfony/Matcher/ContentBased/IsPreview.php
@@ -18,7 +18,7 @@ use Ibexa\Core\MVC\Symfony\View\View;
  */
 final class IsPreview implements ViewMatcherInterface
 {
-    private bool $isPreview;
+    private bool $isPreview = true;
 
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/IsPreviewTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/IsPreviewTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
+use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\IsPreview;
+use Ibexa\Core\MVC\Symfony\View\ContentView;
+use Ibexa\Core\MVC\Symfony\View\View;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\IsPreview
+ */
+final class IsPreviewTest extends TestCase
+{
+    private IsPreview $isPreviewMatcher;
+
+    protected function setUp(): void
+    {
+        $this->isPreviewMatcher = new IsPreview();
+    }
+
+    /**
+     * @return iterable<string, array{\Ibexa\Core\MVC\Symfony\View\View, boolean, boolean}>
+     */
+    public static function getDataForTestMatch(): iterable
+    {
+        $previewContentView = new ContentView();
+        $previewContentView->setParameters(['isPreview' => true]);
+
+        $notPreviewContentView = new ContentView();
+        $notPreviewContentView->setParameters(['isPreview' => false]);
+
+        $viewContentView = new ContentView();
+        yield 'match for preview content view' => [
+            $previewContentView,
+            true, // IsPreview: true
+            true, // matches the view
+        ];
+
+        yield 'do not match for preview content view' => [
+            $previewContentView,
+            false, // IsPreview: false
+            false, // doesn't match the view
+        ];
+
+        yield 'match for view content view' => [
+            $notPreviewContentView,
+            false, // IsPreview: false
+            true, // matches since it's not a preview content view
+        ];
+
+        yield 'do not match for view content view' => [
+            $notPreviewContentView,
+            true, // IsPreview: true
+            false, // doesn't match since it's not a preview content view
+        ];
+
+        yield 'not match for not set isPreview parameter' => [
+            $viewContentView,
+            true, // IsPreview: true
+            false, // by default, it's not a preview view if parameter is not set
+        ];
+
+        yield 'do not match for not set isPreview parameter' => [
+            $viewContentView,
+            false,
+            true, // matches not a preview view, when parameter is not set
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForTestMatch
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testMatch(View $view, bool $matchConfig, bool $expectedIsPreview): void
+    {
+        $this->isPreviewMatcher->setMatchingConfig($matchConfig);
+
+        self::assertSame($expectedIsPreview, $this->isPreviewMatcher->match($view));
+    }
+
+    public function testSetMatchConfigThrowsInvalidArgumentException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('IsPreview matcher expects true or false value, got a value of integer type');
+        $this->isPreviewMatcher->setMatchingConfig(123);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6875](https://issues.ibexa.co/browse/IBX-6875)
| **Required by**                     | ibexa/dashboard#26
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This PR proposes `IsPreview` View Matcher allowing to distinguish templates for the same view type and SiteAccess but preview or non-preview view. Alternatively this can be achieved by either creating separate view type or using Twig "ifs" like `{% if parameters.editorial_mode %}` (PB) or `{% if isPreview %}` (Core).

Consider the following configuration:
```yaml
ibexa:
  system:
    default:
      content_view:
        full:
          my_view:
            template: '@ibexadesign/app/my_view.html.twig'
            match:
              Identifier\ContentType: [ my_content_type ]
              IsPreview: false

          my_preview:
            template: '@ibexadesign/app/my_preview.html.twig'
            match:
              Identifier\ContentType: [ my_content_type ]
              IsPreview: true
```
When viewing a content of `my_content_type` content type `my_view.html.twig` template would be used. When previewing that content `my_preview.html.twig` would be used. Tested with `ibexa/dashboard` feature but that could work with core preview feature as well and maybe provide value overall.

**Review remark:** magic - this is legacy namespace-based view matcher - it's dynamically created as long as this class exists in that namespace...

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (`main`).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
