### PR TITLE
IBX-7717: Introduced strict getters for LookupLimitationResult and VersionInfo Value Object

### DIFF
--- a/src/contracts/Repository/Values/Content/VersionInfo.php
+++ b/src/contracts/Repository/Values/Content/VersionInfo.php
@@ -108,6 +108,11 @@ abstract class VersionInfo extends ValueObject implements MultiLanguageName
     abstract public function getLanguages(): iterable;
 
     /**
+     * @return iterable<string>
+     */
+    abstract public function getLanguageCodes(): iterable;
+
+    /**
      * Returns true if version is a draft.
      *
      * @return bool

--- a/src/contracts/Repository/Values/Content/VersionInfo.php
+++ b/src/contracts/Repository/Values/Content/VersionInfo.php
@@ -89,7 +89,7 @@ abstract class VersionInfo extends ValueObject implements MultiLanguageName
      *
      * @var string[]
      */
-    protected $languageCodes = [];
+    protected array $languageCodes = [];
 
     /**
      * Content of the content this version belongs to.
@@ -108,9 +108,12 @@ abstract class VersionInfo extends ValueObject implements MultiLanguageName
     abstract public function getLanguages(): iterable;
 
     /**
-     * @return iterable<string>
+     * @return array<string>
      */
-    abstract public function getLanguageCodes(): iterable;
+    public function getLanguageCodes(): array
+    {
+        return $this->languageCodes;
+    }
 
     /**
      * Returns true if version is a draft.

--- a/src/contracts/Repository/Values/User/LookupLimitationResult.php
+++ b/src/contracts/Repository/Values/User/LookupLimitationResult.php
@@ -45,11 +45,17 @@ final class LookupLimitationResult extends ValueObject
         return $this->hasAccess;
     }
 
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation[]
+     */
     public function getRoleLimitations(): array
     {
         return $this->roleLimitations;
     }
 
+    /**
+     * @return \Ibexa\Contracts\Core\Repository\Values\User\LookupPolicyLimitations[]
+     */
     public function getLookupPolicyLimitations(): array
     {
         return $this->lookupPolicyLimitations;

--- a/src/contracts/Repository/Values/User/LookupLimitationResult.php
+++ b/src/contracts/Repository/Values/User/LookupLimitationResult.php
@@ -16,16 +16,15 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 final class LookupLimitationResult extends ValueObject
 {
     /** @var bool */
-    protected $hasAccess;
+    protected bool $hasAccess;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\Limitation[] */
-    protected $roleLimitations;
+    protected array $roleLimitations;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\LookupPolicyLimitations[] */
-    protected $lookupPolicyLimitations;
+    protected array $lookupPolicyLimitations;
 
     /**
-     * @param bool $hasAccess
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation[] $roleLimitations
      * @param \Ibexa\Contracts\Core\Repository\Values\User\LookupPolicyLimitations[] $lookupPolicyLimitations
      */
@@ -39,6 +38,21 @@ final class LookupLimitationResult extends ValueObject
         $this->hasAccess = $hasAccess;
         $this->lookupPolicyLimitations = $lookupPolicyLimitations;
         $this->roleLimitations = $roleLimitations;
+    }
+
+    public function hasAccess(): bool
+    {
+        return $this->hasAccess;
+    }
+
+    public function getRoleLimitations(): array
+    {
+        return $this->roleLimitations;
+    }
+
+    public function getLookupPolicyLimitations(): array
+    {
+        return $this->lookupPolicyLimitations;
     }
 }
 

--- a/src/lib/Repository/Values/Content/VersionInfo.php
+++ b/src/lib/Repository/Values/Content/VersionInfo.php
@@ -89,6 +89,11 @@ class VersionInfo extends APIVersionInfo
         return $this->languages;
     }
 
+    public function getLanguageCodes(): iterable
+    {
+        return $this->languageCodes;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/lib/Repository/Values/Content/VersionInfo.php
+++ b/src/lib/Repository/Values/Content/VersionInfo.php
@@ -89,11 +89,6 @@ class VersionInfo extends APIVersionInfo
         return $this->languages;
     }
 
-    public function getLanguageCodes(): iterable
-    {
-        return $this->languageCodes;
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7717](https://issues.ibexa.co/browse/IBX-7717)
| **Required by** | ibexa/admin-ui#1197
| **Target Ibexa version** | `v4.5`
| **BC breaks**                          | no

Introducing strict getters for `LookupLimitationResult` for the issue detected by PHPStan in ibexa/admin-ui#1197.
Alternatively we could add `@property-read` PHPDoc, but as agreed, we're no longer doing magic.

Also added strict properties. Reasoning: given the class already has declared strict types and the properties can be set only by strictly-typed constructor, it shouldn't be possible to have code which would set something else for these properties.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
