### PR TITLE
IBX-3957: Made NOP URL aliases not reusable and original

### DIFF
--- a/src/lib/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -603,7 +603,7 @@ final class DoctrineDatabase extends Gateway
             $values['is_original'] = 1;
         }
         if ($values['action'] === self::NOP_ACTION) {
-            $values['is_original'] = 0;
+            $values['is_original'] = 1;
         }
 
         $query = $this->connection->createQueryBuilder();

--- a/src/lib/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -231,11 +231,9 @@ class Handler implements UrlAliasHandlerInterface
             }
 
             // Row exists, check if it is reusable. There are 3 cases when this is possible:
-            // 1. NOP entry
-            // 2. existing location or custom alias entry
-            // 3. history entry
+            // 1. existing location or custom alias entry
+            // 2. history entry
             if (
-                $row['action'] === Gateway::NOP_ACTION ||
                 $row['action'] === $action ||
                 (int)$row['is_original'] === 0
             ) {

--- a/tests/integration/Core/Repository/URLAliasServiceTest.php
+++ b/tests/integration/Core/Repository/URLAliasServiceTest.php
@@ -1501,6 +1501,7 @@ class URLAliasServiceTest extends BaseTest
 
         // 2. Create child folder
         $child = $this->createFolder([$languageCode => 'b'], $folderLocationId);
+        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $childLocation */
         $childLocation = $child->getVersionInfo()->getContentInfo()->getMainLocation();
         $childLocationId = $childLocation->id;
 
@@ -1519,6 +1520,7 @@ class URLAliasServiceTest extends BaseTest
         $contentService->publishVersion($renamedFolder->getVersionInfo());
 
         // Loading aliases shouldn't throw a `BadStateException`
+        /** @var array<int, \Ibexa\Contracts\Core\Repository\Values\Content\URLAlias>  $childLocationAliases */
         $childLocationAliases = $urlAliasService->listLocationAliases($childLocation);
 
         self::assertCount(1, $childLocationAliases);

--- a/tests/integration/Core/Repository/URLAliasServiceTest.php
+++ b/tests/integration/Core/Repository/URLAliasServiceTest.php
@@ -1501,8 +1501,10 @@ class URLAliasServiceTest extends BaseTest
 
         // 2. Create child folder
         $child = $this->createFolder([$languageCode => 'b'], $folderLocationId);
-        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $childLocation */
         $childLocation = $child->getVersionInfo()->getContentInfo()->getMainLocation();
+
+        self::assertInstanceOf(Location::class, $childLocation);
+
         $childLocationId = $childLocation->id;
 
         // 3. Create custom URL alias for child folder
@@ -1520,11 +1522,11 @@ class URLAliasServiceTest extends BaseTest
         $contentService->publishVersion($renamedFolder->getVersionInfo());
 
         // Loading aliases shouldn't throw a `BadStateException`
-        /** @var array<int, \Ibexa\Contracts\Core\Repository\Values\Content\URLAlias>  $childLocationAliases */
         $childLocationAliases = $urlAliasService->listLocationAliases($childLocation);
+        $childLocationAliasesUnpacked = iterator_to_array($childLocationAliases);
 
-        self::assertCount(1, $childLocationAliases);
-        self::assertSame('/c/b', $childLocationAliases[0]->path);
+        self::assertCount(1, $childLocationAliasesUnpacked);
+        self::assertSame('/c/b', $childLocationAliasesUnpacked[0]->path);
 
         // Renamed content should have '/c2' path alias
         $lookupRenamed = $urlAliasService->lookup('c2');


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3957](https://issues.ibexa.co/browse/IBX-3957)
| **Type**                                   | bug
| **Target Ibexa version** | `v5.0`
| **BC breaks**                          | yes

Reasoning: because `nop` aliases are **not** original and they are reusable creating another alias with the same name will break such an alias, however, imo it should be incremented instead. This will prevent creating exactly the same alias with the same parent and as a result, breaking the old one.

--- 
**_Maintainer updates:_**

## Documentation

Breaking change: if there already exists a custom URL alias having path `/a/b` where `a` is a virtual (`NOP`) entry - not pointing to any content - renaming or creating another content on the same level using a colliding name - `a` in this case - will result in actually creating `/a2` entry, as `/a` is already taken by `/a/b` path.

_(not sure if wording is good here, might need improvement)_

## QA

More reasoning behind changes and description what happens was provided here https://github.com/ezsystems/ezplatform-kernel/pull/385#discussion_r1370276934

We need to test system behavior, find things we missed, edge cases, etc.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
