### PR TITLE
[Tests] Dropped providing fallback Kernel if not defined

### DIFF
--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Test;
 
-use LogicException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -17,13 +16,4 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 abstract class IbexaKernelTestCase extends KernelTestCase
 {
     use IbexaKernelTestTrait;
-
-    protected static function getKernelClass(): string
-    {
-        try {
-            return parent::getKernelClass();
-        } catch (LogicException $e) {
-            return IbexaTestKernel::class;
-        }
-    }
 }

--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -11,7 +11,7 @@ namespace Ibexa\Contracts\Core\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
- * @experimental
+ * @internal For core tests only. Use \Ibexa\Contracts\Test\Core\IbexaKernelTestCase from ibexa/test-core instead.
  */
 abstract class IbexaKernelTestCase extends KernelTestCase
 {

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -33,7 +33,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
- * @experimental
+ * @internal For core tests only. Use \Ibexa\Contracts\Test\Core\IbexaTestKernel from ibexa/test-core instead.
  *
  * Baseline test kernel that dependent packages can extend for their integration tests.
  *


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | n/a |
| **Type**                 | improvement                             |
| **Target Ibexa version** | `v4.6`              |
| **BC breaks**            | no[1]                                              |

See https://github.com/ibexa/test-core/pull/10 for reasoning about this change.

Also updated PHPDoc to clearly state that ibexa/test-core should be used by the other packages, see [1].

---
[1] With the appearance of [`ibexa/test-core`](https://github.com/ibexa/test-core/) both `IbexaKernelTestCase` and `IbexaTestKernel` became internal.