### PR TITLE
IBX-7418: Added ContentNameCriterion

### DIFF
--- a/src/contracts/Repository/Values/Content/Query/Criterion/ContentName.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/ContentName.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Spec
 
 final class ContentName extends Criterion
 {
-    public function __construct($value)
+    public function __construct(string $value)
     {
         parent::__construct(null, Operator::LIKE, $value);
     }

--- a/src/contracts/Repository/Values/Content/Query/Criterion/ContentName.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/ContentName.php
@@ -11,7 +11,7 @@ namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications;
 
-final class ContentNameCriterion extends Criterion
+final class ContentName extends Criterion
 {
     public function __construct($value)
     {

--- a/src/contracts/Repository/Values/Content/Query/Criterion/ContentNameCriterion.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/ContentNameCriterion.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+final class ContentNameCriterion extends Criterion
+{
+    public function __construct($value)
+    {
+        parent::__construct(null, Operator::LIKE, $value);
+    }
+
+    /**
+     * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications>
+     */
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::LIKE, Specifications::FORMAT_SINGLE),
+        ];
+    }
+}

--- a/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -73,6 +73,12 @@ services:
             - {name: ibexa.search.legacy.gateway.criterion_handler.content}
             - {name: ibexa.search.legacy.gateway.criterion_handler.location}
 
+    Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentName:
+        parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
+        tags:
+            - { name: ibexa.search.legacy.gateway.criterion_handler.content }
+            - { name: ibexa.search.legacy.gateway.criterion_handler.location }
+
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeGroupId:
         parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeGroupId
@@ -339,11 +345,3 @@ services:
 
     ibexa.search.legacy.gateway.criterion_field_value_handler.default:
         alias: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Composite
-
-    Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentName:
-        parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
-        arguments:
-            $transformationProcessor: '@Ibexa\Core\Persistence\TransformationProcessor\PreprocessedBased'
-        tags:
-            - { name: ibexa.search.legacy.gateway.criterion_handler.content }
-            - { name: ibexa.search.legacy.gateway.criterion_handler.location }

--- a/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -339,3 +339,11 @@ services:
 
     ibexa.search.legacy.gateway.criterion_field_value_handler.default:
         alias: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Composite
+
+    Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentName:
+        parent: Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
+        arguments:
+            $transformationProcessor: '@Ibexa\Core\Persistence\TransformationProcessor\PreprocessedBased'
+        tags:
+            - { name: ibexa.search.legacy.gateway.criterion_handler.content }
+            - { name: ibexa.search.legacy.gateway.criterion_handler.location }

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
@@ -33,7 +33,7 @@ final class ContentName extends CriterionHandler
 
     public function accept(Criterion $criterion): bool
     {
-        return $criterion instanceof Criterion\ContentNameCriterion
+        return $criterion instanceof Criterion\ContentName
             && $criterion->operator === Criterion\Operator::LIKE;
     }
 

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
@@ -8,28 +8,19 @@ declare(strict_types=1);
 
 namespace Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
-use Ibexa\Core\Persistence\TransformationProcessor;
+use Ibexa\Core\Persistence\Legacy\Content\Gateway;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+/**
+ * @internal
+ */
 final class ContentName extends CriterionHandler
 {
     private const CONTENTOBJECT_NAME_ALIAS = 'ezc_n';
     private const CONTENTOBJECT_ALIAS = 'c';
-
-    private TransformationProcessor $transformationProcessor;
-
-    public function __construct(
-        Connection $connection,
-        TransformationProcessor $transformationProcessor
-    ) {
-        parent::__construct($connection);
-
-        $this->transformationProcessor = $transformationProcessor;
-    }
 
     public function accept(Criterion $criterion): bool
     {
@@ -42,6 +33,8 @@ final class ContentName extends CriterionHandler
      *     languages: array<string>,
      *     useAlwaysAvailable: bool,
      *  } $languageSettings
+     *
+     * @throws \Doctrine\DBAL\Exception
      */
     public function handle(
         CriteriaConverter $converter,
@@ -51,69 +44,31 @@ final class ContentName extends CriterionHandler
     ): string {
         $subQuery = $this->connection->createQueryBuilder();
         $subQuery
-            ->select('contentobject_id')
-            ->distinct()
-            ->from('ezcontentobject_name', self::CONTENTOBJECT_NAME_ALIAS)
-            ->innerJoin(
-                self::CONTENTOBJECT_NAME_ALIAS,
-                'ezcontentobject',
-                self::CONTENTOBJECT_ALIAS,
-                $this->getInnerJoinCondition()
-            )
+            ->select('1')
+            ->from(Gateway::CONTENT_NAME_TABLE, self::CONTENTOBJECT_NAME_ALIAS)
             ->andWhere(
+                $queryBuilder->expr()->eq(
+                    self::CONTENTOBJECT_NAME_ALIAS . '.contentobject_id',
+                    self::CONTENTOBJECT_ALIAS . '.id'
+                ),
+                $queryBuilder->expr()->eq(
+                    self::CONTENTOBJECT_NAME_ALIAS . '.content_version',
+                    self::CONTENTOBJECT_ALIAS . '.current_version'
+                ),
                 $queryBuilder->expr()->like(
                     $this->toLowerCase(self::CONTENTOBJECT_NAME_ALIAS . '.name'),
-                    $queryBuilder->createNamedParameter(
-                        $this->prepareValue($criterion)
+                    $this->toLowerCase(
+                        $queryBuilder->createNamedParameter(
+                            $this->prepareValue($criterion)
+                        )
                     )
                 )
             );
 
-        if (!empty($languageSettings['languages'])) {
-            $this->addLanguageConditionToSubQuery(
-                $subQuery,
-                $queryBuilder,
-                $languageSettings['languages']
-            );
-        }
-
-        return $queryBuilder->expr()->in(
-            self::CONTENTOBJECT_ALIAS . '.id',
+        return sprintf(
+            'EXISTS (%s)',
             $subQuery->getSQL()
         );
-    }
-
-    private function getInnerJoinCondition(): string
-    {
-        return sprintf(
-            '(%s = %s AND %s = %s)',
-            self::CONTENTOBJECT_NAME_ALIAS . '.contentobject_id',
-            self::CONTENTOBJECT_ALIAS . '.id',
-            self::CONTENTOBJECT_NAME_ALIAS . '.content_version',
-            self::CONTENTOBJECT_ALIAS . '.current_version',
-        );
-    }
-
-    /**
-     * @param array<string> $languages
-     */
-    private function addLanguageConditionToSubQuery(
-        QueryBuilder $subQuery,
-        QueryBuilder $queryBuilder,
-        array $languages
-    ): void {
-        $subQuery
-            ->andWhere(
-                $queryBuilder->expr()->in(
-                    $this->toLowerCase(self::CONTENTOBJECT_NAME_ALIAS . '.content_translation'),
-                    $this->toLowerCase(
-                        $queryBuilder->createNamedParameter(
-                            $languages,
-                            Connection::PARAM_STR_ARRAY
-                        )
-                    ),
-                )
-            );
     }
 
     private function prepareValue(Criterion $criterion): string
@@ -125,20 +80,17 @@ final class ContentName extends CriterionHandler
             '*',
             '%',
             addcslashes(
-                $this->transformationProcessor->transformByGroup(
-                    $value,
-                    'lowercase'
-                ),
+                $value,
                 '%_'
             )
         );
     }
 
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
     private function toLowerCase(string $value): string
     {
-        return sprintf(
-            'LOWER(%s)',
-            $value
-        );
+        return $this->connection->getDatabasePlatform()->getLowerExpression($value);
     }
 }

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
@@ -17,8 +17,8 @@ use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
 final class ContentName extends CriterionHandler
 {
-    private const EZCONTENTOBJECT_NAME_ALIAS = 'ezc_n';
-    private const EZCONTENTOBJECT_ALIAS = 'c';
+    private const CONTENTOBJECT_NAME_ALIAS = 'ezc_n';
+    private const CONTENTOBJECT_ALIAS = 'c';
 
     private TransformationProcessor $transformationProcessor;
 
@@ -53,16 +53,16 @@ final class ContentName extends CriterionHandler
         $subQuery
             ->select('contentobject_id')
             ->distinct()
-            ->from('ezcontentobject_name', self::EZCONTENTOBJECT_NAME_ALIAS)
+            ->from('ezcontentobject_name', self::CONTENTOBJECT_NAME_ALIAS)
             ->innerJoin(
-                self::EZCONTENTOBJECT_NAME_ALIAS,
+                self::CONTENTOBJECT_NAME_ALIAS,
                 'ezcontentobject',
-                self::EZCONTENTOBJECT_ALIAS,
+                self::CONTENTOBJECT_ALIAS,
                 $this->getInnerJoinCondition()
             )
             ->andWhere(
                 $queryBuilder->expr()->like(
-                    $this->toLowerCase(self::EZCONTENTOBJECT_NAME_ALIAS . '.name'),
+                    $this->toLowerCase(self::CONTENTOBJECT_NAME_ALIAS . '.name'),
                     $queryBuilder->createNamedParameter(
                         $this->prepareValue($criterion)
                     )
@@ -78,7 +78,7 @@ final class ContentName extends CriterionHandler
         }
 
         return $queryBuilder->expr()->in(
-            self::EZCONTENTOBJECT_ALIAS . '.id',
+            self::CONTENTOBJECT_ALIAS . '.id',
             $subQuery->getSQL()
         );
     }
@@ -87,10 +87,10 @@ final class ContentName extends CriterionHandler
     {
         return sprintf(
             '(%s = %s AND %s = %s)',
-            self::EZCONTENTOBJECT_NAME_ALIAS . '.contentobject_id',
-            self::EZCONTENTOBJECT_ALIAS . '.id',
-            self::EZCONTENTOBJECT_NAME_ALIAS . '.content_version',
-            self::EZCONTENTOBJECT_ALIAS . '.current_version',
+            self::CONTENTOBJECT_NAME_ALIAS . '.contentobject_id',
+            self::CONTENTOBJECT_ALIAS . '.id',
+            self::CONTENTOBJECT_NAME_ALIAS . '.content_version',
+            self::CONTENTOBJECT_ALIAS . '.current_version',
         );
     }
 
@@ -105,7 +105,7 @@ final class ContentName extends CriterionHandler
         $subQuery
             ->andWhere(
                 $queryBuilder->expr()->in(
-                    $this->toLowerCase(self::EZCONTENTOBJECT_NAME_ALIAS . '.content_translation'),
+                    $this->toLowerCase(self::CONTENTOBJECT_NAME_ALIAS . '.content_translation'),
                     $this->toLowerCase(
                         $queryBuilder->createNamedParameter(
                             $languages,

--- a/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
+++ b/src/lib/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentName.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Core\Persistence\TransformationProcessor;
+use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+final class ContentName extends CriterionHandler
+{
+    private const EZCONTENTOBJECT_NAME_ALIAS = 'ezc_n';
+    private const EZCONTENTOBJECT_ALIAS = 'c';
+
+    private TransformationProcessor $transformationProcessor;
+
+    public function __construct(
+        Connection $connection,
+        TransformationProcessor $transformationProcessor
+    ) {
+        parent::__construct($connection);
+
+        $this->transformationProcessor = $transformationProcessor;
+    }
+
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof Criterion\ContentNameCriterion
+            && $criterion->operator === Criterion\Operator::LIKE;
+    }
+
+    /**
+     * @param array{
+     *     languages: array<string>,
+     *     useAlwaysAvailable: bool,
+     *  } $languageSettings
+     */
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ): string {
+        $subQuery = $this->connection->createQueryBuilder();
+        $subQuery
+            ->select('contentobject_id')
+            ->distinct()
+            ->from('ezcontentobject_name', self::EZCONTENTOBJECT_NAME_ALIAS)
+            ->innerJoin(
+                self::EZCONTENTOBJECT_NAME_ALIAS,
+                'ezcontentobject',
+                self::EZCONTENTOBJECT_ALIAS,
+                $this->getInnerJoinCondition()
+            )
+            ->andWhere(
+                $queryBuilder->expr()->like(
+                    $this->toLowerCase(self::EZCONTENTOBJECT_NAME_ALIAS . '.name'),
+                    $queryBuilder->createNamedParameter(
+                        $this->prepareValue($criterion)
+                    )
+                )
+            );
+
+        if (!empty($languageSettings['languages'])) {
+            $this->addLanguageConditionToSubQuery(
+                $subQuery,
+                $queryBuilder,
+                $languageSettings['languages']
+            );
+        }
+
+        return $queryBuilder->expr()->in(
+            self::EZCONTENTOBJECT_ALIAS . '.id',
+            $subQuery->getSQL()
+        );
+    }
+
+    private function getInnerJoinCondition(): string
+    {
+        return sprintf(
+            '(%s = %s AND %s = %s)',
+            self::EZCONTENTOBJECT_NAME_ALIAS . '.contentobject_id',
+            self::EZCONTENTOBJECT_ALIAS . '.id',
+            self::EZCONTENTOBJECT_NAME_ALIAS . '.content_version',
+            self::EZCONTENTOBJECT_ALIAS . '.current_version',
+        );
+    }
+
+    /**
+     * @param array<string> $languages
+     */
+    private function addLanguageConditionToSubQuery(
+        QueryBuilder $subQuery,
+        QueryBuilder $queryBuilder,
+        array $languages
+    ): void {
+        $subQuery
+            ->andWhere(
+                $queryBuilder->expr()->in(
+                    $this->toLowerCase(self::EZCONTENTOBJECT_NAME_ALIAS . '.content_translation'),
+                    $this->toLowerCase(
+                        $queryBuilder->createNamedParameter(
+                            $languages,
+                            Connection::PARAM_STR_ARRAY
+                        )
+                    ),
+                )
+            );
+    }
+
+    private function prepareValue(Criterion $criterion): string
+    {
+        /** @var string $value */
+        $value = $criterion->value;
+
+        return str_replace(
+            '*',
+            '%',
+            addcslashes(
+                $this->transformationProcessor->transformByGroup(
+                    $value,
+                    'lowercase'
+                ),
+                '%_'
+            )
+        );
+    }
+
+    private function toLowerCase(string $value): string
+    {
+        return sprintf(
+            'LOWER(%s)',
+            $value
+        );
+    }
+}

--- a/tests/integration/Core/Repository/SearchServiceContentNameTest.php
+++ b/tests/integration/Core/Repository/SearchServiceContentNameTest.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchHit;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Core\FieldType\TextLine\Value;
+use Ibexa\Tests\Integration\Core\RepositorySearchTestCase;
+
+final class SearchServiceContentNameTest extends RepositorySearchTestCase
+{
+    private const TOTAL_COUNT = 20;
+
+    private const LANGUAGE_CODE_ENG = 'eng-GB';
+    private const LANGUAGE_CODE_GER = 'ger-DE';
+
+    private const CAR_ENG = 'Car';
+    private const SPORTS_CAR_ENG = 'Sports car';
+    private const TRUCK_ENG = 'TRUCK';
+
+    private const CAR_GER = 'auto';
+    private const SPORTS_CAR_GER = 'Sportwagen';
+    private const TRUCK_GER = 'LASTWAGEN';
+
+    private const CONTENT_ITEMS_MAP = [
+        [
+            'mainLanguageCode' => self::LANGUAGE_CODE_ENG,
+            'name' => self::CAR_ENG,
+            'translations' => [
+                self::LANGUAGE_CODE_GER => self::CAR_GER,
+            ],
+        ],
+        [
+            'mainLanguageCode' => self::LANGUAGE_CODE_ENG,
+            'name' => self::SPORTS_CAR_ENG,
+            'translations' => [
+                self::LANGUAGE_CODE_GER => self::SPORTS_CAR_GER,
+            ],
+        ],
+        [
+            'mainLanguageCode' => self::LANGUAGE_CODE_ENG,
+            'name' => self::TRUCK_ENG,
+            'translations' => [
+                self::LANGUAGE_CODE_GER => self::TRUCK_GER,
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createTestContentItems();
+
+        $this->refreshSearch();
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testCriterionFindAllContentItems(): void
+    {
+        $query = $this->createQuery(
+            $this->createContentNameCriterion('*')
+        );
+
+        self::assertSame(
+            self::TOTAL_COUNT,
+            self::getSearchService()->findContent($query)->totalCount
+        );
+    }
+
+    /**
+     * @dataProvider provideDataForTestCriterion
+     *
+     * @param array<string> $expectedContentItemTitles
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidCriterionArgumentException
+     */
+    public function testCriterion(
+        Criterion $criterion,
+        ?string $languageCode,
+        array $expectedContentItemTitles,
+        int $expectedCount
+    ): void {
+        $result = self::getSearchService()->findContent(
+            $this->createQuery($criterion),
+            $this->getLanguageFilter($languageCode)
+        );
+
+        self::assertEquals(
+            $expectedContentItemTitles,
+            array_map(
+                static function (SearchHit $searchHit) use ($languageCode): ?string {
+                    $content = $searchHit->valueObject;
+                    if ($content instanceof Content) {
+                        return $content->getName($languageCode);
+                    }
+
+                    return null;
+                },
+                $result->searchHits
+            )
+        );
+
+        self::assertSame(
+            $expectedCount,
+            $result->totalCount
+        );
+    }
+
+    /**
+     * @return iterable<array{
+     *     \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion,
+     *     ?string,
+     *     array<string>,
+     *     int,
+     * }>
+     */
+    public function provideDataForTestCriterion(): iterable
+    {
+        yield 'Content items not found' => [
+            $this->createContentNameCriterion('foo'),
+            self::LANGUAGE_CODE_ENG,
+            [],
+            0,
+        ];
+
+        yield 'Return content items in default language (English) that contain "car" in name' => [
+            $this->createContentNameCriterion('*car*'),
+            null,
+            [
+                self::CAR_ENG,
+                self::SPORTS_CAR_ENG,
+            ],
+            2,
+        ];
+
+        yield 'Return content item in default language (English) whose name starts with "car"' => [
+            $this->createContentNameCriterion('Car*'),
+            null,
+            [
+                self::CAR_ENG,
+            ],
+            1,
+        ];
+
+        yield 'Return content item in English that contain "Spo*t*" in name' => [
+            $this->createContentNameCriterion('Spo*t*'),
+            self::LANGUAGE_CODE_ENG,
+            [
+                self::SPORTS_CAR_ENG,
+            ],
+            1,
+        ];
+
+        yield 'Return content item in English with name "sports car"' => [
+            $this->createContentNameCriterion('sports car'),
+            self::LANGUAGE_CODE_ENG,
+            [
+                self::SPORTS_CAR_ENG,
+            ],
+            1,
+        ];
+
+        yield 'Return content item in English that contain "**ruc*" in name' => [
+            $this->createContentNameCriterion('**ruc*'),
+            self::LANGUAGE_CODE_ENG,
+            [
+                self::TRUCK_ENG,
+            ],
+            1,
+        ];
+
+        yield 'Return content item in German that contain "aut*" in name' => [
+            $this->createContentNameCriterion('aut*'),
+            self::LANGUAGE_CODE_GER,
+            [
+                self::CAR_GER,
+            ],
+            1,
+        ];
+
+        yield 'Return content items in German that contain "*wagen" in name' => [
+            $this->createContentNameCriterion('*wagen'),
+            self::LANGUAGE_CODE_GER,
+            [
+                self::SPORTS_CAR_GER,
+                self::TRUCK_GER,
+            ],
+            2,
+        ];
+
+        yield 'Return content item in German with name "lastwagen"' => [
+            $this->createContentNameCriterion('lastwagen'),
+            self::LANGUAGE_CODE_GER,
+            [
+                self::TRUCK_GER,
+            ],
+            1,
+        ];
+    }
+
+    private function createTestContentItems(): void
+    {
+        foreach (self::CONTENT_ITEMS_MAP as $contentItem) {
+            $this->createContent(
+                $contentItem['name'],
+                $contentItem['mainLanguageCode'],
+                $contentItem['translations']
+            );
+        }
+    }
+
+    /**
+     * @param array<string> $translations
+     *
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
+    private function createContent(
+        string $title,
+        string $mainLanguageCode,
+        array $translations
+    ): Content {
+        $contentService = self::getContentService();
+        $createStruct = $contentService->newContentCreateStruct(
+            $this->loadContentType('article'),
+            $mainLanguageCode
+        );
+
+        $createStruct->setField('title', new Value($title));
+
+        if (!empty($translations)) {
+            foreach ($translations as $languageCode => $translatedName) {
+                $createStruct->setField('title', new Value($translatedName), $languageCode);
+            }
+        }
+
+        $content = $contentService->createContent($createStruct);
+
+        $contentService->publishVersion($content->getVersionInfo());
+
+        return $content;
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     */
+    private function loadContentType(string $contentTypeIdentifier): ContentType
+    {
+        return self::getContentTypeService()
+            ->loadContentTypeByIdentifier($contentTypeIdentifier);
+    }
+
+    private function createContentNameCriterion(string $value): Criterion
+    {
+        return new Criterion\ContentNameCriterion($value);
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidCriterionArgumentException
+     */
+    private function createQuery(Criterion $criterion): Query
+    {
+        $query = new Query();
+        $query->filter = new Criterion\LogicalAnd(
+            [$criterion]
+        );
+
+        return $query;
+    }
+
+    /**
+     * @return array{}|array{
+     *     languages: array<string>
+     * }
+     */
+    public function getLanguageFilter(?string $languageCode): array
+    {
+        return null !== $languageCode
+            ? ['languages' => [$languageCode]]
+            : [];
+    }
+}

--- a/tests/integration/Core/Repository/SearchServiceContentNameTest.php
+++ b/tests/integration/Core/Repository/SearchServiceContentNameTest.php
@@ -236,7 +236,7 @@ final class SearchServiceContentNameTest extends RepositorySearchTestCase
             0,
         ];
 
-        yield 'Return content items in default language (English) that contain "car" or starts with "sports" in name' => [
+        yield 'Return content items in default language (English) that contain "car" or start with "sports" in name' => [
             $this->createContentNameCriterion('*car* OR SPORTS*'),
             null,
             [

--- a/tests/integration/Core/Repository/SearchServiceContentNameTest.php
+++ b/tests/integration/Core/Repository/SearchServiceContentNameTest.php
@@ -337,7 +337,7 @@ final class SearchServiceContentNameTest extends RepositorySearchTestCase
 
     private function createContentNameCriterion(string $value): Criterion
     {
-        return new Criterion\ContentNameCriterion($value);
+        return new Criterion\ContentName($value);
     }
 
     /**

--- a/tests/integration/Core/Repository/SearchServiceContentNameTest.php
+++ b/tests/integration/Core/Repository/SearchServiceContentNameTest.php
@@ -94,7 +94,7 @@ final class SearchServiceContentNameTest extends RepositorySearchTestCase
         int $expectedCount
     ): void {
         if (getenv('SEARCH_ENGINE') === 'legacy') {
-            self::markTestSkipped('Extended syntax are not supported in Legacy Search Engine');
+            self::markTestSkipped('Extended syntax is not supported in Legacy Search Engine');
         }
 
         $this->assertResult(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7418](https://issues.ibexa.co/browse/IBX-7418)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no
| **Related PRs**                          | https://github.com/ibexa/solr/pull/61, https://github.com/ibexa/elasticsearch/pull/34, https://github.com/ibexa/rest/pull/82 |

This PR adds new criterion that allows to search by content names.  

## Examples: 

```php 
new ContentName('phrase'); 

new ContentName('phra*'); 

new ContentName('*phrase*'); 

new ContentName('phr*se*'); 

```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
