### PR TITLE
[Composer] Dropped obsolete symfony/thanks config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,10 +159,6 @@
     "extra": {
         "branch-alias": {
             "dev-main": "4.6.x-dev"
-        },
-        "thanks": {
-            "name": "ezsystems/ezplatform",
-            "url": "https://github.com/ezsystems/ezplatform"
         }
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | yes (?), but of no value reduced

Long time ago we decided to add config for https://github.com/symfony/thanks. That feature was a Symfony extension point able to add GitHub star to a configured package (which can be done via GitHub interface anyway). At that time there was single `ezsystems/ezplatform` meta-package, which no longer applies.

We could configure `ibexa/oss` or `ibexa/core` itself, but I think it doesn't produce any value for DXP, so I'm proposing to remove it instead.

#### Checklist:
- [x] Provided PR description.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review.
