### PR TITLE
IBX-8032: Added proper casting to int for width/height in image search field

### DIFF
--- a/src/lib/FieldType/Image/SearchField.php
+++ b/src/lib/FieldType/Image/SearchField.php
@@ -18,8 +18,13 @@ class SearchField implements Indexable
 {
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
-        $width = $field->value->data['width'] ?? null;
-        $height = $field->value->data['height'] ?? null;
+        $width = isset($field->value->data['width']) && $field->value->data['width'] !== null
+            ? (int)$field->value->data['width']
+            : null;
+
+        $height = isset($field->value->data['height']) && $field->value->data['height'] !== null
+            ? (int)$field->value->data['height']
+            : null;
 
         return [
             new Search\Field(


### PR DESCRIPTION
| :ticket: Issue | IBX-8032 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR is about adding integer casting for width/height values to work with `SearchField::getOrientation()` method. It seems some legacy data might fail as strict typing is introduced here. However, the old way of composing index like
```
new Search\Field(
    'width',
    $width,
    new Search\FieldType\IntegerField()
),
``` 
is less forgiving and accepts some "wider spectrum" of types.

#### For QA:
Since there is no easy way to reproduce the issue I think sanities will do in this case.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
