### PR TITLE
Fixed incorrect list of excluded dirs for JMS translation extraction

### DIFF
--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -1028,7 +1028,7 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
                     ],
                     'output_dir' => __DIR__ . '/../Resources/translations/',
                     'output_format' => 'xlf',
-                    'excluded_dirs' => ['Behat', 'Tests', 'node_modules', 'Features'],
+                    'excluded_dirs' => ['Test', 'Features'],
                 ],
             ],
         ]);

--- a/src/bundle/Core/Resources/translations/repository_exceptions.en.xlf
+++ b/src/bundle/Core/Resources/translations/repository_exceptions.en.xlf
@@ -126,6 +126,11 @@
         <target>The User does not have the '%function%' '%module%' permission with: %with%</target>
         <note>key: The User does not have the '%function%' '%module%' permission with: %with%</note>
       </trans-unit>
+      <trans-unit id="3b2e044f9c9821aef27834972d90f59f28b1a0b4" resname="Token '%tokenType%:%token%' expired on '%when%'">
+        <source>Token '%tokenType%:%token%' expired on '%when%'</source>
+        <target>Token '%tokenType%:%token%' expired on '%when%'</target>
+        <note>key: Token '%tokenType%:%token%' expired on '%when%'</note>
+      </trans-unit>
       <trans-unit id="27a77deaffe8551b169928675adc64ae8450937f" resname="User &quot;%login%&quot; already exists">
         <source>User "%login%" already exists</source>
         <target>User "%login%" already exists</target>


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`+
| **BC breaks**                          | no

Seems the list of `excluded_dirs` for `ibexa_core` JMS translation extraction is incorrect, resulting in the following error when trying to extract translations:
```
$ php bin/console translation:extract --config=ibexa_core
Extracting Translations for locale en
Keep old translations: No
(...)
Extracting messages from directory : /home/andrew/packages/ibexa/core/src/bundle/Core/DependencyInjection/../../..

In KernelTestCase.php line 25:
                                                                          
  Attempted to load class "TestCase" from namespace "PHPUnit\Framework".  
  Did you forget a "use" statement for another namespace?                 

(...)
```

We have `./src/contracts/Test` containing testing framework contracts, which should never be checked for extraction. It worked only because untill 5 days ago any Ibexa DXP project had PHPUnit installed due to  `zetacomponents/feed` peer depenency, which good moved to `require-dev` section recently.

Kept also `Features` directory since it still exists and contains Behat feature files. The rest is not necessary.

Regenerated the translations as well.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
