### PR TITLE
Remove incorrect parameter type doc of GenericType::getSortInfo()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5156,11 +5156,6 @@ parameters:
 			path: src/contracts/FieldType/Generic/Type.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of method Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Generic\\\\Type\\:\\:getSortInfo\\(\\) expects Ibexa\\\\Core\\\\FieldType\\\\Value, Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value given\\.$#"
-			count: 1
-			path: src/contracts/FieldType/Generic/Type.php
-
-		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\ValidationError\\:\\:setTarget\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/contracts/FieldType/ValidationError.php

--- a/src/contracts/FieldType/Generic/Type.php
+++ b/src/contracts/FieldType/Generic/Type.php
@@ -194,8 +194,6 @@ abstract class Type extends FieldType
      *
      * In case of multi value, values should be string and separated by "-" or ",".
      *
-     * @param \Ibexa\Core\FieldType\Value $value
-     *
      * @return mixed
      */
     protected function getSortInfo(Value $value)


### PR DESCRIPTION
The method parameter is of type `\Ibexa\Contracts\Core\FieldType\Value` while the docblock claims its type as `\Ibexa\Core\FieldType\Value`, which is a sub type of `\Ibexa\Contracts\Core\FieldType\Value`.

This line can cause PHPStan issues when the method is called in implementations of `toPersistenceValue()`.

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | 
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | yno

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ibexa/engineering`).
