### PR TITLE
IBX-6856: Added mime types limitation for ezimage field type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30601,21 +30601,6 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:assertCopiedFieldDataLoadedCorrectly\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getAdditionallyIndexedFieldData\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -30627,11 +30612,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getStoragePrefix\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getValidatorSchema\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
@@ -30656,27 +30636,7 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:providerForTestIsEmptyValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:providerForTestIsNotEmptyValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:publishNewImage\\(\\) has parameter \\$parentLocationIDs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:testInherentCopyForNewLanguage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:testUpdatingImageMetadataOnlyWorks\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30626,11 +30626,6 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getSettingsSchema\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getStoragePrefix\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10746,11 +10746,6 @@ parameters:
 			path: src/lib/FieldType/Validator/FloatValueValidator.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\Validator\\\\ImageValidator\\:\\:innerValidate\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/FieldType/Validator/ImageValidator.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\Validator\\\\ImageValidator\\:\\:innerValidate\\(\\) has parameter \\$filePath with no type specified\\.$#"
 			count: 1
 			path: src/lib/FieldType/Validator/ImageValidator.php
@@ -30641,16 +30636,6 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getValidUpdateFieldData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getValidUpdateFieldData\\(\\) should return array but returns Ibexa\\\\Core\\\\FieldType\\\\Image\\\\Value\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:getValidatorSchema\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -30698,11 +30683,6 @@ parameters:
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:testUpdatingImageMetadataOnlyWorks\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$newImageValue of method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\ImageIntegrationTest\\:\\:updateImage\\(\\) expects Ibexa\\\\Core\\\\FieldType\\\\Image\\\\Value, array given\\.$#"
-			count: 2
 			path: tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
 
 		-

--- a/src/lib/FieldType/Image/Type.php
+++ b/src/lib/FieldType/Image/Type.php
@@ -36,7 +36,8 @@ class Type extends FieldType implements TranslationContainerInterface
         ],
     ];
 
-    /** @var array{
+    /**
+     * @var array{
      *     mimeTypes: array{
      *         type: string,
      *         default: array{},

--- a/src/lib/FieldType/Image/Type.php
+++ b/src/lib/FieldType/Image/Type.php
@@ -51,22 +51,22 @@ class Type extends FieldType implements TranslationContainerInterface
         ],
     ];
 
-    /** @var array<string> */
-    private array $mimeTypes;
-
     /** @var \Ibexa\Core\FieldType\Validator[] */
     private $validators;
 
+    /** @var array<string> */
+    private array $mimeTypes;
+
     /**
-     * @param array<string> $mimeTypes
      * @param array<\Ibexa\Core\FieldType\Validator> $validators
+     * @param array<string> $mimeTypes
      */
     public function __construct(
-        array $mimeTypes,
-        array $validators
+        array $validators,
+        array $mimeTypes = []
     ) {
-        $this->mimeTypes = $mimeTypes;
         $this->validators = $validators;
+        $this->mimeTypes = $mimeTypes;
     }
 
     /**
@@ -247,6 +247,7 @@ class Type extends FieldType implements TranslationContainerInterface
 
             if (
                 $name === 'mimeTypes'
+                && !empty($this->mimeTypes)
                 && !empty(array_diff($value, $this->mimeTypes))
             ) {
                 $validationErrors[] = new ValidationError(

--- a/src/lib/FieldType/Image/Type.php
+++ b/src/lib/FieldType/Image/Type.php
@@ -243,7 +243,7 @@ class Type extends FieldType implements TranslationContainerInterface
                 && !empty(array_diff($value, $this->mimeTypes))
             ) {
                 $validationErrors[] = new ValidationError(
-                    "Setting '%setting%' contains not supported mime types",
+                    "Setting '%setting%' contains unsupported mime types",
                     null,
                     [
                         '%setting%' => $name,

--- a/src/lib/FieldType/Image/Type.php
+++ b/src/lib/FieldType/Image/Type.php
@@ -36,7 +36,13 @@ class Type extends FieldType implements TranslationContainerInterface
         ],
     ];
 
-    /** @var array<string, array<array<mixed>|scalar>> */
+    /** @var array{
+     *     mimeTypes: array{
+     *         type: string,
+     *         default: array{},
+     *     }
+     * }
+     */
     protected $settingsSchema = [
         'mimeTypes' => [
             'type' => 'choice',

--- a/src/lib/FieldType/Validator.php
+++ b/src/lib/FieldType/Validator.php
@@ -7,6 +7,7 @@
 namespace Ibexa\Core\FieldType;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\PropertyNotFoundException as PropertyNotFound;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 
 /**
  * Base field type validator validator.
@@ -98,7 +99,7 @@ abstract class Validator
      *
      * @return bool
      */
-    abstract public function validate(Value $value);
+    abstract public function validate(Value $value, ?FieldDefinition $fieldDefinition = null);
 
     /**
      * Returns array of messages on performed validations.

--- a/src/lib/FieldType/Validator/EmailAddressValidator.php
+++ b/src/lib/FieldType/Validator/EmailAddressValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -84,7 +85,7 @@ class EmailAddressValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $pattern = '/^((\"[^\"\f\n\r\t\v\b]+\")|([A-Za-z0-9_\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+(\.[A-Za-z0-9_\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+)*))@((\[(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))\])|(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))|((([A-Za-z0-9\-])+\.)+[A-Za-z\-]{2,}))$/';
 

--- a/src/lib/FieldType/Validator/FileExtensionBlackListValidator.php
+++ b/src/lib/FieldType/Validator/FileExtensionBlackListValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
@@ -45,7 +46,7 @@ class FileExtensionBlackListValidator extends Validator
     /**
      * {@inheritdoc}
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         if (
             pathinfo($value->fileName, PATHINFO_BASENAME) !== $value->fileName ||

--- a/src/lib/FieldType/Validator/FileSizeValidator.php
+++ b/src/lib/FieldType/Validator/FileSizeValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -66,7 +67,7 @@ class FileSizeValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/FieldType/Validator/FloatValueValidator.php
+++ b/src/lib/FieldType/Validator/FloatValueValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -82,7 +83,7 @@ class FloatValueValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/FieldType/Validator/ImageValidator.php
+++ b/src/lib/FieldType/Validator/ImageValidator.php
@@ -51,7 +51,8 @@ class ImageValidator extends Validator
     {
         // silence `getimagesize` error as extension-wise valid image files might produce it anyway
         // note that file extension checking is done using other validation which should be called before this one
-        if (!$imageData = @getimagesize($filePath)) {
+        $imageData = @getimagesize($filePath);
+        if (false === $imageData) {
             $this->errors[] = new ValidationError(
                 'A valid image file is required.',
                 null,

--- a/src/lib/FieldType/Validator/ImageValidator.php
+++ b/src/lib/FieldType/Validator/ImageValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value;
@@ -15,7 +16,7 @@ class ImageValidator extends Validator
     /**
      * {@inheritdoc}
      */
-    public function validateConstraints($constraints)
+    public function validateConstraints($constraints, ?FieldDefinition $fieldDefinition = null)
     {
         return [];
     }
@@ -23,30 +24,58 @@ class ImageValidator extends Validator
     /**
      * {@inheritdoc}
      */
-    public function validate(Value $value)
+    public function validate(Value $value, ?FieldDefinition $fieldDefinition = null)
     {
+        $mimeTypes = [];
+        if (null !== $fieldDefinition) {
+            $mimeTypes = $fieldDefinition->getFieldSettings()['mimeTypes'] ?? [];
+        }
+
         $isValid = true;
-        if (isset($value->inputUri) && !$this->innerValidate($value->inputUri)) {
+        if (isset($value->inputUri) && !$this->innerValidate($value->inputUri, $mimeTypes)) {
             $isValid = false;
         }
 
         // BC: Check if file is a valid image if the value of 'id' matches a local file
-        if (isset($value->id) && file_exists($value->id) && !$this->innerValidate($value->id)) {
+        if (isset($value->id) && file_exists($value->id) && !$this->innerValidate($value->id, $mimeTypes)) {
             $isValid = false;
         }
 
         return $isValid;
     }
 
-    private function innerValidate($filePath)
+    /**
+     * @param array<string> $mimeTypes
+     */
+    private function innerValidate($filePath, array $mimeTypes): bool
     {
         // silence `getimagesize` error as extension-wise valid image files might produce it anyway
         // note that file extension checking is done using other validation which should be called before this one
-        if (!@getimagesize($filePath)) {
+        if (!$imageData = @getimagesize($filePath)) {
             $this->errors[] = new ValidationError(
                 'A valid image file is required.',
                 null,
                 [],
+                'id'
+            );
+
+            return false;
+        }
+
+        // If array with mime types is empty, it means that all mime types are allowed
+        if (empty($mimeTypes)) {
+            return true;
+        }
+
+        $mimeType = $imageData['mime'];
+        if (!in_array($mimeType, $mimeTypes, true)) {
+            $this->errors[] = new ValidationError(
+                'The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.',
+                null,
+                [
+                    '%mimeType%' => $mimeType,
+                    '%mimeTypes%' => implode(', ', $mimeTypes),
+                ],
                 'id'
             );
 

--- a/src/lib/FieldType/Validator/IntegerValueValidator.php
+++ b/src/lib/FieldType/Validator/IntegerValueValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -85,7 +86,7 @@ class IntegerValueValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/FieldType/Validator/StringLengthValidator.php
+++ b/src/lib/FieldType/Validator/StringLengthValidator.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Core\FieldType\Validator;
 
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
@@ -104,7 +105,7 @@ class StringLengthValidator extends Validator
      *
      * @return bool
      */
-    public function validate(BaseValue $value)
+    public function validate(BaseValue $value, ?FieldDefinition $fieldDefinition = null)
     {
         $isValid = true;
 

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -186,6 +186,10 @@ EOT;
         $storageDef->dataFloat1 = $validators['FileSizeValidator']['maxFileSize'] ?? 0.0;
         $storageDef->dataInt2 = (int)($validators['AlternativeTextValidator']['required'] ?? 0);
         $storageDef->dataText1 = 'MB';
+
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+
+        $storageDef->dataText5 = json_encode($fieldSettings['mimeTypes'] ?? [], JSON_THROW_ON_ERROR);
     }
 
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef): void
@@ -200,8 +204,25 @@ EOT;
                         'required' => (bool)$storageDef->dataInt2,
                     ],
                 ],
+                'fieldSettings' => $this->getFieldSettings($storageDef),
             ]
         );
+    }
+
+    /**
+     * @return array<string>
+     *
+     * @throws \JsonException
+     */
+    private function getFieldSettings(StorageFieldDefinition $storageFieldDefinition): array
+    {
+        $mimeTypes = $storageFieldDefinition->dataText5;
+
+        return [
+            'mimeTypes' => !empty($mimeTypes)
+                ? json_decode($mimeTypes, true, 512, JSON_THROW_ON_ERROR)
+                : [],
+        ];
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -210,7 +210,7 @@ EOT;
     }
 
     /**
-     * @return array<string>
+     * @return array<string, string>
      *
      * @throws \JsonException
      */

--- a/src/lib/Resources/settings/fieldtypes.yml
+++ b/src/lib/Resources/settings/fieldtypes.yml
@@ -249,6 +249,16 @@ parameters:
         ZM: {Name: "Zambia", Alpha2: "ZM", Alpha3: "ZMB", IDC: "260"}
         ZW: {Name: "Zimbabwe", Alpha2: "ZW", Alpha3: "ZWE", IDC: "263"}
 
+    ibexa.field_type.ezimage.mime_types:
+        - image/jpeg
+        - image/pjpeg
+        - image/png
+        - image/bmp
+        - image/gif
+        - image/tiff
+        - image/x-icon
+        - image/webp
+
 services:
     Ibexa\Core\FieldType\FieldType:
         class: Ibexa\Core\FieldType\FieldType
@@ -325,7 +335,10 @@ services:
     Ibexa\Core\FieldType\Image\Type:
         class: Ibexa\Core\FieldType\Image\Type
         arguments:
-            - ['@Ibexa\Core\FieldType\Validator\FileExtensionBlackListValidator', '@Ibexa\Core\FieldType\Validator\ImageValidator']
+            $validators:
+                - '@Ibexa\Core\FieldType\Validator\FileExtensionBlackListValidator'
+                - '@Ibexa\Core\FieldType\Validator\ImageValidator'
+            $mimeTypes: '%ibexa.field_type.ezimage.mime_types%'
         parent: Ibexa\Core\FieldType\FieldType
         tags:
             - {name: ibexa.field_type, alias: ezimage}

--- a/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Test\Repository\SetupFactory\Legacy;
 use Ibexa\Core\FieldType\Image\Value as ImageValue;
+use stdClass;
 
 /**
  * Integration test for use field type.
@@ -42,7 +43,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @return array
      */
-    protected function getFixtureData()
+    protected function getFixtureData(): array
     {
         return [
             'create' => [
@@ -65,7 +66,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @return string
      */
-    public function getTypeName()
+    public function getTypeName(): string
     {
         return 'ezimage';
     }
@@ -91,9 +92,11 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Get a valid $fieldSettings value.
      *
-     * @return mixed
+     * @return array{
+     *     mimeTypes: array<string>,
+     * }
      */
-    public function getValidFieldSettings()
+    public function getValidFieldSettings(): array
     {
         return [
             'mimeTypes' => [
@@ -106,9 +109,11 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Get $fieldSettings value not accepted by the field type.
      *
-     * @return mixed
+     * @return array{
+     *       somethingUnknown: int,
+     *   }
      */
-    public function getInvalidFieldSettings()
+    public function getInvalidFieldSettings(): array
     {
         return [
             'somethingUnknown' => 0,
@@ -118,9 +123,22 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Get expected validator schema.
      *
-     * @return array
+     * @return array{
+     *     FileSizeValidator: array{
+     *          maxFileSize: array{
+     *              type: string,
+     *              default: null,
+     *          }
+     *     },
+     *     AlternativeTextValidator: array{
+     *          required: array{
+     *              type: string,
+     *              default: bool,
+     *          }
+     *     },
+     * }
      */
-    public function getValidatorSchema()
+    public function getValidatorSchema(): array
     {
         return [
             'FileSizeValidator' => [
@@ -141,9 +159,16 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Get a valid $validatorConfiguration.
      *
-     * @return mixed
+     * @return array{
+     *     FileSizeValidator: array{
+     *          maxFileSize: numeric,
+     *     },
+     *     AlternativeTextValidator: array{
+     *          required: bool,
+     *     },
+     * }
      */
-    public function getValidValidatorConfiguration()
+    public function getValidValidatorConfiguration(): array
     {
         return [
             'FileSizeValidator' => [
@@ -158,23 +183,25 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Get $validatorConfiguration not accepted by the field type.
      *
-     * @return mixed
+     * @return array{
+     *     StringLengthValidator: array{
+     *          minStringLength: \stdClass,
+     *     },
+     * }
      */
-    public function getInvalidValidatorConfiguration()
+    public function getInvalidValidatorConfiguration(): array
     {
         return [
             'StringLengthValidator' => [
-                'minStringLength' => new \stdClass(),
+                'minStringLength' => new stdClass(),
             ],
         ];
     }
 
     /**
      * Get initial field data for valid object creation.
-     *
-     * @return mixed
      */
-    public function getValidCreationFieldData()
+    public function getValidCreationFieldData(): ImageValue
     {
         $fixtureData = $this->getFixtureData();
 
@@ -186,7 +213,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @return string
      */
-    public function getFieldName()
+    public function getFieldName(): string
     {
         return 'My icy flower at night';
     }
@@ -226,7 +253,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         self::$loadedImagePath = $field->value->id;
     }
 
-    public function provideInvalidCreationFieldData()
+    public function provideInvalidCreationFieldData(): array
     {
         return [
             // will fail because the provided file doesn't exist, and fileSize/fileName won't be set
@@ -243,24 +270,15 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
 
     /**
      * Get update field externals data.
-     *
-     * @return \Ibexa\Core\FieldType\Image\Value
      */
-    public function getValidUpdateFieldData()
+    public function getValidUpdateFieldData(): ImageValue
     {
         $fixtureData = $this->getFixtureData();
 
         return new ImageValue($fixtureData['update']);
     }
 
-    /**
-     * Get externals updated field data values.
-     *
-     * This is a PHPUnit data provider
-     *
-     * @return array
-     */
-    public function assertUpdatedFieldDataLoadedCorrect(Field $field)
+    public function assertUpdatedFieldDataLoadedCorrect(Field $field): void
     {
         self::assertInstanceOf(
             ImageValue::class,
@@ -289,7 +307,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         );
     }
 
-    public function provideInvalidUpdateFieldData()
+    public function provideInvalidUpdateFieldData(): array
     {
         return $this->provideInvalidCreationFieldData();
     }
@@ -299,10 +317,8 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * Asserts that the data provided by {@link getValidCreationFieldData()}
      * was copied and loaded correctly.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field $field
      */
-    public function assertCopiedFieldDataLoadedCorrectly(Field $field)
+    public function assertCopiedFieldDataLoadedCorrectly(Field $field): void
     {
         $this->assertFieldDataLoadedCorrect($field);
 
@@ -332,7 +348,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @return array
      */
-    public function provideToHashData()
+    public function provideToHashData(): array
     {
         return [
             [
@@ -397,7 +413,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      *
      * @return array
      */
-    public function provideFromHashData()
+    public function provideFromHashData(): array
     {
         $fixture = $this->getFixtureData();
 
@@ -409,7 +425,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         ];
     }
 
-    public function testInherentCopyForNewLanguage()
+    public function testInherentCopyForNewLanguage(): void
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -459,14 +475,24 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         }
     }
 
-    public function providerForTestIsEmptyValue()
+    /**
+     * @return array<array{
+     *     \Ibexa\Core\FieldType\Image\Value
+     * }>
+     */
+    public function providerForTestIsEmptyValue(): array
     {
         return [
             [new ImageValue()],
         ];
     }
 
-    public function providerForTestIsNotEmptyValue()
+    /**
+     * @return array<array{
+     *     \Ibexa\Core\FieldType\Image\Value
+     * }>
+     */
+    public function providerForTestIsNotEmptyValue(): array
     {
         return [
             [
@@ -478,7 +504,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Covers EZP-23080.
      */
-    public function testUpdatingImageMetadataOnlyWorks()
+    public function testUpdatingImageMetadataOnlyWorks(): void
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -599,7 +625,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         }
     }
 
-    protected function getValidSearchValueOne()
+    protected function getValidSearchValueOne(): ImageValue
     {
         return new ImageValue(
             [
@@ -611,7 +637,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         );
     }
 
-    protected function getValidSearchValueTwo()
+    protected function getValidSearchValueTwo(): ImageValue
     {
         return new ImageValue(
             [
@@ -623,22 +649,31 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         );
     }
 
-    protected function getSearchTargetValueOne()
+    protected function getSearchTargetValueOne(): string
     {
         $value = $this->getValidSearchValueOne();
 
-        // ensure case-insensitivity
+        /**
+         * ensure case-insensitivity.
+         *
+         * @phpstan-ignore-next-line
+         */
         return strtoupper($value->fileName);
     }
 
-    protected function getSearchTargetValueTwo()
+    protected function getSearchTargetValueTwo(): string
     {
         $value = $this->getValidSearchValueTwo();
-        // ensure case-insensitivity
+
+        /**
+         * ensure case-insensitivity.
+         *
+         * @phpstan-ignore-next-line
+         */
         return strtoupper($value->fileName);
     }
 
-    protected function getAdditionallyIndexedFieldData()
+    protected function getAdditionallyIndexedFieldData(): array
     {
         return [
             [

--- a/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -71,11 +71,14 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     }
 
     /**
-     * Get expected settings schema.
-     *
-     * @return array
+     * @return array{
+     *      mimeTypes: array{
+     *          type: string,
+     *          default: array{},
+     *      }
+     *  }
      */
-    public function getSettingsSchema()
+    public function getSettingsSchema(): array
     {
         return [
             'mimeTypes' => [

--- a/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/ImageIntegrationTest.php
@@ -77,7 +77,12 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      */
     public function getSettingsSchema()
     {
-        return [];
+        return [
+            'mimeTypes' => [
+                'type' => 'choice',
+                'default' => [],
+            ],
+        ];
     }
 
     /**
@@ -87,7 +92,12 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
      */
     public function getValidFieldSettings()
     {
-        return [];
+        return [
+            'mimeTypes' => [
+                'image/jpeg',
+                'image/png',
+            ],
+        ];
     }
 
     /**
@@ -231,7 +241,7 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
     /**
      * Get update field externals data.
      *
-     * @return array
+     * @return \Ibexa\Core\FieldType\Image\Value
      */
     public function getValidUpdateFieldData()
     {

--- a/tests/lib/FieldType/ImageTest.php
+++ b/tests/lib/FieldType/ImageTest.php
@@ -21,6 +21,12 @@ use Ibexa\Core\FieldType\Validator\ImageValidator;
  */
 class ImageTest extends FieldTypeTest
 {
+    private const MIME_TYPES = [
+        'image/png',
+        'image/jpeg',
+        'image/gif',
+    ];
+
     protected $blackListedExtensions = [
         'php',
         'php3',
@@ -61,10 +67,13 @@ class ImageTest extends FieldTypeTest
      */
     protected function createFieldTypeUnderTest()
     {
-        $fieldType = new ImageType([
-            $this->getBlackListValidatorMock(),
-            $this->getImageValidatorMock(),
-        ]);
+        $fieldType = new ImageType(
+            self::MIME_TYPES,
+            [
+                $this->getBlackListValidatorMock(),
+                $this->getImageValidatorMock(),
+            ]
+        );
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
 
         return $fieldType;
@@ -132,7 +141,12 @@ class ImageTest extends FieldTypeTest
      */
     protected function getSettingsSchemaExpectation()
     {
-        return [];
+        return [
+            'mimeTypes' => [
+                'type' => 'choice',
+                'default' => [],
+            ],
+        ];
     }
 
     /**
@@ -853,6 +867,36 @@ class ImageTest extends FieldTypeTest
                         null,
                         [],
                         'alternativeText'
+                    ),
+                ],
+            ],
+            'Image with not allowed mime type' => [
+                [
+                    'fieldSettings' => [
+                        'mimeTypes' => [
+                            'image/png',
+                            'image/gif',
+                        ],
+                    ],
+                ],
+                new ImageValue(
+                    [
+                        'id' => $this->getImageInputPath(),
+                        'fileName' => basename($this->getImageInputPath()),
+                        'fileSize' => filesize($this->getImageInputPath()),
+                        'alternativeText' => '',
+                        'uri' => '',
+                    ]
+                ),
+                [
+                    new ValidationError(
+                        'The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.',
+                        null,
+                        [
+                            '%mimeType%' => 'image/jpeg',
+                            '%mimeTypes%' => 'image/png, image/gif',
+                        ],
+                        'id'
                     ),
                 ],
             ],

--- a/tests/lib/FieldType/ImageTest.php
+++ b/tests/lib/FieldType/ImageTest.php
@@ -68,11 +68,11 @@ class ImageTest extends FieldTypeTest
     protected function createFieldTypeUnderTest()
     {
         $fieldType = new ImageType(
-            self::MIME_TYPES,
             [
                 $this->getBlackListValidatorMock(),
                 $this->getImageValidatorMock(),
-            ]
+            ],
+            self::MIME_TYPES
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
 

--- a/tests/lib/Persistence/FieldValue/Converter/ImageConverterTest.php
+++ b/tests/lib/Persistence/FieldValue/Converter/ImageConverterTest.php
@@ -18,6 +18,13 @@ use PHPUnit\Framework\TestCase;
 
 final class ImageConverterTest extends TestCase
 {
+    private const MIME_TYPES = [
+        'image/png',
+        'image/jpeg',
+    ];
+
+    private const MIME_TYPES_STORAGE_VALUE = '["image\/png","image\/jpeg"]';
+
     /** @var \Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter */
     private $imageConverter;
 
@@ -57,7 +64,7 @@ final class ImageConverterTest extends TestCase
 
     public function dataProviderForTestToStorageFieldDefinition(): iterable
     {
-        yield [
+        yield 'No validators' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [],
@@ -67,10 +74,11 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 0.0,
                 'dataInt2' => 0,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
             ]),
         ];
 
-        yield [
+        yield 'FileSizeValidator' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [
@@ -84,10 +92,11 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 1.0,
                 'dataInt2' => 0,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
             ]),
         ];
 
-        yield [
+        yield 'AlternativeTextValidator - required' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [
@@ -101,10 +110,11 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 0.0,
                 'dataInt2' => 1,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
             ]),
         ];
 
-        yield [
+        yield 'AlternativeTextValidator - not required' => [
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
                     'validators' => [
@@ -118,6 +128,23 @@ final class ImageConverterTest extends TestCase
                 'dataFloat1' => 0.0,
                 'dataInt2' => 0,
                 'dataText1' => 'MB',
+                'dataText5' => '[]',
+            ]),
+        ];
+
+        yield 'mimeTypes' => [
+            new FieldDefinition([
+                'fieldTypeConstraints' => new FieldTypeConstraints([
+                    'fieldSettings' => [
+                        'mimeTypes' => self::MIME_TYPES,
+                    ],
+                ]),
+            ]),
+            new StorageFieldDefinition([
+                'dataFloat1' => 0.0,
+                'dataInt2' => 0,
+                'dataText1' => 'MB',
+                'dataText5' => self::MIME_TYPES_STORAGE_VALUE,
             ]),
         ];
     }
@@ -145,6 +172,7 @@ final class ImageConverterTest extends TestCase
             new StorageFieldDefinition([
                 'dataFloat1' => 0.0,
                 'dataInt2' => 0,
+                'dataText5' => [],
             ]),
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
@@ -156,6 +184,9 @@ final class ImageConverterTest extends TestCase
                             'required' => false,
                         ],
                     ],
+                    'fieldSettings' => [
+                        'mimeTypes' => [],
+                    ],
                 ]),
             ]),
         ];
@@ -164,6 +195,7 @@ final class ImageConverterTest extends TestCase
             new StorageFieldDefinition([
                 'dataFloat1' => 1.0,
                 'dataInt2' => 1,
+                'dataText5' => self::MIME_TYPES_STORAGE_VALUE,
             ]),
             new FieldDefinition([
                 'fieldTypeConstraints' => new FieldTypeConstraints([
@@ -174,6 +206,9 @@ final class ImageConverterTest extends TestCase
                         'AlternativeTextValidator' => [
                             'required' => true,
                         ],
+                    ],
+                    'fieldSettings' => [
+                        'mimeTypes' => self::MIME_TYPES,
                     ],
                 ]),
             ]),


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6856](https://issues.ibexa.co/browse/IBX-6856)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Requires: 
https://github.com/ibexa/admin-ui/pull/1021
https://github.com/ibexa/content-forms/pull/55
https://github.com/ibexa/image-editor/pull/80

This PR adds `mimeTypes` field setting to store which mime types are allowed for Image Field type. If empty array then all image mime types are allowed.


There is also added `ibexa.field_type.ezimage.mime_types` parameter with predefined mime type list that will be displayed in Image Field type definition.

![Screen Shot 2023-12-04 at 13 04 24](https://github.com/ibexa/admin-ui/assets/9850711/edb18fd8-2b8f-4b6c-bb3d-e1ccbe097ee5)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
