### PR TITLE
Fixed DebugTemplate missing newly introduced return type in `display` method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4176,22 +4176,12 @@ parameters:
 			path: src/bundle/Debug/IbexaDebugBundle.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Debug\\\\Twig\\\\DebugTemplate\\:\\:display\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Debug/Twig/DebugTemplate.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Debug\\\\Twig\\\\DebugTemplate\\:\\:display\\(\\) has parameter \\$blocks with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Debug/Twig/DebugTemplate.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Debug\\\\Twig\\\\DebugTemplate\\:\\:display\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Debug/Twig/DebugTemplate.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Debug\\\\Twig\\\\DebugTemplate\\:\\:doDisplay\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/Debug/Twig/DebugTemplate.php
 
@@ -4232,11 +4222,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|false given\\.$#"
-			count: 1
-			path: src/bundle/Debug/Twig/DebugTemplate.php
-
-		-
-			message: "#^Property Ibexa\\\\Bundle\\\\Debug\\\\Twig\\\\DebugTemplate\\:\\:\\$fileSystem has no type specified\\.$#"
 			count: 1
 			path: src/bundle/Debug/Twig/DebugTemplate.php
 

--- a/src/bundle/Debug/Twig/DebugTemplate.php
+++ b/src/bundle/Debug/Twig/DebugTemplate.php
@@ -17,11 +17,11 @@ use Twig\Template;
  */
 class DebugTemplate extends Template
 {
-    private $fileSystem;
+    private Filesystem $fileSystem;
 
-    public function display(array $context, array $blocks = [])
+    public function display(array $context, array $blocks = []): void
     {
-        $this->fileSystem = $this->fileSystem ?: new Filesystem();
+        $this->fileSystem = $this->fileSystem ?? new Filesystem();
 
         // Bufferize to be able to insert template name as HTML comments if applicable.
         // Layout template name will only appear at the end, to avoid potential quirks with old browsers
@@ -68,7 +68,7 @@ class DebugTemplate extends Template
     /**
      * {@inheritdoc}
      */
-    public function getTemplateName()
+    public function getTemplateName(): string
     {
         return '';
     }
@@ -84,7 +84,7 @@ class DebugTemplate extends Template
     /**
      * {@inheritdoc}
      */
-    protected function doDisplay(array $context, array $blocks = [])
+    protected function doDisplay(array $context, array $blocks = []): string
     {
         return '';
     }
@@ -92,7 +92,7 @@ class DebugTemplate extends Template
     /**
      * {@inheritdoc}
      */
-    public function getDebugInfo()
+    public function getDebugInfo(): array
     {
         return [];
     }


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

Twig 3.9.x introduced return type to an internal class, which we extend. As a current issue resolution I have added return types where applicable.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
