### PR TITLE
Made focus mode disabled for clean installation administrative user

### DIFF
--- a/data/mysql/cleandata.sql
+++ b/data/mysql/cleandata.sql
@@ -299,3 +299,6 @@ VALUES (11,28,'','',1),
 INSERT INTO `ezuser_setting` (`is_enabled`, `max_login`, `user_id`)
 VALUES (1,1000,10),
        (1,10,14);
+
+INSERT INTO `ezpreferences` (`name`, `user_id`, `value`)
+SELECT 'focus_mode', u.contentobject_id, '0' FROM `ezuser` u WHERE u.login = 'admin';

--- a/data/postgresql/cleandata.sql
+++ b/data/postgresql/cleandata.sql
@@ -300,6 +300,9 @@ INSERT INTO "ezuser_setting" ("is_enabled", "max_login", "user_id")
 VALUES (1, 1000, 10),
        (1, 10, 14);
 
+INSERT INTO "ezpreferences" ("name", "user_id", "value")
+SELECT 'focus_mode', u.contentobject_id, '0' FROM "ezuser" u WHERE u.login = 'admin';
+
 -- Set proper sequence values after inserting data
 SELECT SETVAL('ezcobj_state_group_id_seq', COALESCE(MAX(id), 1) ) FROM ezcobj_state_group;
 SELECT SETVAL('ezcobj_state_id_seq', COALESCE(MAX(id), 1) ) FROM ezcobj_state;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a ?
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no
| **Regressions** | https://github.com/ibexa/commerce/pull/681

We want just for clean installation `admin` user to turn off focus mode, so administrator sees all UI by default.

For any other users, including new ones we still want focus mode to be turned on by [the fallback setting](https://github.com/ibexa/admin-ui/blob/2b7ef66637ccab7000d729a8d1e1bb541d1dc6e1/src/bundle/Resources/config/default_parameters.yaml#L82).

Note that while this belongs to ibexa/admin-ui, there's no extension point to place it there. Installer Provisioners are part of Ibexa DXP (commercial) package. That being said, user preference data is code-agnostic and having it here does no harm.

We also don't want this to be included in upgrade scripts as there's no easy way to tell which user is an administrative one.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage // any failure should be visible in behat tests.
- [x] Checked that target branch is set correctly.
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.
