### PR TITLE
IBX-7502: Added file size validation for image asset field type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43586,11 +43586,6 @@ parameters:
 			path: tests/lib/FieldType/ImageAssetTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\ImageAssetTest\\:\\:testValidateValidNonEmptyAssetValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/FieldType/ImageAssetTest.php
-
-		-
 			message: "#^Access to an undefined property Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\ImageTest\\:\\:\\$mimeTypeDetectorMock\\.$#"
 			count: 1
 			path: tests/lib/FieldType/ImageTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9756,6 +9756,11 @@ parameters:
 			path: src/lib/FieldType/ImageAsset/Type.php
 
 		-
+			message: "#^Property Ibexa\\\\Core\\\\FieldType\\\\ImageAsset\\\\Type\\:\\:\\$contentTypeService is never read, only written\\.$#"
+			count: 1
+			path: src/lib/FieldType/ImageAsset/Type.php
+
+		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\:\\:\\$value\\.$#"
 			count: 1
 			path: src/lib/FieldType/Integer/Type.php
@@ -22689,6 +22694,7 @@ parameters:
 			message: "#^Method Ibexa\\\\Core\\\\Search\\\\Legacy\\\\Content\\\\Gateway\\\\CriterionHandler\\\\Ancestor\\:\\:handle\\(\\) has parameter \\$languageSettings with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Search/Legacy/Content/Gateway/CriterionHandler/Ancestor.php
+
 		-
 			message: "#^Method Ibexa\\\\Core\\\\Search\\\\Legacy\\\\Content\\\\Gateway\\\\CriterionHandler\\\\LocationId\\:\\:handle\\(\\) has parameter \\$languageSettings with no value type specified in iterable type array\\.$#"
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9756,11 +9756,6 @@ parameters:
 			path: src/lib/FieldType/ImageAsset/Type.php
 
 		-
-			message: "#^Property Ibexa\\\\Core\\\\FieldType\\\\ImageAsset\\\\Type\\:\\:\\$contentTypeService is never read, only written\\.$#"
-			count: 1
-			path: src/lib/FieldType/ImageAsset/Type.php
-
-		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\:\\:\\$value\\.$#"
 			count: 1
 			path: src/lib/FieldType/Integer/Type.php

--- a/src/lib/FieldType/ImageAsset/Type.php
+++ b/src/lib/FieldType/ImageAsset/Type.php
@@ -11,7 +11,6 @@ namespace Ibexa\Core\FieldType\ImageAsset;
 use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as SPIContentHandler;
 use Ibexa\Contracts\Core\Repository\ContentService;
-use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
@@ -31,29 +30,18 @@ class Type extends FieldType implements TranslationContainerInterface
     /** @var \Ibexa\Contracts\Core\Repository\ContentService */
     private $contentService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
-
     /** @var \Ibexa\Core\FieldType\ImageAsset\AssetMapper */
     private $assetMapper;
 
     /** @var \Ibexa\Contracts\Core\Persistence\Content\Handler */
     private $handler;
 
-    /**
-     * @param \Ibexa\Contracts\Core\Repository\ContentService $contentService
-     * @param \Ibexa\Contracts\Core\Repository\ContentTypeService $contentTypeService
-     * @param \Ibexa\Core\FieldType\ImageAsset\AssetMapper $mapper
-     * @param \Ibexa\Contracts\Core\Persistence\Content\Handler $handler
-     */
     public function __construct(
         ContentService $contentService,
-        ContentTypeService $contentTypeService,
         AssetMapper $mapper,
         SPIContentHandler $handler
     ) {
         $this->contentService = $contentService;
-        $this->contentTypeService = $contentTypeService;
         $this->assetMapper = $mapper;
         $this->handler = $handler;
     }

--- a/src/lib/FieldType/ImageAsset/Type.php
+++ b/src/lib/FieldType/ImageAsset/Type.php
@@ -70,20 +70,22 @@ class Type extends FieldType implements TranslationContainerInterface
             (int)$fieldValue->destinationContentId
         );
 
-        if ($this->assetMapper->isAsset($content)) {
-            $validationError = $this->validateMaxFileSize($content);
-            if (null !== $validationError) {
-                $errors[] = $validationError;
-            }
-        } else {
-            $errors[] = new ValidationError(
-                'Content %type% is not a valid asset target',
-                null,
-                [
-                    '%type%' => $content->getContentType()->identifier,
-                ],
-                'destinationContentId'
-            );
+        if (!$this->assetMapper->isAsset($content)) {
+            return [
+                new ValidationError(
+                    'Content %type% is not a valid asset target',
+                    null,
+                    [
+                        '%type%' => $content->getContentType()->identifier,
+                    ],
+                    'destinationContentId'
+                ),
+            ];
+        }
+
+        $validationError = $this->validateMaxFileSize($content);
+        if (null !== $validationError) {
+            $errors[] = $validationError;
         }
 
         return $errors;

--- a/src/lib/Resources/settings/fieldtypes.yml
+++ b/src/lib/Resources/settings/fieldtypes.yml
@@ -549,7 +549,6 @@ services:
         parent: Ibexa\Core\FieldType\FieldType
         arguments:
             - '@ibexa.api.service.content'
-            - '@ibexa.api.service.content_type'
             - '@Ibexa\Core\FieldType\ImageAsset\AssetMapper'
             - '@Ibexa\Core\Persistence\Cache\ContentHandler'
         tags:

--- a/tests/lib/FieldType/ImageAssetTest.php
+++ b/tests/lib/FieldType/ImageAssetTest.php
@@ -296,7 +296,7 @@ class ImageAssetTest extends FieldTypeTest
     public function testValidateValidNonEmptyAssetValue(
         int $fileSize,
         array $expectedValidationErrors
-    ) {
+    ): void {
         $destinationContentId = 7;
         $destinationContent = $this->createMock(Content::class);
 

--- a/tests/lib/FieldType/ImageAssetTest.php
+++ b/tests/lib/FieldType/ImageAssetTest.php
@@ -12,7 +12,6 @@ use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as SPIContentHandler;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\ContentService;
-use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Relation;
@@ -34,9 +33,6 @@ class ImageAssetTest extends FieldTypeTest
     /** @var \Ibexa\Contracts\Core\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
     private $contentServiceMock;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
-    private $contentTypeServiceMock;
-
     /** @var \Ibexa\Core\FieldType\ImageAsset\AssetMapper|\PHPUnit\Framework\MockObject\MockObject */
     private $assetMapperMock;
 
@@ -51,7 +47,6 @@ class ImageAssetTest extends FieldTypeTest
         parent::setUp();
 
         $this->contentServiceMock = $this->createMock(ContentService::class);
-        $this->contentTypeServiceMock = $this->createMock(ContentTypeService::class);
         $this->assetMapperMock = $this->createMock(ImageAsset\AssetMapper::class);
         $this->contentHandlerMock = $this->createMock(SPIContentHandler::class);
         $versionInfo = new VersionInfo([
@@ -96,7 +91,6 @@ class ImageAssetTest extends FieldTypeTest
     {
         return new ImageAsset\Type(
             $this->contentServiceMock,
-            $this->contentTypeServiceMock,
             $this->assetMapperMock,
             $this->contentHandlerMock
         );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7502](https://issues.ibexa.co/browse/IBX-7502)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Ref: https://github.com/ibexa/content-forms/pull/61

This PR adds file size validation to image asset field type definition, base on validation settings from ezimage field type. Currently validation is added as Symfony File validator in: https://github.com/ibexa/content-forms/blob/main/src/lib/Form/Type/FieldType/ImageAssetFieldType.php#L82-L86. 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
