### PR TITLE
IBX-7959: Added `ContentInfo::getSectionId` strict getter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36531,11 +36531,6 @@ parameters:
 			path: tests/integration/Core/Repository/SearchEngineIndexingTest.php
 
 		-
-			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$sectionId\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/SearchEngineIndexingTest.php
-
-		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$versionInfo\\.$#"
 			count: 2
 			path: tests/integration/Core/Repository/SearchEngineIndexingTest.php
@@ -61479,11 +61474,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Validator\\\\TargetContentValidatorTest\\:\\:\\$contentTypeHandler has unknown class PHPUnit_Framework_MockObject_MockObject as its type\\.$#"
 			count: 1
 			path: tests/lib/Repository/Validator/TargetContentValidatorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfoTest\\:\\:testObjectProperties\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Values/Content/ContentInfoTest.php
 
 		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Language\\:\\:\\$notDefined\\.$#"

--- a/src/contracts/Repository/Values/Content/ContentInfo.php
+++ b/src/contracts/Repository/Values/Content/ContentInfo.php
@@ -195,6 +195,11 @@ class ContentInfo extends ValueObject
         return $this->section;
     }
 
+    public function getSectionId(): int
+    {
+        return $this->sectionId;
+    }
+
     public function getMainLanguage(): Language
     {
         return $this->mainLanguage;

--- a/src/contracts/Repository/Values/Content/ContentInfo.php
+++ b/src/contracts/Repository/Values/Content/ContentInfo.php
@@ -18,7 +18,7 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  * @property-read int $id @deprecated Use {@see ContentInfo::getId} instead. The unique id of the Content object
  * @property-read int $contentTypeId The unique id of the content type item the Content object is an instance of
  * @property-read string $name the computed name (via name schema) in the main language of the Content object
- * @property-read int $sectionId the section to which the Content object is assigned
+ * @property-read int $sectionId @deprecated 4.6.2 Use {@see ContentInfo::getSectionId} instead. The section to which the Content object is assigned
  * @property-read int $currentVersionNo Current Version number is the version number of the published version or the version number of a newly created draft (which is 1).
  * @property-read bool $published true if there exists a published version false otherwise
  * @property-read int $ownerId the user id of the owner of the Content object

--- a/src/contracts/Repository/Values/Content/ContentInfo.php
+++ b/src/contracts/Repository/Values/Content/ContentInfo.php
@@ -65,7 +65,7 @@ class ContentInfo extends ValueObject
      *
      * @var int
      */
-    protected $sectionId;
+    protected int $sectionId;
 
     /**
      * Current Version number is the version number of the published version or the version number of

--- a/src/lib/Limitation/SectionLimitationType.php
+++ b/src/lib/Limitation/SectionLimitationType.php
@@ -138,10 +138,12 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
         /*
          * We ignore Targets here, they are only interesting in NewState limitation as we on this one is more interested
          * the section already assigned to object.
-         *
-         * @var $object ContentInfo|ContentCreateStruct
          */
-        return in_array($object->sectionId, $value->limitationValues);
+        if ($object instanceof ContentCreateStruct) {
+            return in_array($object->sectionId, $value->limitationValues);
+        }
+
+        return in_array($object->getSectionId(), $value->limitationValues);
     }
 
     /**

--- a/src/lib/Limitation/SectionLimitationType.php
+++ b/src/lib/Limitation/SectionLimitationType.php
@@ -138,6 +138,8 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
         /*
          * We ignore Targets here, they are only interesting in NewState limitation as we on this one is more interested
          * the section already assigned to object.
+         *
+         * We can't use strict comparison because limitationValues is an array of string
          */
         if ($object instanceof ContentCreateStruct) {
             return in_array($object->sectionId, $value->limitationValues);

--- a/src/lib/MVC/Symfony/Matcher/ContentBased/Id/Section.php
+++ b/src/lib/MVC/Symfony/Matcher/ContentBased/Id/Section.php
@@ -23,7 +23,7 @@ class Section extends MultipleValued
      */
     public function matchLocation(APILocation $location)
     {
-        return isset($this->values[$location->getContentInfo()->sectionId]);
+        return isset($this->values[$location->getContentInfo()->getSectionId()]);
     }
 
     /**
@@ -35,7 +35,7 @@ class Section extends MultipleValued
      */
     public function matchContentInfo(ContentInfo $contentInfo)
     {
-        return isset($this->values[$contentInfo->sectionId]);
+        return isset($this->values[$contentInfo->getSectionId()]);
     }
 
     public function match(View $view)
@@ -44,7 +44,7 @@ class Section extends MultipleValued
             return false;
         }
 
-        return isset($this->values[$view->getContent()->contentInfo->sectionId]);
+        return isset($this->values[$view->getContent()->contentInfo->getSectionId()]);
     }
 }
 

--- a/src/lib/MVC/Symfony/Matcher/ContentBased/Identifier/Section.php
+++ b/src/lib/MVC/Symfony/Matcher/ContentBased/Identifier/Section.php
@@ -27,7 +27,7 @@ class Section extends MultipleValued
         $section = $this->repository->sudo(
             static function (Repository $repository) use ($location) {
                 return $repository->getSectionService()->loadSection(
-                    $location->getContentInfo()->sectionId
+                    $location->getContentInfo()->getSectionId()
                 );
             }
         );
@@ -47,7 +47,7 @@ class Section extends MultipleValued
         $section = $this->repository->sudo(
             static function (Repository $repository) use ($contentInfo) {
                 return $repository->getSectionService()->loadSection(
-                    $contentInfo->sectionId
+                    $contentInfo->getSectionId()
                 );
             }
         );
@@ -65,7 +65,7 @@ class Section extends MultipleValued
         $section = $this->repository->sudo(
             static function (Repository $repository) use ($contentInfo) {
                 return $repository->getSectionService()->loadSection(
-                    $contentInfo->sectionId
+                    $contentInfo->getSectionId()
                 );
             }
         );

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -632,7 +632,7 @@ class ContentService implements ContentServiceInterface
                 $location = $this->repository->getLocationService()->loadLocation(
                     $locationCreateStructs[0]->parentLocationId
                 );
-                $contentCreateStruct->sectionId = $location->contentInfo->sectionId;
+                $contentCreateStruct->sectionId = $location->getContentInfo()->getSectionId();
             } else {
                 $contentCreateStruct->sectionId = 1;
             }
@@ -1945,7 +1945,7 @@ class ContentService implements ContentServiceInterface
                 'create',
                 [
                     'parentLocationId' => $destinationLocationCreateStruct->parentLocationId,
-                    'sectionId' => $contentInfo->sectionId,
+                    'sectionId' => $contentInfo->getSectionId(),
                 ]
             );
         }

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -1365,7 +1365,7 @@ class ContentServiceTest extends BaseContentServiceTest
                 $contentInfo->mainLanguageCode,
                 $contentInfo->ownerId,
                 $contentInfo->remoteId,
-                $contentInfo->sectionId,
+                $contentInfo->getSectionId(),
             ]
         );
     }
@@ -2071,7 +2071,7 @@ class ContentServiceTest extends BaseContentServiceTest
             ],
             [
                 'remoteId' => $contentInfo->remoteId,
-                'sectionId' => $contentInfo->sectionId,
+                'sectionId' => $contentInfo->getSectionId(),
                 'alwaysAvailable' => $contentInfo->alwaysAvailable,
                 'currentVersionNo' => $contentInfo->currentVersionNo,
                 'mainLanguageCode' => $contentInfo->mainLanguageCode,

--- a/tests/integration/Core/Repository/SearchEngineIndexingTest.php
+++ b/tests/integration/Core/Repository/SearchEngineIndexingTest.php
@@ -1112,7 +1112,10 @@ class SearchEngineIndexingTest extends BaseTest
         $criterion = new Criterion\ContentId($content->id);
         $query = new Query(['filter' => $criterion]);
         $results = $searchService->findContentInfo($query);
-        $this->assertEquals($section->id, $results->searchHits[0]->valueObject->sectionId);
+
+        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo */
+        $contentInfo = $results->searchHits[0]->valueObject;
+        $this->assertEquals($section->id, $contentInfo->getSectionId());
     }
 
     /**

--- a/tests/integration/Core/Repository/SearchEngineIndexingTest.php
+++ b/tests/integration/Core/Repository/SearchEngineIndexingTest.php
@@ -1115,7 +1115,7 @@ class SearchEngineIndexingTest extends BaseTest
 
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo */
         $contentInfo = $results->searchHits[0]->valueObject;
-        $this->assertEquals($section->id, $contentInfo->getSectionId());
+        self::assertEquals($section->id, $contentInfo->getSectionId());
     }
 
     /**

--- a/tests/integration/Core/Repository/Values/User/Limitation/NewSectionLimitationTest.php
+++ b/tests/integration/Core/Repository/Values/User/Limitation/NewSectionLimitationTest.php
@@ -63,7 +63,7 @@ class NewSectionLimitationTest extends BaseLimitationTest
 
         $this->assertSame(
             $sectionId,
-            $contentService->loadContentInfo($contentId)->sectionId
+            $contentService->loadContentInfo($contentId)->getSectionId()
         );
     }
 

--- a/tests/lib/Repository/Values/Content/ContentInfoTest.php
+++ b/tests/lib/Repository/Values/Content/ContentInfoTest.php
@@ -6,6 +6,7 @@
  */
 namespace Ibexa\Tests\Core\Repository\Values\Content;
 
+use DateTimeImmutable;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use PHPUnit\Framework\TestCase;
 
@@ -14,35 +15,41 @@ use PHPUnit\Framework\TestCase;
  */
 class ContentInfoTest extends TestCase
 {
-    public function testObjectProperties()
+    public function testCreateObject(): void
     {
-        $object = new ContentInfo();
-        $properties = $object->attributes();
-        self::assertNotContains('internalFields', $properties, 'Internal property found ');
-        self::assertContains('contentTypeId', $properties, 'Property not found');
-        self::assertContains('id', $properties, 'Property not found');
-        self::assertContains('name', $properties, 'Property not found');
-        self::assertContains('sectionId', $properties, 'Property not found');
-        self::assertContains('currentVersionNo', $properties, 'Property not found');
-        self::assertContains('published', $properties, 'Property not found');
-        self::assertContains('ownerId', $properties, 'Property not found');
-        self::assertContains('modificationDate', $properties, 'Property not found');
-        self::assertContains('publishedDate', $properties, 'Property not found');
-        self::assertContains('alwaysAvailable', $properties, 'Property not found');
-        self::assertContains('remoteId', $properties, 'Property not found');
-        self::assertContains('mainLanguageCode', $properties, 'Property not found');
-        self::assertContains('mainLocationId', $properties, 'Property not found');
+        $dateTime = new DateTimeImmutable();
+        $contentInfo = new ContentInfo(
+            [
+                'id' => 1,
+                'contentTypeId' => 2,
+                'name' => 'foo',
+                'sectionId' => 1,
+                'currentVersionNo' => 1,
+                'status' => 1,
+                'ownerId' => 10,
+                'modificationDate' => $dateTime,
+                'publishedDate' => $dateTime,
+                'alwaysAvailable' => false,
+                'remoteId' => '1qaz2wsx',
+                'mainLanguageCode' => 'eng-GB',
+                'mainLocationId' => 2,
+            ]
+        );
 
-        // check for duplicates and double check existence of property
-        $propertiesHash = [];
-        foreach ($properties as $property) {
-            if (isset($propertiesHash[$property])) {
-                self::fail("Property '{$property}' exists several times in properties list");
-            } elseif (!isset($object->$property)) {
-                self::fail("Property '{$property}' does not exist on object, even though it was hinted to be there");
-            }
-            $propertiesHash[$property] = 1;
-        }
+        $dateFormatted = $dateTime->format('c');
+        self::assertSame($contentInfo->getId(), 1);
+        self::assertSame($contentInfo->contentTypeId, 2);
+        self::assertSame($contentInfo->name, 'foo');
+        self::assertSame($contentInfo->getSectionId(), 1);
+        self::assertSame($contentInfo->currentVersionNo, 1);
+        self::assertTrue($contentInfo->isPublished());
+        self::assertSame($contentInfo->ownerId, 10);
+        self::assertSame($dateFormatted, $contentInfo->modificationDate->format('c'));
+        self::assertSame($dateFormatted, $contentInfo->publishedDate->format('c'));
+        self::assertFalse($contentInfo->alwaysAvailable);
+        self::assertSame($contentInfo->remoteId, '1qaz2wsx');
+        self::assertSame($contentInfo->getMainLanguageCode(), 'eng-GB');
+        self::assertSame($contentInfo->getMainLocationId(), 2);
     }
 }
 

--- a/tests/lib/Repository/Values/Content/ContentInfoTest.php
+++ b/tests/lib/Repository/Values/Content/ContentInfoTest.php
@@ -37,19 +37,19 @@ class ContentInfoTest extends TestCase
         );
 
         $dateFormatted = $dateTime->format('c');
-        self::assertSame($contentInfo->getId(), 1);
-        self::assertSame($contentInfo->contentTypeId, 2);
-        self::assertSame($contentInfo->name, 'foo');
-        self::assertSame($contentInfo->getSectionId(), 1);
-        self::assertSame($contentInfo->currentVersionNo, 1);
+        self::assertSame(1, $contentInfo->getId());
+        self::assertSame(2, $contentInfo->contentTypeId);
+        self::assertSame('foo', $contentInfo->name);
+        self::assertSame(1, $contentInfo->getSectionId());
+        self::assertSame(1, $contentInfo->currentVersionNo);
         self::assertTrue($contentInfo->isPublished());
-        self::assertSame($contentInfo->ownerId, 10);
+        self::assertSame(10, $contentInfo->ownerId);
         self::assertSame($dateFormatted, $contentInfo->modificationDate->format('c'));
         self::assertSame($dateFormatted, $contentInfo->publishedDate->format('c'));
         self::assertFalse($contentInfo->alwaysAvailable);
-        self::assertSame($contentInfo->remoteId, '1qaz2wsx');
-        self::assertSame($contentInfo->getMainLanguageCode(), 'eng-GB');
-        self::assertSame($contentInfo->getMainLocationId(), 2);
+        self::assertSame('1qaz2wsx', $contentInfo->remoteId);
+        self::assertSame('eng-GB', $contentInfo->getMainLanguageCode());
+        self::assertSame(2, $contentInfo->getMainLocationId());
     }
 }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Added `getSectionId` method to `ContentInfo` VO to avoid using php magic to get the value.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
