### PR TITLE
IBX-7364: Ensured independent property assignment in setPreviewActive  method by using clone

### DIFF
--- a/src/lib/Helper/ContentPreviewHelper.php
+++ b/src/lib/Helper/ContentPreviewHelper.php
@@ -98,6 +98,7 @@ class ContentPreviewHelper implements SiteAccessAware
     public function setPreviewActive($previewActive)
     {
         $this->previewActive = (bool)$previewActive;
+        $this->originalSiteAccess = clone $this->originalSiteAccess;
     }
 
     /**

--- a/tests/lib/Helper/ContentPreviewHelperTest.php
+++ b/tests/lib/Helper/ContentPreviewHelperTest.php
@@ -78,11 +78,16 @@ class ContentPreviewHelperTest extends TestCase
 
     public function testPreviewActive()
     {
+        $originalSiteAccess = new SiteAccess('foo', 'bar');
+        $this->previewHelper->setSiteAccess($originalSiteAccess);
+
         $this->assertFalse($this->previewHelper->isPreviewActive());
         $this->previewHelper->setPreviewActive(true);
         $this->assertTrue($this->previewHelper->isPreviewActive());
         $this->previewHelper->setPreviewActive(false);
         $this->assertFalse($this->previewHelper->isPreviewActive());
+
+        self::assertNotSame($originalSiteAccess, $this->previewHelper->getOriginalSiteAccess());
     }
 
     public function testPreviewedContent()


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7364](https://issues.ibexa.co/browse/IBX-7364)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | yes/no

in `\Ibexa\Core\MVC\Symfony\Controller\Content\PreviewController::previewContentAction` when requesting preview for given siteaccess, that siteaccess then override original one (and everywhere else by reference) in  `\Ibexa\Bundle\Core\EventListener\SiteAccessListener::onSiteAccessMatch`, as those are the same object - because of that, after doing request for preview in site-context, after that request we end up with wrong siteaccess for the rest of logic.

Cloning SA object when starting preview action solves reference issue, and still allowes for override `default` siteaccess with proper one at request initialization.

used in:
https://github.com/ibexa/site-context/pull/28
#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
