### PR TITLE
[CI] Added workflow for publishing the Solr image

### DIFF
--- a/.github/workflows/solr.yaml
+++ b/.github/workflows/solr.yaml
@@ -1,0 +1,26 @@
+name: Build and publish Solr Docker image
+on:
+    workflow_dispatch: ~
+
+env:
+  IMAGE_NAME: ghcr.io/ibexa/core/solr
+
+jobs:
+    build-and-publish:
+        runs-on: ubuntu-latest
+        permissions:
+          packages: write
+        steps:
+            - uses: actions/checkout@v3
+            - name: Log in to the Container registry
+              uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+              with:
+                registry: ghcr.io
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Build image
+              run: docker build -t "$IMAGE_NAME:latest" docker/solr
+            - name: Push image
+              if: github.event_name == 'workflow_dispatch'
+              run: docker push "$IMAGE_NAME"
+

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.18.5 as builder
+RUN apk add --no-cache --upgrade bash git curl
+RUN adduser --disabled-password user
+USER user
+WORKDIR /home/user
+RUN git clone --depth=1 https://github.com/ibexa/solr.git solr
+RUN ./solr/bin/generate-solr-config.sh --destination-dir=config --solr-version=8.6.3
+
+FROM solr:8.6.3
+USER root
+RUN rm -rf server/solr/configsets/_default/conf/*
+USER solr
+COPY --from=builder /home/user/config server/solr/configsets/_default/conf
+CMD ["solr-precreate", "collection1"]


### PR DESCRIPTION
A little backstory (the way I remember it):
1) The solr image orginally has been added in Product Catalog - https://github.com/ibexa/product-catalog/pull/24
2) Because we needed it in public repositories as well the package was moved (without rebuilding it - it was republished) from product-catalog to core (https://github.com/ibexa/product-catalog/pull/479)
3) This process was not automated and I don't think it's possible to trace the original Dockerfile that was used to create the image (there's one in the first linked PR and another in https://github.com/ezsystems/ezplatform-solr-search-engine/pull/214)

I wrote a little Dockerfile that:
1) Generates the Solr config using the script for ibexa/solr package - this way we don't have to do any in-place editing of the config
2) Combines the Solr config with the default Solr image

The default Solr config from the Solr image contains some settings that we do not want - for example the managed schema is enabled. To get rid of it I'm deleting everything first - the only configuration that will be used will the one that we provide.

This is combined with a simple Github Actions workflow that can be used to publish the image - so that we won't have to go through this again 🙈 

Not done: versioning. The Solr configuration is always taken from master - and the image is always tagged as `latest`. We probably will have to change this in the future, but I don't have a clear way how it should look - and I'd like to make the CI green in this repository before the beta tag.

Contains TMP commits that need to be removed:
- https://github.com/ibexa/core/pull/303/commits/2d3ae23cf19ed7a0244f911bbef8cd763d09e5c1
- https://github.com/ibexa/core/pull/303/commits/bf28cafac3d5d29127267bed0176726179e79818

I have no idea what happened to PHPStan, maybe new version has been released?