### PR TITLE
IBX-7236: Added support of % on both sides of a 'like' statement in fulltext criterion

### DIFF
--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -146,10 +146,9 @@ class FullText extends CriterionHandler
      */
     protected function getWordExpression(QueryBuilder $query, string $token): string
     {
-        if ($this->configuration['enableWildcards'] && str_contains($token, '*')) {
-            $hasLeadingWildcard = str_starts_with($token, '*');
-            $hasTrailingWildcard = str_ends_with($token, '*');
-
+        $hasLeadingWildcard = str_starts_with($token, '*');
+        $hasTrailingWildcard = str_ends_with($token, '*');
+        if ($this->configuration['enableWildcards'] && ($hasLeadingWildcard || $hasTrailingWildcard)) {
             $token = $hasLeadingWildcard ? substr($token, 1) : $token;
             $token = $hasTrailingWildcard ? substr($token, 0, -1) : $token;
 

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -146,7 +146,7 @@ class FullText extends CriterionHandler
      */
     protected function getWordExpression(QueryBuilder $query, string $token): string
     {
-        if ($this->configuration['enableWildcards'] && str_contains('*', $token)) {
+        if ($this->configuration['enableWildcards'] && str_contains($token, '*')) {
             $hasLeadingWildcard = str_starts_with($token, '*');
             $hasTrailingWildcard = str_ends_with($token, '*');
 

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -147,8 +147,8 @@ class FullText extends CriterionHandler
     protected function getWordExpression(QueryBuilder $query, string $token): string
     {
         if ($this->configuration['enableWildcards']) {
-            $hasLeadingWildcard = $token[0] === '*';
-            $hasTrailingWildcard = $token[strlen($token) - 1] === '*';
+            $hasLeadingWildcard = str_starts_with($token, '*');
+            $hasTrailingWildcard = str_ends_with($token, '*');
 
             $token = $hasLeadingWildcard ? substr($token, 1) : $token;
             $token = $hasTrailingWildcard ? substr($token, 0, -1) : $token;

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -146,7 +146,7 @@ class FullText extends CriterionHandler
      */
     protected function getWordExpression(QueryBuilder $query, string $token): string
     {
-        if ($this->configuration['enableWildcards']) {
+        if ($this->configuration['enableWildcards'] && str_contains('*', $token)) {
             $hasLeadingWildcard = str_starts_with($token, '*');
             $hasTrailingWildcard = str_ends_with($token, '*');
 

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -146,17 +146,21 @@ class FullText extends CriterionHandler
      */
     protected function getWordExpression(QueryBuilder $query, string $token): string
     {
-        if ($this->configuration['enableWildcards'] && $token[0] === '*') {
-            return $query->expr()->like(
-                'word',
-                $query->createNamedParameter('%' . substr($token, 1))
-            );
-        }
+        if ($this->configuration['enableWildcards']) {
+            $hasLeadingWildcard = $token[0] === '*';
+            $hasTrailingWildcard = $token[strlen($token) - 1] === '*';
 
-        if ($this->configuration['enableWildcards'] && $token[strlen($token) - 1] === '*') {
+            $token = $hasLeadingWildcard ? substr($token, 1) : $token;
+            $token = $hasTrailingWildcard ? substr($token, 0, -1) : $token;
+
+            $token = str_replace('%', '\\%', $token);
+
+            $token = $hasLeadingWildcard ? '%' . $token : $token;
+            $token = $hasTrailingWildcard ? $token . '%' : $token;
+
             return $query->expr()->like(
                 'word',
-                $query->createNamedParameter(substr($token, 0, -1) . '%')
+                $query->createNamedParameter($token)
             );
         }
 

--- a/tests/integration/Core/Repository/SearchServiceFulltextTest.php
+++ b/tests/integration/Core/Repository/SearchServiceFulltextTest.php
@@ -166,6 +166,10 @@ class SearchServiceFulltextTest extends BaseTest
                 [[1, 5, 6, 7, 11, 12, 13, 15]],
             ],
             [
+                '*row*',
+                [[2,5,8,9,11,12,14,15]],
+            ],
+            [
                 '+qui* +fox',
                 [6, [11, 13], 15],
             ],

--- a/tests/integration/Core/Repository/SearchServiceFulltextTest.php
+++ b/tests/integration/Core/Repository/SearchServiceFulltextTest.php
@@ -167,7 +167,7 @@ class SearchServiceFulltextTest extends BaseTest
             ],
             [
                 '*row*',
-                [[2,5,8,9,11,12,14,15]],
+                [[2, 5, 8, 9, 11, 12, 14, 15]],
             ],
             [
                 '+qui* +fox',


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7236](https://issues.ibexa.co/browse/IBX-7236)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This PR adds support of % on both sides of like statement in fulltext criterion

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
