### PR TITLE
IBX-5821: Fixed an issue where incomplete request object was passed over to route Matcher

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26391,11 +26391,6 @@ parameters:
 			path: tests/bundle/Core/Routing/DefaultRouterTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Routing\\\\DefaultRouterTest\\:\\:generateRouter\\(\\) has parameter \\$mockedMethods with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/Routing/DefaultRouterTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Routing\\\\DefaultRouterTest\\:\\:getExpectedRequestContext\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/bundle/Core/Routing/DefaultRouterTest.php
@@ -26406,22 +26401,12 @@ parameters:
 			path: tests/bundle/Core/Routing/DefaultRouterTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Routing\\\\DefaultRouterTest\\:\\:getRouterClass\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/Routing/DefaultRouterTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Routing\\\\DefaultRouterTest\\:\\:providerGenerateNoSiteAccess\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/bundle/Core/Routing/DefaultRouterTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Routing\\\\DefaultRouterTest\\:\\:providerGenerateWithSiteAccess\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/Routing/DefaultRouterTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Routing\\\\DefaultRouterTest\\:\\:providerGetContextBySimplifiedRequest\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/bundle/Core/Routing/DefaultRouterTest.php
 
@@ -26468,11 +26453,6 @@ parameters:
 		-
 			message: "#^Offset 'scheme' does not exist on array\\{scheme\\?\\: string, host\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 2
-			path: tests/bundle/Core/Routing/DefaultRouterTest.php
-
-		-
-			message: "#^Unable to resolve the template type T in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\)$#"
-			count: 1
 			path: tests/bundle/Core/Routing/DefaultRouterTest.php
 
 		-

--- a/src/bundle/Core/Routing/DefaultRouter.php
+++ b/src/bundle/Core/Routing/DefaultRouter.php
@@ -64,7 +64,10 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
 
     public function matchRequest(Request $request)
     {
-        return $this->match($request->attributes->get('semanticPathinfo', $request->getPathInfo()));
+        $siteAccessRequest = $request->duplicate();
+        $siteAccessRequest->server->set('REQUEST_URI', $request->attributes->get('semanticPathinfo', $request->getPathInfo()));
+
+        return parent::matchRequest($siteAccessRequest);
     }
 
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)

--- a/src/bundle/Core/Routing/DefaultRouter.php
+++ b/src/bundle/Core/Routing/DefaultRouter.php
@@ -65,7 +65,10 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
     public function matchRequest(Request $request)
     {
         $siteAccessRequest = $request->duplicate();
-        $siteAccessRequest->server->set('REQUEST_URI', $request->attributes->get('semanticPathinfo', $request->getPathInfo()));
+        $siteAccessRequest->server->set(
+            'REQUEST_URI',
+            $request->attributes->get('semanticPathinfo', $request->getPathInfo())
+        );
 
         return parent::matchRequest($siteAccessRequest);
     }

--- a/src/bundle/Core/Routing/DefaultRouter.php
+++ b/src/bundle/Core/Routing/DefaultRouter.php
@@ -64,13 +64,15 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
 
     public function matchRequest(Request $request)
     {
-        $siteAccessRequest = $request->duplicate();
-        $siteAccessRequest->server->set(
-            'REQUEST_URI',
-            $request->attributes->get('semanticPathinfo', $request->getPathInfo())
-        );
+        if ($request->attributes->has('semanticPathinfo')) {
+            $request = $request->duplicate();
+            $request->server->set(
+                'REQUEST_URI',
+                $request->attributes->get('semanticPathinfo')
+            );
+        }
 
-        return parent::matchRequest($siteAccessRequest);
+        return parent::matchRequest($request);
     }
 
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5821](https://issues.ibexa.co/browse/IBX-5821)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

This PR fixes an issue where an incomplete `Request` object was passed into `UrlMatcher`, because old `Router::match()` method was called internally when `Router::matchRequest()` was used.

New code mimics the old behavior, but instead of creating an entirely new Request object for matching, it duplicates the existing one (using a built-in method) and replaces `REQUEST_URI` with new path value (the same as used before).

I can confirm that both Admin UI and basic front works with this solution.

![image](https://github.com/ibexa/core/assets/3183926/9ad5a1e4-ab4c-4c5e-9fce-f2f49d3ff836)

![image](https://github.com/ibexa/core/assets/3183926/00505ea4-5b90-4b02-b0b9-a8ebe71ce07a)

Tests were updated to more specifically check what values are used by Matcher.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
