### PR TITLE
IBX-7149: Refactored content type-based indexing to rely on a dedicated strategy

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>&Traversable given\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/ExpireUserPasswordsCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/ResizeOriginalImagesCommand.php

--- a/phpstan-baseline-8.0.neon
+++ b/phpstan-baseline-8.0.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>&Traversable given\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/ExpireUserPasswordsCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/ResizeOriginalImagesCommand.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -319,7 +319,18 @@ parameters:
 			message: "#^Property Ibexa\\\\Bundle\\\\Core\\\\Command\\\\ReindexCommand\\:\\:\\$phpPath \\(string\\) does not accept string\\|null\\.$#"
 			count: 2
 			path: src/bundle/Core/Command/ReindexCommand.php
-
+		-
+			message: "#^Call to an undefined method iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\&Traversable\\:\\:valid\\(\\)\\.$#"
+			count: 1
+			path: src/bundle/Core/Command/ReindexCommand.php
+		-
+			message: "#^Call to an undefined method iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\&Traversable\\:\\:current\\(\\)\\.$#"
+			count: 1
+			path: src/bundle/Core/Command/ReindexCommand.php
+		-
+			message: "#^Call to an undefined method iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\&Traversable\\:\\:next\\(\\)\\.$#"
+			count: 1
+			path: src/bundle/Core/Command/ReindexCommand.php
 		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$fields\\.$#"
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,11 +271,6 @@ parameters:
 			path: src/bundle/Core/Command/ReindexCommand.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\ReindexCommand\\:\\:getPhpProcess\\(\\) has parameter \\$contentIds with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/ReindexCommand.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\ReindexCommand\\:\\:initialize\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/ReindexCommand.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -317,18 +317,6 @@ parameters:
 
 		-
 			message: "#^Property Ibexa\\\\Bundle\\\\Core\\\\Command\\\\ReindexCommand\\:\\:\\$phpPath \\(string\\) does not accept string\\|null\\.$#"
-			count: 2
-			path: src/bundle/Core/Command/ReindexCommand.php
-		-
-			message: "#^Call to an undefined method iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\&Traversable\\:\\:valid\\(\\)\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/ReindexCommand.php
-		-
-			message: "#^Call to an undefined method iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\&Traversable\\:\\:current\\(\\)\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/ReindexCommand.php
-		-
-			message: "#^Call to an undefined method iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\&Traversable\\:\\:next\\(\\)\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/ReindexCommand.php
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -256,11 +256,6 @@ parameters:
 			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
 
 		-
-			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\Content\\\\Location\\\\Handler\\:\\:\\$pathString\\.$#"
-			count: 2
-			path: src/bundle/Core/Command/ReindexCommand.php
-
-		-
 			message: "#^Call to an undefined method Ibexa\\\\Core\\\\Search\\\\Common\\\\Indexer\\:\\:purge\\(\\)\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/ReindexCommand.php
@@ -268,11 +263,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Ibexa\\\\Core\\\\Search\\\\Common\\\\Indexer\\:\\:updateSearchIndex\\(\\)\\.$#"
 			count: 2
-			path: src/bundle/Core/Command/ReindexCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\ReindexCommand\\:\\:__construct\\(\\) has parameter \\$searchIndexer with no type specified\\.$#"
-			count: 1
 			path: src/bundle/Core/Command/ReindexCommand.php
 
 		-
@@ -319,6 +309,7 @@ parameters:
 			message: "#^Property Ibexa\\\\Bundle\\\\Core\\\\Command\\\\ReindexCommand\\:\\:\\$phpPath \\(string\\) does not accept string\\|null\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/ReindexCommand.php
+
 		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$fields\\.$#"
 			count: 1
@@ -6930,11 +6921,6 @@ parameters:
 			path: src/contracts/Repository/Iterator/BatchIteratorAdapter/ContentFilteringAdapter.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Iterator\\\\BatchIteratorAdapter\\\\ContentFilteringAdapter\\:\\:fetch\\(\\) should return Iterator but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>&Traversable\\.$#"
-			count: 1
-			path: src/contracts/Repository/Iterator/BatchIteratorAdapter/ContentFilteringAdapter.php
-
-		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Iterator\\\\BatchIteratorAdapter\\\\LocationFilteringAdapter\\:\\:__construct\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Repository/Iterator/BatchIteratorAdapter/LocationFilteringAdapter.php
@@ -7081,11 +7067,6 @@ parameters:
 
 		-
 			message: "#^Class Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentList implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/contracts/Repository/Values/Content/ContentList.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentList\\:\\:__construct\\(\\) has parameter \\$contentItems with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Repository/Values/Content/ContentList.php
 
@@ -34341,11 +34322,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Traversable\\<mixed, mixed\\>\\:\\:offsetGet\\(\\)\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/Filtering/ContentFilteringTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>&Traversable\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/Filtering/ContentFilteringTest.php
 

--- a/src/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategy.php
+++ b/src/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategy.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Core\Command\Indexer\ContentIdList;
+
+use Generator;
+use Ibexa\Bundle\Core\Command\Indexer\ContentIdListGeneratorStrategyInterface;
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentList;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query;
+use Ibexa\Contracts\Core\Repository\Values\Filter\Filter;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @internal
+ */
+final class ContentTypeInputGeneratorStrategy implements ContentIdListGeneratorStrategyInterface
+{
+    private ContentService $contentService;
+
+    /** @var array<string, \Ibexa\Contracts\Core\Repository\Values\Content\ContentList> */
+    private static array $inMemoryContentListCache = [];
+
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     */
+    public function getGenerator(InputInterface $input, int $iterationCount): Generator
+    {
+        $contentList = $this->getContentList($input->getOption('content-type'));
+        $contentListIterator = $contentList->getIterator();
+        do {
+            $contentIds = [];
+            for ($i = 0; $i < $iterationCount; ++$i) {
+                if (!$contentListIterator->valid()) {
+                    break;
+                }
+                $contentIds[] = $contentListIterator->current()->getVersionInfo()->getContentInfo()->getId();
+                $contentListIterator->next();
+            }
+            if (empty($contentIds)) {
+                break;
+            }
+
+            yield $contentIds;
+        } while ($contentListIterator->valid());
+    }
+
+    public function shouldPurgeIndex(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     */
+    public function getCount(InputInterface $input): int
+    {
+        return $this->getContentList($input->getOption('content-type'))->getTotalCount();
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     */
+    private function getContentList(string $contentTypeIdentifier): ContentList
+    {
+        if (isset(self::$inMemoryContentListCache[$contentTypeIdentifier])) {
+            return self::$inMemoryContentListCache[$contentTypeIdentifier];
+        }
+
+        $filter = new Filter();
+        $filter
+            ->withCriterion(
+                new Query\Criterion\ContentTypeIdentifier($contentTypeIdentifier)
+            )
+        ;
+
+        self::$inMemoryContentListCache[$contentTypeIdentifier] = $this->contentService->find($filter);
+
+        return self::$inMemoryContentListCache[$contentTypeIdentifier];
+    }
+}

--- a/src/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategy.php
+++ b/src/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategy.php
@@ -37,22 +37,17 @@ final class ContentTypeInputGeneratorStrategy implements ContentIdListGeneratorS
     public function getGenerator(InputInterface $input, int $iterationCount): Generator
     {
         $contentList = $this->getContentList($input->getOption('content-type'));
-        $contentListIterator = $contentList->getIterator();
-        do {
-            $contentIds = [];
-            for ($i = 0; $i < $iterationCount; ++$i) {
-                if (!$contentListIterator->valid()) {
-                    break;
-                }
-                $contentIds[] = $contentListIterator->current()->getVersionInfo()->getContentInfo()->getId();
-                $contentListIterator->next();
+        $contentIds = [];
+        foreach ($contentList as $content) {
+            $contentIds[] = $content->getVersionInfo()->getContentInfo()->getId();
+            if (count($contentIds) >= $iterationCount) {
+                yield $contentIds;
+                $contentIds = [];
             }
-            if (empty($contentIds)) {
-                break;
-            }
-
+        }
+        if (!empty($contentIds)) {
             yield $contentIds;
-        } while ($contentListIterator->valid());
+        }
     }
 
     public function shouldPurgeIndex(): bool

--- a/src/bundle/Core/Command/Indexer/ContentIdListGeneratorStrategyInterface.php
+++ b/src/bundle/Core/Command/Indexer/ContentIdListGeneratorStrategyInterface.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 interface ContentIdListGeneratorStrategyInterface
 {
     /**
-     * @return \Generator<int, int[]>
+     * @return \Generator<int, array<int>>
      */
     public function getGenerator(InputInterface $input, int $iterationCount): Generator;
 

--- a/src/bundle/Core/Command/Indexer/ContentIdListGeneratorStrategyInterface.php
+++ b/src/bundle/Core/Command/Indexer/ContentIdListGeneratorStrategyInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Core\Command\Indexer;
+
+use Generator;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @internal
+ */
+interface ContentIdListGeneratorStrategyInterface
+{
+    /**
+     * @return \Generator<int, int[]>
+     */
+    public function getGenerator(InputInterface $input, int $iterationCount): Generator;
+
+    public function getCount(InputInterface $input): int;
+
+    public function shouldPurgeIndex(): bool;
+}

--- a/src/bundle/Core/Command/Indexer/ContentIdListGeneratorStrategyInterface.php
+++ b/src/bundle/Core/Command/Indexer/ContentIdListGeneratorStrategyInterface.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\Command\Indexer;
 
-use Generator;
+use Ibexa\Core\Search\Indexer\ContentIdBatchList;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -16,12 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
  */
 interface ContentIdListGeneratorStrategyInterface
 {
-    /**
-     * @return \Generator<int, array<int>>
-     */
-    public function getGenerator(InputInterface $input, int $iterationCount): Generator;
+    public function shouldPurgeIndex(InputInterface $input): bool;
 
-    public function getCount(InputInterface $input): int;
-
-    public function shouldPurgeIndex(): bool;
+    public function getBatchList(InputInterface $input, int $batchSize): ContentIdBatchList;
 }

--- a/src/bundle/Core/Command/ReindexCommand.php
+++ b/src/bundle/Core/Command/ReindexCommand.php
@@ -12,6 +12,7 @@ use const DIRECTORY_SEPARATOR;
 use Generator;
 use Ibexa\Contracts\Core\Persistence\Content\Location\Handler;
 use Ibexa\Contracts\Core\Repository\ContentService as APIContentService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentList;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Filter\Filter;
@@ -83,7 +84,6 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
         $this->isDebug = $isDebug;
         $this->projectDir = $projectDir;
         $this->contentService = $contentService;
-        $this->phpPath = $phpPath;
 
         parent::__construct();
     }
@@ -481,6 +481,7 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
 
     private function fetchIterationFromContentList(ContentList $contentList, int $iterationCount): Generator
     {
+        /** @var \ArrayIterator<int, Content> $contentListIterator */
         $contentListIterator = $contentList->getIterator();
 
         while ($contentListIterator->valid()) {

--- a/src/bundle/Core/Command/ReindexCommand.php
+++ b/src/bundle/Core/Command/ReindexCommand.php
@@ -59,7 +59,7 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
     private ContentIdListGeneratorStrategyInterface $contentIdListGeneratorStrategy;
 
     public function __construct(
-        $searchIndexer,
+        Indexer $searchIndexer,
         Handler $locationHandler,
         IndexerGateway $gateway,
         LoggerInterface $logger,
@@ -337,7 +337,7 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
         int $processCount,
         bool $commit
     ): void {
-        /** @var \Symfony\Component\Process\Process[]|null[] */
+        /** @var \Symfony\Component\Process\Process[]|null[] $processes */
         $processes = array_fill(0, $processCount, null);
         do {
             /** @var \Symfony\Component\Process\Process $process */

--- a/src/bundle/Core/Command/ReindexCommand.php
+++ b/src/bundle/Core/Command/ReindexCommand.php
@@ -481,16 +481,17 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
 
     private function fetchIterationFromContentList(ContentList $contentList, int $iterationCount): Generator
     {
-        $i = 1;
-        $contentIds = [];
-        foreach ($contentList as $content) {
-            $contentIds[] = $content->id;
-            if ($iterationCount <= $i) {
-                break;
+        $contentListIterator = $contentList->getIterator();
+
+        while ($contentListIterator->valid()) {
+            $contentIds = [];
+            for ($i = 0; $i < $iterationCount; ++$i) {
+                $contentIds[] = $contentListIterator->current()->id;
+                $contentListIterator->next();
             }
-            ++$i;
+
+            yield $contentIds;
         }
-        yield $contentIds;
     }
 }
 

--- a/src/bundle/Core/Resources/config/commands.yml
+++ b/src/bundle/Core/Resources/config/commands.yml
@@ -42,7 +42,7 @@ services:
             $env: '%kernel.environment%'
             $projectDir: '%kernel.project_dir%'
             $isDebug: '%kernel.debug%'
-            $contentService: '@Ibexa\Contracts\Core\Repository\ContentService'
+            $contentIdListGeneratorStrategy: '@Ibexa\Bundle\Core\Command\Indexer\ContentIdList\ContentTypeInputGeneratorStrategy'
         tags:
             - { name: console.command }
 
@@ -65,3 +65,7 @@ services:
     Ibexa\Bundle\Core\Command\ExpireUserPasswordsCommand:
         autowire: true
         autoconfigure: true
+
+    # Dedicated services for commands
+    Ibexa\Bundle\Core\Command\Indexer\ContentIdList\ContentTypeInputGeneratorStrategy:
+        autowire: true

--- a/src/contracts/Repository/Values/Content/ContentList.php
+++ b/src/contracts/Repository/Values/Content/ContentList.php
@@ -11,7 +11,6 @@ namespace Ibexa\Contracts\Core\Repository\Values\Content;
 use ArrayIterator;
 use Ibexa\Contracts\Core\Repository\Collections\TotalCountAwareInterface;
 use IteratorAggregate;
-use Traversable;
 
 /**
  * A filtered Content items list iterator.
@@ -19,13 +18,15 @@ use Traversable;
 final class ContentList implements IteratorAggregate, TotalCountAwareInterface
 {
     /** @var int */
-    private $totalCount;
+    private int $totalCount;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content[] */
-    private $contentItems;
+    private array $contentItems;
 
     /**
      * @internal for internal use by Repository
+     *
+     * @param array<\Ibexa\Contracts\Core\Repository\Values\Content\Content> $contentItems
      */
     public function __construct(int $totalCount, array $contentItems)
     {
@@ -39,9 +40,9 @@ final class ContentList implements IteratorAggregate, TotalCountAwareInterface
     }
 
     /**
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content[]|\Traversable
+     * @return \ArrayIterator<int, \Ibexa\Contracts\Core\Repository\Values\Content\Content>
      */
-    public function getIterator(): Traversable
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->contentItems);
     }

--- a/src/lib/Search/Indexer/ContentIdBatchList.php
+++ b/src/lib/Search/Indexer/ContentIdBatchList.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Search\Indexer;
+
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @internal content id batch list for ReindexCommand
+ *
+ * @see \Ibexa\Bundle\Core\Command\ReindexCommand
+ *
+ * @implements \IteratorAggregate<int, array<int>>
+ */
+final class ContentIdBatchList implements IteratorAggregate
+{
+    /** @var iterable<int, array<int>> */
+    private iterable $list;
+
+    private int $totalCount;
+
+    /**
+     * @param iterable<int, array<int>> $list
+     */
+    public function __construct(iterable $list, int $totalCount)
+    {
+        $this->list = $list;
+        $this->totalCount = $totalCount;
+    }
+
+    /**
+     * return \Traversable<int, array<int>>.
+     */
+    public function getIterator(): Traversable
+    {
+        yield from $this->list;
+    }
+
+    public function getCount(): int
+    {
+        return $this->totalCount;
+    }
+}

--- a/tests/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategyTest.php
+++ b/tests/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategyTest.php
@@ -26,10 +26,8 @@ final class ContentTypeInputGeneratorStrategyTest extends TestCase
      * @dataProvider getDataForTestGetGenerator
      *
      * @param array<int, int[]> $expectedBatches
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
      */
-    public function testGetGenerator(ContentList $contentList, int $iterationCount, array $expectedBatches): void
+    public function testGetGenerator(ContentList $contentList, int $batchSize, array $expectedBatches): void
     {
         $contentServiceMock = $this->createMock(ContentService::class);
         $contentServiceMock->method('find')->willReturn($contentList);
@@ -37,11 +35,11 @@ final class ContentTypeInputGeneratorStrategyTest extends TestCase
         $inputMock = $this->createMock(InputInterface::class);
         $inputMock->method('getOption')->with('content-type')->willReturn(uniqid('type', true));
 
-        $generator = new ContentTypeInputGeneratorStrategy($contentServiceMock);
+        $strategy = new ContentTypeInputGeneratorStrategy($contentServiceMock);
 
         self::assertSame(
             $expectedBatches,
-            iterator_to_array($generator->getGenerator($inputMock, $iterationCount))
+            iterator_to_array($strategy->getBatchList($inputMock, $batchSize))
         );
     }
 

--- a/tests/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategyTest.php
+++ b/tests/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Core\Command\Indexer\ContentIdList;
+
+use Ibexa\Bundle\Core\Command\Indexer\ContentIdList\ContentTypeInputGeneratorStrategy;
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentList;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Core\Repository\Values\Content\Content;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @covers \Ibexa\Bundle\Core\Command\Indexer\ContentIdList\ContentTypeInputGeneratorStrategy
+ */
+final class ContentTypeInputGeneratorStrategyTest extends TestCase
+{
+    /**
+     * @dataProvider getDataForTestGetGenerator
+     *
+     * @param array<int, int[]> $expectedBatches
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     */
+    public function testGetGenerator(ContentList $contentList, int $iterationCount, array $expectedBatches): void
+    {
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock->method('find')->willReturn($contentList);
+
+        $inputMock = $this->createMock(InputInterface::class);
+        $inputMock->method('getOption')->with('content-type')->willReturn(uniqid('type', true));
+
+        $generator = new ContentTypeInputGeneratorStrategy($contentServiceMock);
+
+        self::assertSame(
+            $expectedBatches,
+            iterator_to_array($generator->getGenerator($inputMock, $iterationCount))
+        );
+    }
+
+    /**
+     * @return iterable<string, array{\Ibexa\Contracts\Core\Repository\Values\Content\ContentList, int, array<int, int[]>}>
+     */
+    public function getDataForTestGetGenerator(): iterable
+    {
+        yield 'iteration count = 3, items = 10' => [
+            $this->generateContentList(10),
+            3,
+            [
+                [1, 2, 3],
+                [4, 5, 6],
+                [7, 8, 9],
+                [10],
+            ],
+        ];
+
+        yield 'iteration count = 6, items = 6' => [
+            $this->generateContentList(6),
+            6,
+            [
+                [1, 2, 3, 4, 5, 6],
+            ],
+        ];
+
+        yield 'iteration count = 2, items = 4' => [
+            $this->generateContentList(4),
+            2,
+            [
+                [1, 2],
+                [3, 4],
+            ],
+        ];
+
+        yield 'iteration count = 10, items = 5' => [
+            $this->generateContentList(5),
+            10,
+            [
+                [1, 2, 3, 4, 5],
+            ],
+        ];
+
+        yield 'iteration count = 5, items = 0' => [
+            $this->generateContentList(0),
+            5,
+            [],
+        ];
+    }
+
+    private function generateContentList(int $totalCount): ContentList
+    {
+        $contentItems = [];
+        for ($i = 0; $i < $totalCount; ++$i) {
+            $contentItems[] = $this->createContentItemWithIdMock($i + 1);
+        }
+
+        return new ContentList($totalCount, $contentItems);
+    }
+
+    private function createContentItemWithIdMock(int $id): Content
+    {
+        $contentItem = $this->createMock(Content::class);
+        $contentInfoMock = $this->createMock(ContentInfo::class);
+        $contentInfoMock->method('getId')->willReturn($id);
+        $versionInfoMock = $this->createMock(VersionInfo::class);
+        $versionInfoMock->method('getContentInfo')->willReturn($contentInfoMock);
+        $contentItem->method('getVersionInfo')->willReturn($versionInfoMock);
+
+        return $contentItem;
+    }
+}

--- a/tests/integration/Core/Repository/Filtering/ContentFilteringTest.php
+++ b/tests/integration/Core/Repository/Filtering/ContentFilteringTest.php
@@ -112,7 +112,9 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
         return new ContentList(
             $searchResults->totalCount,
             array_map(
-                static function (SearchHit $searchHit) {
+                static function (SearchHit $searchHit): Content {
+                    self::assertInstanceOf(Content::class, $searchHit->valueObject);
+
                     return $searchHit->valueObject;
                 },
                 $searchResults->searchHits
@@ -332,7 +334,9 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
         $filter = new Filter(new Criterion\ContentId(57), [$sortClause]);
         $contentList = $this->find($filter, []);
         self::assertCount(1, $contentList);
-        self::assertSame(57, $contentList->getIterator()[0]->id);
+        $contentItem = $contentList->getIterator()[0];
+        self::assertNotNull($contentItem);
+        self::assertSame(57, $contentItem->id);
     }
 
     /**

--- a/tests/lib/Search/Indexer/ContentIdBatchListTest.php
+++ b/tests/lib/Search/Indexer/ContentIdBatchListTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Search\Indexer;
+
+use ArrayIterator;
+use Generator;
+use Ibexa\Core\Search\Indexer\ContentIdBatchList;
+use IteratorAggregate;
+use PHPUnit\Framework\TestCase;
+use Traversable;
+
+/**
+ * @covers \Ibexa\Core\Search\Indexer\ContentIdBatchList
+ */
+final class ContentIdBatchListTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{iterable<int, array<int>>, int, array<int, array<int>>}>
+     */
+    public function getDataForTestGetIterator(): iterable
+    {
+        yield 'generator' => [
+            $this->buildGenerator(),
+            5,
+            [
+                [1, 2, 3],
+                [4, 5],
+            ],
+        ];
+
+        yield 'array' => [
+            [
+                [1, 2],
+                [3, 4],
+                [5],
+            ],
+            5,
+            [
+                [1, 2],
+                [3, 4],
+                [5],
+            ],
+        ];
+
+        yield 'Traversable object' => [
+            $this->buildTraversableObject(),
+            5,
+            [
+                [1, 2, 3, 4],
+                [5],
+            ],
+        ];
+
+        yield 'empty generator' => [
+            $this->buildEmptyGenerator(),
+            0,
+            [],
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForTestGetIterator
+     *
+     * @param iterable<int, array<int>> $list
+     * @param array<int, array<int>> $expectedBatches
+     */
+    public function testGetIterator(iterable $list, int $totalCount, array $expectedBatches): void
+    {
+        $contentIdBatchList = new ContentIdBatchList($list, $totalCount);
+        $unpackedActualBatches = [];
+        foreach ($contentIdBatchList as $index => $items) {
+            $unpackedActualBatches[$index] = $items;
+        }
+        self::assertSame($expectedBatches, $unpackedActualBatches);
+    }
+
+    public function testGetCount(): void
+    {
+        $contentIdBatchList = new ContentIdBatchList([[1, 2, 3]], 3);
+        self::assertSame(3, $contentIdBatchList->getCount());
+    }
+
+    private function buildGenerator(): Generator
+    {
+        yield [1, 2, 3];
+        yield [4, 5];
+    }
+
+    private function buildEmptyGenerator(): \Generator
+    {
+        yield from [];
+    }
+
+    /**
+     * @return \Traversable<int, array<int>>
+     */
+    private function buildTraversableObject(): Traversable
+    {
+        return new class() implements IteratorAggregate {
+            /**
+             * @return \ArrayIterator<int, array{int, int, int, int}|array{int}>
+             */
+            public function getIterator(): ArrayIterator
+            {
+                return new ArrayIterator(
+                    [
+                        [1, 2, 3, 4],
+                        [5],
+                    ]
+                );
+            }
+        };
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7149](https://issues.ibexa.co/browse/IBX-7149)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`+
| **BC breaks**                          | no

**_Maintainer update:_**

Given how complex and error-prone content id batch generating logic is, the fix includes the first portion of refactoring, introducing internal, command-dedicated `\Ibexa\Bundle\Core\Command\Indexer\ContentIdListGeneratorStrategyInterface` which produces `\Ibexa\Core\Search\Indexer\ContentIdBatchList` result wrapper object containing iterable batches of content Ids (meaning content id list chunks/slices) and total count of content ids.

This is the first in a series of refactoring steps, making the command more stable, as reindexing is mission-critical part of content delivery system. The refactoring allows for better test coverage of crucial parts of the logic, aiming towards more single-responsibility-oriented approach.

### QA

Sanity check of `ibexa:reindex` command for various argument lists of the command, including different iteration count (meaning really different batch sizes) on an instance with test fixtures data. 
There are foremost 2 edge cases:
- list of content items of a given content type, which exceeds the batch size (let's say are all 12 folders in the system indexed when using `--content-type=folder` option? - **see that before the fix they weren't**) 
- empty list of content items for given criteria (can be e.g. `--subtree`, but should be tested against `--content-type` as well)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
