### PR TITLE
IBX-7337: Added twig functions to get user preference

### DIFF
--- a/src/bundle/Core/Resources/config/templating.yml
+++ b/src/bundle/Core/Resources/config/templating.yml
@@ -309,3 +309,11 @@ services:
             $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
         tags:
             - { name: twig.extension }
+
+    Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\UserPreferenceExtension:
+        autowire: true
+        autoconfigure: true
+
+    Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\UserPreferenceRuntime:
+        autowire: true
+        autoconfigure: true

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceExtension.php
@@ -11,6 +11,9 @@ namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+/**
+ * @internal
+ */
 final class UserPreferenceExtension extends AbstractExtension
 {
     public function getFunctions(): array

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class UserPreferenceExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ibexa_get_user_preference_value',
+                [UserPreferenceRuntime::class, 'getUserPreferenceValue'],
+            ),
+            new TwigFunction(
+                'ibexa_has_user_preference',
+                [UserPreferenceRuntime::class, 'hasUserPreference'],
+            ),
+        ];
+    }
+}

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceRuntime.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceRuntime.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
-use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
 use Ibexa\Contracts\Core\Repository\UserPreferenceService;
 use Twig\Extension\RuntimeExtensionInterface;
 
@@ -23,22 +22,28 @@ final class UserPreferenceRuntime implements RuntimeExtensionInterface
         $this->userPreferenceService = $userPreferenceService;
     }
 
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
     public function getUserPreferenceValue(string $identifier, string $default): string
     {
         try {
             return $this->userPreferenceService->getUserPreference($identifier)->value;
-        } catch (NotFoundException|UnauthorizedException $e) {
+        } catch (NotFoundException $e) {
             return $default;
         }
     }
 
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
     public function hasUserPreference(string $identifier): bool
     {
         try {
             $this->userPreferenceService->getUserPreference($identifier);
 
             return true;
-        } catch (NotFoundException|UnauthorizedException $e) {
+        } catch (NotFoundException $e) {
             return false;
         }
     }

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceRuntime.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceRuntime.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
+use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
+use Ibexa\Contracts\Core\Repository\UserPreferenceService;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class UserPreferenceRuntime implements RuntimeExtensionInterface
+{
+    private UserPreferenceService $userPreferenceService;
+
+    public function __construct(
+        UserPreferenceService $userPreferenceService
+    ) {
+        $this->userPreferenceService = $userPreferenceService;
+    }
+
+    public function getUserPreferenceValue(string $identifier, string $default): string
+    {
+        try {
+            return $this->userPreferenceService->getUserPreference($identifier)->value;
+        } catch (NotFoundException|UnauthorizedException $e) {
+            return $default;
+        }
+    }
+
+    public function hasUserPreference(string $identifier): bool
+    {
+        try {
+            $this->userPreferenceService->getUserPreference($identifier);
+
+            return true;
+        } catch (NotFoundException|UnauthorizedException $e) {
+            return false;
+        }
+    }
+}

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceRuntime.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceRuntime.php
@@ -12,6 +12,9 @@ use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\UserPreferenceService;
 use Twig\Extension\RuntimeExtensionInterface;
 
+/**
+ * @internal
+ */
 final class UserPreferenceRuntime implements RuntimeExtensionInterface
 {
     private UserPreferenceService $userPreferenceService;

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/UserPreferenceExtensionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use Ibexa\Contracts\Core\Repository\UserPreferenceService;
+use Ibexa\Contracts\Core\Repository\Values\UserPreference\UserPreference;
+use Ibexa\Core\Base\Exceptions\NotFoundException;
+use Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\UserPreferenceExtension;
+use Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\UserPreferenceRuntime;
+use Twig\Extension\RuntimeExtensionInterface;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
+use Twig\Test\IntegrationTestCase;
+
+final class UserPreferenceExtensionTest extends IntegrationTestCase
+{
+    protected function getRuntimeLoaders(): array
+    {
+        $userPreferenceService = $this->createUserPreferenceService();
+
+        return [
+            new class($userPreferenceService) implements RuntimeLoaderInterface {
+                private UserPreferenceService $userPreferenceService;
+
+                public function __construct(
+                    UserPreferenceService $userPreferenceService
+                ) {
+                    $this->userPreferenceService = $userPreferenceService;
+                }
+
+                public function load(string $class): ?RuntimeExtensionInterface
+                {
+                    if ($class === UserPreferenceRuntime::class) {
+                        return new UserPreferenceRuntime($this->userPreferenceService);
+                    }
+
+                    return null;
+                }
+            },
+        ];
+    }
+
+    protected function getFixturesDir(): string
+    {
+        return __DIR__ . '/_fixtures/user_preference_functions';
+    }
+
+    /**
+     * @return \Twig\Extension\ExtensionInterface[]
+     */
+    protected function getExtensions(): array
+    {
+        return [
+            new UserPreferenceExtension(),
+        ];
+    }
+
+    private function createUserPreferenceService(): UserPreferenceService
+    {
+        $callback = static function ($identifier): UserPreference {
+            if ($identifier === 'baz') {
+                throw new NotFoundException('User Preference', 14);
+            }
+
+            return new UserPreference([
+                'value' => 'bar',
+            ]);
+        };
+
+        $userPreferenceService = $this->createMock(UserPreferenceService::class);
+        $userPreferenceService
+            ->method('getUserPreference')
+            ->willReturnCallback($callback);
+
+        return $userPreferenceService;
+    }
+}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_preference_functions/get_user_preference_value.function.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_preference_functions/get_user_preference_value.function.test
@@ -1,0 +1,10 @@
+--TEST--
+"ibexa_get_user_preference_value" function
+--TEMPLATE--
+{{ ibexa_get_user_preference_value('foo', 'default') }}
+{{ ibexa_get_user_preference_value('baz', 'default') }}
+--DATA--
+return [];
+--EXPECT--
+bar
+default

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_preference_functions/has_user_preference.function.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/user_preference_functions/has_user_preference.function.test
@@ -1,0 +1,10 @@
+--TEST--
+"ibexa_has_user_preference" function
+--TEMPLATE--
+{{ ibexa_has_user_preference('foo') is same as(true) }}
+{{ ibexa_has_user_preference('baz') is same as(false) }}
+--DATA--
+return [];
+--EXPECT--
+1
+1


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7337](https://issues.ibexa.co/browse/IBX-7337)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

The first usage will be to check if the banner in the dashboard is hidden (https://github.com/ibexa/dashboard/pull/79)
Example usage:
```
{% if ibexa_has_user_preference('foo') is same as(true) %}

{% set foo = ibexa_get_user_preference_value('foo', 'false') %}
```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
