### PR TITLE
Do not prepend siteaccess to URL if default

### DIFF
--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -34,6 +34,7 @@ services:
             - [setRequestContext, ["@router.request_context"]]
             - [setSiteAccess, ['@?Ibexa\Core\MVC\Symfony\SiteAccess']]
             - [setSiteAccessRouter, ['@Ibexa\Core\MVC\Symfony\SiteAccess\Router']]
+            - [setDefaultSiteAccessName, ['%ibexa.site_access.default%']]
             - [setLogger, ["@?logger"]]
 
     Ibexa\Bundle\Core\Routing\UrlAliasRouter:

--- a/src/lib/MVC/Symfony/Routing/Generator.php
+++ b/src/lib/MVC/Symfony/Routing/Generator.php
@@ -30,6 +30,8 @@ abstract class Generator implements SiteAccessAware
     /** @var \Psr\Log\LoggerInterface */
     protected $logger;
 
+    protected string $defaultSiteAccessName;
+
     /**
      * @param \Symfony\Component\Routing\RequestContext $requestContext
      */
@@ -52,6 +54,11 @@ abstract class Generator implements SiteAccessAware
     public function setSiteAccess(SiteAccess $siteAccess = null)
     {
         $this->siteAccess = $siteAccess;
+    }
+
+    public function setDefaultSiteAccessName(string $name): void
+    {
+        $this->defaultSiteAccessName = $name;
     }
 
     /**
@@ -92,7 +99,7 @@ abstract class Generator implements SiteAccessAware
         $url = $this->doGenerate($urlResource, $parameters);
 
         // Add the SiteAccess URI back if needed.
-        if ($siteAccess && $siteAccess->matcher instanceof SiteAccess\URILexer) {
+        if ($siteAccess && $siteAccess->matcher instanceof SiteAccess\URILexer && $siteAccess->name !== $this->defaultSiteAccessName) {
             $url = $siteAccess->matcher->analyseLink($url);
         }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8088 |
|----------------|-----------|

<!-- 
#### Related PRs: 
    - https://github.com/ibexa/core/pull/1
-->

#### Description:
If default siteaccess uses URI type matching, URL alias generated by passing default siteaccess explicitly will be different than when generated without passing it explicitly. Since in both cases the URL alias is generated for the same siteaccess, the result should be the same:

Example:

```twig
{{ path('ibexa.url.alias', {'contentId': content.id, 'siteaccess': 'default'}) }}
```

generates:

```twig
/default/some-alias
```

But:

```twig
{{ path('ibexa.url.alias', {'contentId': content.id}) }}
```

generates:

```
/some-alias
```

This adds the check that the matched siteaccess is default, in which case prepending of the siteaccess ID to the URL is skipped.
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
