### PR TITLE
Fix typo in ibexa:install option description

### DIFF
--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -73,7 +73,7 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
             'skip-indexing',
             null,
             InputOption::VALUE_NONE,
-            'Skip indexing (ezplaform:reindex)'
+            'Skip indexing (ibexa:reindex)'
         );
     }
 


### PR DESCRIPTION
It should have been "ezplatform" instead of "ezplaform", but "ibexa" is the new prefix.

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          |
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
