### PR TITLE
IBX-6856: Added mime types limitation for ezimage field type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10746,11 +10746,6 @@ parameters:
 			path: src/lib/FieldType/Validator/FloatValueValidator.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\Validator\\\\ImageValidator\\:\\:innerValidate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/FieldType/Validator/ImageValidator.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\Validator\\\\ImageValidator\\:\\:innerValidate\\(\\) has parameter \\$filePath with no type specified\\.$#"
 			count: 1
 			path: src/lib/FieldType/Validator/ImageValidator.php
@@ -30641,16 +30636,6 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getValidUpdateFieldData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getValidUpdateFieldData\\(\\) should return array but returns Ibexa\\\\Core\\\\FieldType\\\\Image\\\\Value\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getValidatorSchema\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -30698,11 +30683,6 @@ parameters:
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:testUpdatingImageMetadataOnlyWorks\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$newImageValue of method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:updateImage\\(\\) expects Ibexa\\\\Core\\\\FieldType\\\\Image\\\\Value, array given\\.$#"
-			count: 2
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
 		-

--- a/src/lib/FieldType/Validator.php
+++ b/src/lib/FieldType/Validator.php
@@ -7,6 +7,7 @@
 namespace Ibexa\Core\FieldType;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\PropertyNotFoundException as PropertyNotFound;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 
 /**
  * Base field type validator validator.
@@ -98,7 +99,7 @@ abstract class Validator
      *
      * @return bool
      */
-    abstract public function validate(Value $value);
+    abstract public function validate(Value $value, ?FieldDefinition $fieldDefinition = null);
 
     /**
      * Returns array of messages on performed validations.

--- a/src/lib/FieldType/Validator/EmailAddressValidator.php
+++ b/src/lib/FieldType/Validator/EmailAddressValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -84,7 +85,7 @@ class EmailAddressValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $pattern = '/^((\"[^\"\f\n\r\t\v\b]+\")|([A-Za-z0-9_\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+(\.[A-Za-z0-9_\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+)*))@((\[(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))\])|(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))|((([A-Za-z0-9\-])+\.)+[A-Za-z\-]{2,}))$/';
 

--- a/src/lib/FieldType/Validator/FileExtensionBlackListValidator.php
+++ b/src/lib/FieldType/Validator/FileExtensionBlackListValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
@@ -45,7 +46,7 @@ class FileExtensionBlackListValidator extends Validator
     /**
      * {@inheritdoc}
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         if (
             pathinfo($value->fileName, PATHINFO_BASENAME) !== $value->fileName ||

--- a/src/lib/FieldType/Validator/FileSizeValidator.php
+++ b/src/lib/FieldType/Validator/FileSizeValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -66,7 +67,7 @@ class FileSizeValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/FieldType/Validator/FloatValueValidator.php
+++ b/src/lib/FieldType/Validator/FloatValueValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -82,7 +83,7 @@ class FloatValueValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/FieldType/Validator/ImageValidator.php
+++ b/src/lib/FieldType/Validator/ImageValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value;
@@ -15,7 +16,7 @@ class ImageValidator extends Validator
     /**
      * {@inheritdoc}
      */
-    public function validateConstraints($constraints)
+    public function validateConstraints($constraints, ?FieldDefinition $fieldDefinition = null)
     {
         return [];
     }
@@ -23,30 +24,58 @@ class ImageValidator extends Validator
     /**
      * {@inheritdoc}
      */
-    public function validate(Value $value)
+    public function validate(Value $value, ?FieldDefinition $fieldDefinition = null)
     {
+        $mimeTypes = [];
+        if (null !== $fieldDefinition) {
+            $mimeTypes = $fieldDefinition->getFieldSettings()['mimeTypes'] ?? [];
+        }
+
         $isValid = true;
-        if (isset($value->inputUri) && !$this->innerValidate($value->inputUri)) {
+        if (isset($value->inputUri) && !$this->innerValidate($value->inputUri, $mimeTypes)) {
             $isValid = false;
         }
 
         // BC: Check if file is a valid image if the value of 'id' matches a local file
-        if (isset($value->id) && file_exists($value->id) && !$this->innerValidate($value->id)) {
+        if (isset($value->id) && file_exists($value->id) && !$this->innerValidate($value->id, $mimeTypes)) {
             $isValid = false;
         }
 
         return $isValid;
     }
 
-    private function innerValidate($filePath)
+    /**
+     * @param array<string> $mimeTypes
+     */
+    private function innerValidate($filePath, array $mimeTypes): bool
     {
         // silence `getimagesize` error as extension-wise valid image files might produce it anyway
         // note that file extension checking is done using other validation which should be called before this one
-        if (!@getimagesize($filePath)) {
+        if (!$imageData = @getimagesize($filePath)) {
             $this->errors[] = new ValidationError(
                 'A valid image file is required.',
                 null,
                 [],
+                'id'
+            );
+
+            return false;
+        }
+
+        // If array with mime types is empty, it means that all mime types are allowed
+        if (empty($mimeTypes)) {
+            return true;
+        }
+
+        $mimeType = $imageData['mime'];
+        if (!in_array($mimeType, $mimeTypes, true)) {
+            $this->errors[] = new ValidationError(
+                'The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.',
+                null,
+                [
+                    '%mimeType%' => $mimeType,
+                    '%mimeTypes%' => implode(', ', $mimeTypes),
+                ],
                 'id'
             );
 

--- a/src/lib/FieldType/Validator/IntegerValueValidator.php
+++ b/src/lib/FieldType/Validator/IntegerValueValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -85,7 +86,7 @@ class IntegerValueValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/FieldType/Validator/StringLengthValidator.php
+++ b/src/lib/FieldType/Validator/StringLengthValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -104,7 +105,7 @@ class StringLengthValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -186,6 +186,10 @@ EOT;
         $storageDef->dataFloat1 = $validators['FileSizeValidator']['maxFileSize'] ?? 0.0;
         $storageDef->dataInt2 = (int)($validators['AlternativeTextValidator']['required'] ?? 0);
         $storageDef->dataText1 = 'MB';
+
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+
+        $storageDef->dataText5 = json_encode($fieldSettings['mimeTypes'] ?? [], JSON_THROW_ON_ERROR);
     }
 
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef): void
@@ -200,8 +204,25 @@ EOT;
                         'required' => (bool)$storageDef->dataInt2,
                     ],
                 ],
+                'fieldSettings' => $this->getFieldSettings($storageDef),
             ]
         );
+    }
+
+    /**
+     * @return array<string>
+     *
+     * @throws \JsonException
+     */
+    private function getFieldSettings(StorageFieldDefinition $storageFieldDefinition): array
+    {
+        $mimeTypes = $storageFieldDefinition->dataText5;
+
+        return [
+            'mimeTypes' => !empty($mimeTypes)
+                ? json_decode($mimeTypes, true, 512, JSON_THROW_ON_ERROR)
+                : [],
+        ];
     }
 
     /**

--- a/src/lib/Resources/settings/fieldtypes.yml
+++ b/src/lib/Resources/settings/fieldtypes.yml
@@ -249,6 +249,16 @@ parameters:
         ZM: {Name: "Zambia", Alpha2: "ZM", Alpha3: "ZMB", IDC: "260"}
         ZW: {Name: "Zimbabwe", Alpha2: "ZW", Alpha3: "ZWE", IDC: "263"}
 
+    ibexa.field_type.ezimage.mime_types:
+        - image/jpeg
+        - image/pjpeg
+        - image/png
+        - image/bmp
+        - image/gif
+        - image/tiff
+        - image/x-icon
+        - image/webp
+
 services:
     Ibexa\Core\FieldType\FieldType:
         class: Ibexa\Core\FieldType\FieldType
@@ -325,7 +335,10 @@ services:
     Ibexa\Core\FieldType\Image\Type:
         class: Ibexa\Core\FieldType\Image\Type
         arguments:
-            - ['@Ibexa\Core\FieldType\Validator\FileExtensionBlackListValidator', '@Ibexa\Core\FieldType\Validator\ImageValidator']
+            $validators:
+                - '@Ibexa\Core\FieldType\Validator\FileExtensionBlackListValidator'
+                - '@Ibexa\Core\FieldType\Validator\ImageValidator'
+            $mimeTypes: '%ibexa.field_type.ezimage.mime_types%'
         parent: Ibexa\Core\FieldType\FieldType
         tags:
             - {name: ibexa.field_type, alias: ezimage}

--- a/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -77,7 +77,12 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      */
     public function getSettingsSchema()
     {
-        return [];
+        return [
+            'mimeTypes' => [
+                'type' => 'choice',
+                'default' => [],
+            ],
+        ];
     }
 
     /**
@@ -87,7 +92,12 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      */
     public function getValidFieldSettings()
     {
-        return [];
+        return [
+            'mimeTypes' => [
+                'image/jpeg',
+                'image/png',
+            ],
+        ];
     }
 
     /**
@@ -231,7 +241,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Get update field externals data.
      *
-     * @return array
+     * @return \Ibexa\Core\FieldType\Image\Value
      */
     public function getValidUpdateFieldData()
     {

--- a/tests/lib/FieldType/ImageTest.php
+++ b/tests/lib/FieldType/ImageTest.php
@@ -21,6 +21,12 @@ use Ibexa\Core\FieldType\Validator\ImageValidator;
  */
 class ImageTest extends FieldTypeTest
 {
+    private const MIME_TYPES = [
+        'image/png',
+        'image/jpeg',
+        'image/gif',
+    ];
+
     protected $blackListedExtensions = [
         'php',
         'php3',
@@ -61,10 +67,13 @@ class ImageTest extends FieldTypeTest
      */
     protected function createFieldTypeUnderTest()
     {
-        $fieldType = new ImageType([
-            $this->getBlackListValidatorMock(),
-            $this->getImageValidatorMock(),
-        ]);
+        $fieldType = new ImageType(
+            self::MIME_TYPES,
+            [
+                $this->getBlackListValidatorMock(),
+                $this->getImageValidatorMock(),
+            ]
+        );
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
 
         return $fieldType;
@@ -132,7 +141,12 @@ class ImageTest extends FieldTypeTest
      */
     protected function getSettingsSchemaExpectation()
     {
-        return [];
+        return [
+            'mimeTypes' => [
+                'type' => 'choice',
+                'default' => [],
+            ],
+        ];
     }
 
     /**
@@ -853,6 +867,36 @@ class ImageTest extends FieldTypeTest
                         null,
                         [],
                         'alternativeText'
+                    ),
+                ],
+            ],
+            'Image with not allowed mime type' => [
+                [
+                    'fieldSettings' => [
+                        'mimeTypes' => [
+                            'image/png',
+                            'image/gif',
+                        ],
+                    ],
+                ],
+                new ImageValue(
+                    [
+                        'id' => $this->getImageInputPath(),
+                        'fileName' => basename($this->getImageInputPath()),
+                        'fileSize' => filesize($this->getImageInputPath()),
+                        'alternativeText' => '',
+                        'uri' => '',
+                    ]
+                ),
+                [
+                    new ValidationError(
+                        'The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.',
+                        null,
+                        [
+                            '%mimeType%' => 'image/jpeg',
+                            '%mimeTypes%' => 'image/png, image/gif',
+                        ],
+                        'id'
                     ),
                 ],
             ],

--- a/tests/lib/Persistence/FieldValue/Converter/ImageConverterTest.php
+++ b/tests/lib/Persistence/FieldValue/Converter/ImageConverterTest.php
@@ -18,6 +18,13 @@ use PHPUnit\Framework\TestCase;
 
 final class ImageConverterTest extends TestCase
 {
+    private const MIME_TYPES = [
+        'image/png',
+        'image/jpeg',
+    ];
+
+    private const MIME_TYPES_STORAGE_VALUE = '["image\/png","image\/jpeg"]';
+
     /** @var \Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter */
     private $imageConverter;
 
@@ -57,7 +64,7 @@ final class ImageConverterTest extends TestCase
 
     public function dataProviderForTestToStorageFieldDefinition(): iterable
     {
-        yield [
+        yield 'No validators' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [],
@@ -67,10 +74,11 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 0.0,
                 'dataInt2' => 0,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
             ]),
         ];
 
-        yield [
+        yield 'FileSizeValidator' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [
@@ -84,10 +92,11 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 1.0,
                 'dataInt2' => 0,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
             ]),
         ];
 
-        yield [
+        yield 'AlternativeTextValidator - required' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [
@@ -101,10 +110,11 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 0.0,
                 'dataInt2' => 1,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
             ]),
         ];
 
-        yield [
+        yield 'AlternativeTextValidator - not required' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [
@@ -118,6 +128,23 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 0.0,
                 'dataInt2' => 0,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
+            ]),
+        ];
+
+        yield 'mimeTypes' => [
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'fieldSettings' => [
+                        'mimeTypes' => self::MIME_TYPES,
+                    ],
+                ]),
+            ]),
+            new StorageFieldDefinition([
+                'dataFloat1' => 0.0,
+                'dataInt2' => 0,
+                'dataText1' => 'MB',
+                'dataText5' => self::MIME_TYPES_STORAGE_VALUE,
             ]),
         ];
     }
@@ -145,6 +172,7 @@ final class ImageConverterTest extends TestCase
             new StorageFieldDefinition([
                 'dataFloat1' => 0.0,
                 'dataInt2' => 0,
+                'dataText5' => [],
             ]),
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
@@ -156,6 +184,9 @@ final class ImageConverterTest extends TestCase
                             'required' => false,
                         ],
                     ],
+                    'fieldSettings' => [
+                        'mimeTypes' => [],
+                    ],
                 ]),
             ]),
         ];
@@ -164,6 +195,7 @@ final class ImageConverterTest extends TestCase
             new StorageFieldDefinition([
                 'dataFloat1' => 1.0,
                 'dataInt2' => 1,
+                'dataText5' => self::MIME_TYPES_STORAGE_VALUE,
             ]),
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
@@ -174,6 +206,9 @@ final class ImageConverterTest extends TestCase
                         'AlternativeTextValidator' => [
                             'required' => true,
                         ],
+                    ],
+                    'fieldSettings' => [
+                        'mimeTypes' => self::MIME_TYPES,
                     ],
                 ]),
             ]),


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6856](https://issues.ibexa.co/browse/IBX-6856)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes/no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
