### PR TITLE
IBX-7689: Modified code to generate hyperlinks only for non-drafts

### DIFF
--- a/src/bundle/Core/Resources/views/default/content/embed.html.twig
+++ b/src/bundle/Core/Resources/views/default/content/embed.html.twig
@@ -5,7 +5,9 @@
 {% else %}
     {% if location is defined %}
         <h3><a href="{{ ibexa_path(location) }}">{{ content_name }}</a></h3>
-    {% else %}
+    {% elseif content.contentInfo.mainLocationId is not null %}
         <h3><a href="{{ ibexa_path(content) }}">{{ content_name }}</a></h3>
+    {% else %}
+        <h3>{{ content_name }}</h3>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7689](https://issues.ibexa.co/browse/IBX-7689)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

There is no way to generate valid URL aliases for non-drafts (in `\Ibexa\Core\MVC\Symfony\Routing\UrlAliasRouter::generate`) and this seems like a simplest solution for this problem.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
