### PR TITLE
IBX-7276: Extended built-in Twig functions library 

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -48911,11 +48911,6 @@ parameters:
 			path: tests/lib/MVC/Symfony/Templating/RenderLocationStrategyTest.php
 
 		-
-			message: "#^Cannot access offset mixed on Ibexa\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Templating\\\\Twig\\\\Extension\\\\ContentExtensionTest\\:\\:getConfigResolverMock\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
@@ -48937,11 +48932,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Templating\\\\Twig\\\\Extension\\\\ContentExtensionTest\\:\\:getField\\(\\) has parameter \\$isEmpty with no type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$fieldDefinitions of class Ibexa\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinitionCollection constructor expects iterable, Ibexa\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition given\\.$#"
 			count: 1
 			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
 

--- a/src/bundle/Core/Resources/config/templating.yml
+++ b/src/bundle/Core/Resources/config/templating.yml
@@ -302,3 +302,9 @@ services:
             $twigVariableProviders: !tagged ezplatform.view.variable_provider
 
     Ibexa\Core\MVC\Symfony\View\VariableProviderRegistry: '@Ibexa\Core\MVC\Symfony\View\GenericVariableProviderRegistry'
+
+    Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\UserExtension:
+        arguments:
+            '$permissionResolver': '@Ibexa\Contracts\Core\Repository\PermissionResolver'
+        tags:
+            - { name: twig.extension }

--- a/src/bundle/Core/Resources/config/templating.yml
+++ b/src/bundle/Core/Resources/config/templating.yml
@@ -13,6 +13,7 @@ services:
             - '@ibexa.api.repository'
             - '@Ibexa\Core\Helper\TranslationHelper'
             - '@Ibexa\Core\Helper\FieldHelper'
+            - '@Ibexa\Core\Helper\FieldsGroups\FieldsGroupsList'
             - "@?logger"
         tags:
             - {name: twig.extension}

--- a/src/bundle/Core/Resources/config/templating.yml
+++ b/src/bundle/Core/Resources/config/templating.yml
@@ -305,6 +305,7 @@ services:
 
     Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\UserExtension:
         arguments:
-            '$permissionResolver': '@Ibexa\Contracts\Core\Repository\PermissionResolver'
+            $userService: '@Ibexa\Contracts\Core\Repository\UserService'
+            $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
         tags:
             - { name: twig.extension }

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\Helper\FieldHelper;
+use Ibexa\Core\Helper\FieldsGroups\FieldsGroupsList;
 use Ibexa\Core\Helper\TranslationHelper;
 use Psr\Log\LoggerInterface;
 use Twig\Extension\AbstractExtension;
@@ -33,6 +34,8 @@ class ContentExtension extends AbstractExtension
     /** @var \Ibexa\Core\Helper\FieldHelper */
     protected $fieldHelper;
 
+    private FieldsGroupsList $fieldsGroupsList;
+
     /** @var \Psr\Log\LoggerInterface */
     protected $logger;
 
@@ -40,11 +43,13 @@ class ContentExtension extends AbstractExtension
         Repository $repository,
         TranslationHelper $translationHelper,
         FieldHelper $fieldHelper,
+        FieldsGroupsList $fieldsGroupsList,
         LoggerInterface $logger = null
     ) {
         $this->repository = $repository;
         $this->translationHelper = $translationHelper;
         $this->fieldHelper = $fieldHelper;
+        $this->fieldsGroupsList = $fieldsGroupsList;
         $this->logger = $logger;
     }
 
@@ -131,6 +136,10 @@ class ContentExtension extends AbstractExtension
             new TwigFunction(
                 'ibexa_field_description',
                 [$this, 'getTranslatedFieldDefinitionDescription']
+            ),
+            new TwigFunction(
+                'ibexa_field_group_name',
+                [$this, 'getFieldGroupName']
             ),
             new TwigFunction(
                 'ez_content_field_identifier_first_filled_image',
@@ -250,6 +259,11 @@ class ContentExtension extends AbstractExtension
     public function hasField(Content $content, string $fieldDefIdentifier): bool
     {
         return $content->getContentType()->hasFieldDefinition($fieldDefIdentifier);
+    }
+
+    public function getFieldGroupName(string $identifier): ?string
+    {
+        return $this->fieldsGroupsList->getGroups()[$identifier] ?? null;
     }
 
     /**

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -101,6 +101,10 @@ class ContentExtension extends AbstractExtension
                 ]
             ),
             new TwigFunction(
+                'ibexa_has_field',
+                [$this, 'hasField']
+            ),
+            new TwigFunction(
                 'ibexa_field_is_empty',
                 [$this, 'isFieldEmpty']
             ),
@@ -241,6 +245,11 @@ class ContentExtension extends AbstractExtension
         }
 
         throw new InvalidArgumentType('$content', 'Content|ContentInfo', $content);
+    }
+
+    public function hasField(Content $content, string $fieldDefIdentifier): bool
+    {
+        return $content->getContentType()->hasFieldDefinition($fieldDefIdentifier);
     }
 
     /**

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/UserExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/UserExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\UserService;
+use Ibexa\Contracts\Core\Repository\Values\User\User;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class UserExtension extends AbstractExtension
+{
+    private UserService $userService;
+
+    private PermissionResolver $permissionResolver;
+
+    public function __construct(UserService $userService, PermissionResolver $permissionResolver)
+    {
+        $this->userService = $userService;
+        $this->permissionResolver = $permissionResolver;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ibexa_get_current_user',
+                [$this, 'getCurrentUser']
+            ),
+            new TwigFunction(
+                'ibexa_is_current_user',
+                [$this, 'isCurrentUser']
+            ),
+        ];
+    }
+
+    public function getCurrentUser(): User
+    {
+        return $this->userService->loadUser(
+            $this->permissionResolver->getCurrentUserReference()->getUserId()
+        );
+    }
+
+    public function isCurrentUser(User $user): bool
+    {
+        return $this->permissionResolver->getCurrentUserReference()->getUserId() === $user->getUserId();
+    }
+}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Helper\FieldHelper;
+use Ibexa\Core\Helper\FieldsGroups\FieldsGroupsList;
 use Ibexa\Core\Helper\TranslationHelper;
 use Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\ContentExtension;
 use Ibexa\Core\Repository\Values\Content\Content;
@@ -52,7 +53,8 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
                     [],
                     $this->createMock(LoggerInterface::class)
                 ),
-                $this->fieldHelperMock
+                $this->fieldHelperMock,
+                $this->getFieldsGroupsListMock()
             ),
         ];
     }
@@ -144,6 +146,16 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
             );
 
         return $mock;
+    }
+
+    private function getFieldsGroupsListMock(): FieldsGroupsList
+    {
+        $fieldsGroupsList = $this->createMock(FieldsGroupsList::class);
+        $fieldsGroupsList->method('getGroups')->willReturn([
+            'content' => 'Content',
+        ]);
+
+        return $fieldsGroupsList;
     }
 
     protected function getField($isEmpty)

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
@@ -32,7 +32,7 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
     /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
     private $fieldHelperMock;
 
-    /** @var \Ibexa\Core\Repository\Values\ContentType\FieldDefinition[] */
+    /** @var array<int, \Ibexa\Core\Repository\Values\ContentType\FieldDefinition[]> */
     private $fieldDefinitions = [];
 
     /** @var int[] */
@@ -115,6 +115,9 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
                         ),
                     ]
                 ),
+                'contentType' => new ContentType([
+                    'fieldDefinitions' => new FieldDefinitionCollection($this->fieldDefinitions[$contentTypeId] ?? []),
+                ]),
             ]
         );
 

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/UserExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/UserExtensionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\UserService;
+use Ibexa\Contracts\Core\Repository\Values\User\User;
+use Ibexa\Contracts\Core\Repository\Values\User\UserReference;
+use Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\UserExtension;
+use Twig\Test\IntegrationTestCase;
+
+final class UserExtensionTest extends IntegrationTestCase
+{
+    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver&\PHPUnit\Framework\MockObject\MockObject */
+    private PermissionResolver $permissionResolver;
+
+    /** @var \Ibexa\Contracts\Core\Repository\UserService&\PHPUnit\Framework\MockObject\MockObject */
+    private UserService $userService;
+
+    /** @var array<int, \Ibexa\Contracts\Core\Repository\Values\User\User> */
+    private array $users = [];
+
+    private int $currentUserId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userService = $this->createMock(UserService::class);
+        $this->userService
+            ->method('loadUser')
+            ->willReturnCallback(fn (int $id): User => $this->users[$id]);
+
+        $this->permissionResolver = $this->createMock(PermissionResolver::class);
+        $this->permissionResolver
+            ->method('getCurrentUserReference')
+            ->willReturnCallback(function (): UserReference {
+                $reference = $this->createMock(UserReference::class);
+                $reference->method('getUserId')->willReturn($this->currentUserId);
+
+                return $reference;
+            });
+
+        $this->getUser(10, true);
+    }
+
+    protected function getExtensions(): array
+    {
+        return [
+            new UserExtension(
+                $this->userService,
+                $this->permissionResolver
+            ),
+        ];
+    }
+
+    public function getUser(int $id, bool $isCurrent = false): User
+    {
+        if (!isset($this->users[$id])) {
+            $user = $this->createMock(User::class);
+            $user->method('getUserId')->willReturn($id);
+
+            $this->users[$id] = $user;
+
+            if ($isCurrent) {
+                $this->currentUserId = $id;
+            }
+        }
+
+        return $this->users[$id];
+    }
+
+    protected function getFixturesDir(): string
+    {
+        return __DIR__ . '/_fixtures/user_functions';
+    }
+}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_group_name.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_group_name.test
@@ -1,0 +1,8 @@
+--TEST--
+"ibexa_field_group_name" function
+--TEMPLATE--
+{{ ibexa_field_group_name('content') }}
+--DATA--
+return [];
+--EXPECT--
+Content

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_has_field.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_has_field.test
@@ -1,0 +1,23 @@
+--TEST--
+"ibexa_has_field" function
+--TEMPLATE--
+{{ ibexa_has_field(content, 'existing') ? 'YES' : 'NO' }}
+{{ ibexa_has_field(content, 'non-existing') ? 'YES' : 'NO' }}
+
+--DATA--
+return [
+    'content' => $this->getContent(
+         'test_content',
+         [
+            'ezstring' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'existing',
+                 'value' => 'value',
+                 'languageCode' => 'eng-GB',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+YES
+NO

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_get_current_user.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_get_current_user.test
@@ -1,0 +1,8 @@
+--TEST--
+"ibexa_get_current_user" function
+--TEMPLATE--
+{{ ibexa_get_current_user().getUserId() }}
+--DATA--
+return [];
+--EXPECT--
+10

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_is_current_user.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_is_current_user.test
@@ -1,0 +1,13 @@
+--TEST--
+"ibexa_is_current_user" function
+--TEMPLATE--
+{{ ibexa_is_current_user(user_foo) ? 'YES' : 'NO' }}
+{{ ibexa_is_current_user(user_bar) ? 'YES' : 'NO' }}
+--DATA--
+return [
+    'user_foo' => $this->getUser(10, true),
+    'user_bar' => $this->getUser(11, false),
+];
+--EXPECT--
+YES
+NO


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7276](https://issues.ibexa.co/browse/IBX-7276)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

### `ibexa_has_field`

`ibexa_has_field` Twig function allows check if content contains given field:

```twig
{% if ibexa_has_field(content, 'foo') %}
    {{ ibexa_render_field(content, 'foo') }}
{% endif %}
```

### `ibexa_field_group_name`

`ibexa_field_group_name`  Twig function return human-readable field group name:

```twig
{{ ibexa_field_group_name('content') }}
```

### `ibexa_is_current_user`

`ibexa_is_current_user` Twig function check if given user is current repository user:

```twig
{% if ibexa_is_current_user(version_info.author) %}
    <!-- display edit link -->
{% endif %}
```

### `ibexa_get_current_user` 

`ibexa_get_current_user` Twig function returns current repository user:

```twig
Current user: {{ ibexa_get_current_user().login }}
```

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [X] Asked for a review (ping `@ibexa/engineering`).
