### PR TITLE
[BC break] Added `implements \Stringable` to `Translation` Value Object

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8531,11 +8531,6 @@ parameters:
 			path: src/lib/Base/Exceptions/UnauthorizedException.php
 
 		-
-			message: "#^Cannot cast Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Translation to string\\.$#"
-			count: 1
-			path: src/lib/Base/Exceptions/UserPasswordValidationException.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Exceptions\\\\UserPasswordValidationException\\:\\:__construct\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Base/Exceptions/UserPasswordValidationException.php
@@ -43039,11 +43034,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\FloatValueValidatorTest\\:\\:testValidateWrongValues\\(\\) has parameter \\$values with no type specified\\.$#"
 			count: 1
 			path: tests/lib/FieldType/FloatValueValidatorTest.php
-
-		-
-			message: "#^Cannot cast Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Translation to string\\.$#"
-			count: 1
-			path: tests/lib/FieldType/Generic/GenericTest.php
 
 		-
 			message: "#^Class Symfony\\\\Component\\\\Validator\\\\ConstraintViolation constructor invoked with 1 parameter, 6\\-10 required\\.$#"

--- a/src/contracts/Repository/Values/Translation.php
+++ b/src/contracts/Repository/Values/Translation.php
@@ -8,12 +8,15 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values;
 
+use Stringable;
+
 /**
- * Base class fro translation messages.
+ * Abstract for UI translation messages, use its extensions: Translation\Message, Translation\Plural.
  *
- * Use its extensions: Translation\Singular, Translation\Plural.
+ * @see \Ibexa\Contracts\Core\Repository\Values\Translation\Message
+ * @see \Ibexa\Contracts\Core\Repository\Values\Translation\Plural
  */
-abstract class Translation extends ValueObject
+abstract class Translation extends ValueObject implements Stringable
 {
 }
 

--- a/src/contracts/Repository/Values/Translation/Message.php
+++ b/src/contracts/Repository/Values/Translation/Message.php
@@ -42,12 +42,12 @@ class Message extends Translation
     {
         $this->message = $message;
         $this->values = $values;
+
+        parent::__construct();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
+    #[\Override]
+    public function __toString(): string
     {
         return strtr($this->message, $this->values);
     }

--- a/src/contracts/Repository/Values/Translation/Plural.php
+++ b/src/contracts/Repository/Values/Translation/Plural.php
@@ -67,12 +67,12 @@ class Plural extends Translation
         $this->singular = $singular;
         $this->plural = $plural;
         $this->values = $values;
+
+        parent::__construct();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
+    #[\Override]
+    public function __toString(): string
     {
         return strtr(current($this->values) == 1 ? $this->plural : $this->singular, $this->values);
     }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|
| BC breaks | yes, for 5.0.0 major |

#### Description:
`\Ibexa\Contracts\Core\Repository\Values\Translation` class has no `__toString()` method but all two implementations: `Plural`, and `Message` - have it. Given we operate on the common abstract contract, it causes static analysis issue:
```
Error: Cannot cast Ibexa\Contracts\Core\Repository\Values\Translation to string.
```
This method should be declared on the `Translation` abstract. The easiest way to solve it is to implement `\Stringable` on the abstract Translation class, forcing all its children to actually implement `public function __toString(): string`.

```php
abstract class Translation extends ValueObject implements \Stringable
```

#### For QA:
No QA required, regressions are enough.

#### Documentation:

Should be documented as a breaking change. I'll update proper internal document that will be used when documenting all 5.0 breaks, so for this PR no "doc needed" label.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
