### PR TITLE
[PHPStan] Regenerated baseline after PHPStan release

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -131,31 +131,6 @@ parameters:
 			path: src/bundle/Core/Imagine/PlaceholderProvider/RemoteProvider.php
 
 		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_add_handle expects resource, resource\\|false given\\.$#"
-			count: 2
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_close expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_exec expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_info_read expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_remove_handle expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of function trim expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/bundle/Debug/Twig/DebugTemplate.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18146,6 +18146,11 @@ parameters:
 			path: src/lib/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
 
 		-
+			message: "#^Parameter \\#2 \\$callback of function array_filter expects \\(callable\\(int\\)\\: bool\\)\\|null, Closure\\(mixed\\)\\: int given\\.$#"
+			count: 1
+			path: src/lib/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+
+		-
 			message: "#^Variable \\$connection in PHPDoc tag @var does not match assigned variable \\$query\\.$#"
 			count: 1
 			path: src/lib/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

PHPStan after its recent release reports new error. The analysis is valid, that portion of legacy code is not very strict and relies on numeric and true-ish values. Adding to baseline to avoid QA on URLAlias GW now.