### PR TITLE
Unified Image Criteria argument names

### DIFF
--- a/src/contracts/Repository/Values/Content/Query/Criterion/Image.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/Image.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 
-use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Image\AbstractImageCompositeCriterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Image\FileSize;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Image\Height;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Image\MimeType;
@@ -28,7 +28,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Image\Width;
  *
  * @template-extends \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Image\AbstractImageCompositeCriterion<ImageCriteria>
  */
-final class Image extends Criterion\Image\AbstractImageCompositeCriterion
+final class Image extends AbstractImageCompositeCriterion
 {
     public const IMAGE_SEARCH_CRITERIA = [
         'mimeTypes',
@@ -44,7 +44,7 @@ final class Image extends Criterion\Image\AbstractImageCompositeCriterion
     }
 
     /**
-     * @phpstan-param ImageCriteria $data
+     * @phpstan-param ImageCriteria $imageCriteriaData
      *
      * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion>
      *
@@ -52,19 +52,19 @@ final class Image extends Criterion\Image\AbstractImageCompositeCriterion
      */
     protected function buildCriteria(
         string $fieldDefIdentifier,
-        array $data
+        array $imageCriteriaData
     ): array {
         $criteria = [];
 
-        if (isset($data['mimeTypes'])) {
+        if (isset($imageCriteriaData['mimeTypes'])) {
             $criteria[] = new MimeType(
                 $fieldDefIdentifier,
-                $data['mimeTypes']
+                $imageCriteriaData['mimeTypes']
             );
         }
 
-        if (isset($data['size'])) {
-            $size = $data['size'];
+        if (isset($imageCriteriaData['size'])) {
+            $size = $imageCriteriaData['size'];
             $criteria[] = new FileSize(
                 $fieldDefIdentifier,
                 $this->getMinValue($size),
@@ -72,8 +72,8 @@ final class Image extends Criterion\Image\AbstractImageCompositeCriterion
             );
         }
 
-        if (isset($data['width'])) {
-            $width = $data['width'];
+        if (isset($imageCriteriaData['width'])) {
+            $width = $imageCriteriaData['width'];
             $criteria[] = new Width(
                 $fieldDefIdentifier,
                 $this->getMinValue($width),
@@ -81,8 +81,8 @@ final class Image extends Criterion\Image\AbstractImageCompositeCriterion
             );
         }
 
-        if (isset($data['height'])) {
-            $height = $data['height'];
+        if (isset($imageCriteriaData['height'])) {
+            $height = $imageCriteriaData['height'];
             $criteria[] = new Height(
                 $fieldDefIdentifier,
                 $this->getMinValue($height),
@@ -90,10 +90,10 @@ final class Image extends Criterion\Image\AbstractImageCompositeCriterion
             );
         }
 
-        if (isset($data['orientation'])) {
+        if (isset($imageCriteriaData['orientation'])) {
             $criteria[] = new Orientation(
                 $fieldDefIdentifier,
-                $data['orientation']
+                $imageCriteriaData['orientation']
             );
         }
 

--- a/src/contracts/Repository/Values/Content/Query/Criterion/Image/AbstractImageCompositeCriterion.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/Image/AbstractImageCompositeCriterion.php
@@ -23,29 +23,29 @@ use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 abstract class AbstractImageCompositeCriterion extends CompositeCriterion
 {
     /**
-     * @phpstan-param TImageCriteria $data
+     * @phpstan-param TImageCriteria $imageCriteriaData
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     public function __construct(
         string $fieldDefIdentifier,
-        array $data
+        array $imageCriteriaData
     ) {
-        $this->validate($data, $this->getSupportedCriteria());
+        $this->validate($imageCriteriaData, $this->getSupportedCriteria());
 
         $criteria = new Criterion\LogicalAnd(
-            $this->buildCriteria($fieldDefIdentifier, $data)
+            $this->buildCriteria($fieldDefIdentifier, $imageCriteriaData)
         );
 
         parent::__construct($criteria);
     }
 
     /**
-     * @phpstan-param TImageCriteria $data
+     * @phpstan-param TImageCriteria $imageCriteriaData
      *
      * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion>
      */
-    abstract protected function buildCriteria(string $fieldDefIdentifier, array $data): array;
+    abstract protected function buildCriteria(string $fieldDefIdentifier, array $imageCriteriaData): array;
 
     /**
      * @return array<string>
@@ -53,17 +53,17 @@ abstract class AbstractImageCompositeCriterion extends CompositeCriterion
     abstract protected function getSupportedCriteria(): array;
 
     /**
-     * @phpstan-param TImageCriteria $data
+     * @phpstan-param TImageCriteria $imageCriteriaData
      *
      * @param array<string> $supportedCriteria
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     protected function validate(
-        array $data,
+        array $imageCriteriaData,
         array $supportedCriteria
     ): void {
-        if (empty($data)) {
+        if (empty($imageCriteriaData)) {
             throw new InvalidArgumentException(
                 '$data',
                 sprintf(
@@ -74,7 +74,7 @@ abstract class AbstractImageCompositeCriterion extends CompositeCriterion
         }
 
         $notSupportedCriteria = array_diff(
-            array_keys($data),
+            array_keys($imageCriteriaData),
             $supportedCriteria
         );
 

--- a/src/contracts/Repository/Values/Content/Query/Criterion/Image/Dimensions.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/Image/Dimensions.php
@@ -34,7 +34,7 @@ final class Dimensions extends AbstractImageCompositeCriterion
     }
 
     /**
-     * @phpstan-param ImageCriteria $data
+     * @phpstan-param ImageCriteria $imageCriteriaData
      *
      * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion>
      *
@@ -42,12 +42,12 @@ final class Dimensions extends AbstractImageCompositeCriterion
      */
     protected function buildCriteria(
         string $fieldDefIdentifier,
-        array $data
+        array $imageCriteriaData
     ): array {
         $criteria = [];
 
-        if (isset($data['width'])) {
-            $width = $data['width'];
+        if (isset($imageCriteriaData['width'])) {
+            $width = $imageCriteriaData['width'];
             $criteria[] = new Width(
                 $fieldDefIdentifier,
                 $this->getMinValue($width),
@@ -55,8 +55,8 @@ final class Dimensions extends AbstractImageCompositeCriterion
             );
         }
 
-        if (isset($data['height'])) {
-            $height = $data['height'];
+        if (isset($imageCriteriaData['height'])) {
+            $height = $imageCriteriaData['height'];
             $criteria[] = new Height(
                 $fieldDefIdentifier,
                 $this->getMinValue($height),

--- a/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
@@ -10,29 +10,23 @@ namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Image;
 
 final class FileSize extends AbstractImageRangeCriterion
 {
-    /**
-     * @param numeric $minFileSize
-     * @param numeric|null $maxFileSize
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     */
     public function __construct(
         string $fieldDefIdentifier,
-        $minFileSize = 0,
-        $maxFileSize = null
+        $minValue = 0,
+        $maxValue = null
     ) {
-        if ($minFileSize > 0) {
-            $minFileSize *= 1024 * 1024;
+        if ($minValue > 0) {
+            $minValue *= 1024 * 1024;
         }
 
-        if ($maxFileSize > 0) {
-            $maxFileSize *= 1024 * 1024;
+        if ($maxValue > 0) {
+            $maxValue *= 1024 * 1024;
         }
 
         parent::__construct(
             $fieldDefIdentifier,
-            $minFileSize,
-            $maxFileSize
+            $minValue,
+            $maxValue
         );
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Renamed argument names:

- `data` to `imageCriteriaData` - (Should be clearer what data should be passed)
- `minFileSize` to `minValue` (Name should be the same for all range Criteria)
- `maxFileSize` to `maxValue` (Name should be the same for all range Criteria)

ref: https://github.com/ibexa/core/blob/main/src/contracts/Repository/Values/Content/Query/Criterion/Image/AbstractImageRangeCriterion.php

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
