### PR TITLE
IBX-7276: Renamed ibexa_get_current_user Twig function to ibexa_current_user

### DIFF
--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/UserExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/UserExtension.php
@@ -30,7 +30,7 @@ final class UserExtension extends AbstractExtension
     {
         return [
             new TwigFunction(
-                'ibexa_get_current_user',
+                'ibexa_current_user',
                 [$this, 'getCurrentUser']
             ),
             new TwigFunction(

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_current_user.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_current_user.test
@@ -1,0 +1,8 @@
+--TEST--
+"ibexa_current_user" function
+--TEMPLATE--
+{{ ibexa_current_user().getUserId() }}
+--DATA--
+return [];
+--EXPECT--
+10

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_get_current_user.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_functions/ibexa_get_current_user.test
@@ -1,8 +1,0 @@
---TEST--
-"ibexa_get_current_user" function
---TEMPLATE--
-{{ ibexa_get_current_user().getUserId() }}
---DATA--
-return [];
---EXPECT--
-10


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7276](https://issues.ibexa.co/browse/IBX-7276)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Renamed `ibexa_get_current_user` Twig function to `ibexa_current_user` as requested by @lserwatka & @kmadejski 

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
