### PR TITLE
IBX-8452: Fixed string substitution for Plural Value Object when casting to string

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7431,26 +7431,6 @@ parameters:
 			path: src/contracts/Repository/Values/ObjectState/ObjectStateCreateStruct.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Translation\\\\Message\\:\\:__construct\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Repository/Values/Translation/Message.php
-
-		-
-			message: "#^Property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Translation\\\\Message\\:\\:\\$values type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Repository/Values/Translation/Message.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Translation\\\\Plural\\:\\:__construct\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Repository/Values/Translation/Plural.php
-
-		-
-			message: "#^Property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Translation\\\\Plural\\:\\:\\$values type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Repository/Values/Translation/Plural.php
-
-		-
 			message: "#^Class Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\URL\\\\SearchResult implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: src/contracts/Repository/Values/URL/SearchResult.php

--- a/src/contracts/Repository/Values/Translation/Message.php
+++ b/src/contracts/Repository/Values/Translation/Message.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\Translation;
 
@@ -20,26 +21,23 @@ class Message extends Translation
     /**
      * Message string. Might use replacements like %foo%, which are replaced by
      * the values specified in the values array.
-     *
-     * @var string
      */
-    protected $message;
+    protected string $message;
 
     /**
      * Translation value objects. May not contain any numbers, which might
      * result in requiring plural forms. Use Plural for that.
      *
-     * @var array
+     * @var array<string, scalar>
      */
-    protected $values;
+    protected array $values;
 
     /**
      * Construct singular only message from string and optional value array.
      *
-     * @param string $message
-     * @param array $values
+     * @param array<string, scalar> $values
      */
-    public function __construct($message, array $values = [])
+    public function __construct(string $message, array $values = [])
     {
         $this->message = $message;
         $this->values = $values;

--- a/src/contracts/Repository/Values/Translation/Plural.php
+++ b/src/contracts/Repository/Values/Translation/Plural.php
@@ -75,6 +75,8 @@ class Plural extends Translation
     #[\Override]
     public function __toString(): string
     {
-        return strtr(current($this->values) == 1 ? $this->plural : $this->singular, $this->values);
+        $firstValue = !empty($this->values) ? current(array_values($this->values)) : null;
+
+        return strtr((int)$firstValue === 1 ? $this->singular : $this->plural, $this->values);
     }
 }

--- a/src/contracts/Repository/Values/Translation/Plural.php
+++ b/src/contracts/Repository/Values/Translation/Plural.php
@@ -16,17 +16,20 @@ use Ibexa\Contracts\Core\Repository\Values\Translation;
  * replaced by the values provided. A raw % can be escaped like %%.
  *
  * You need to provide a singular and plural variant for the string. The
- * strings provided should be english and will be translated depending on the
+ * strings provided should be English and will be translated depending on the
  * environment language.
  *
- * This interface follows the interfaces of XLiff, gettext, Symfony2
- * Translations and Zend_Translate. For singular forms you just provide a plain
- * string (with optional placeholders without effects on the plural forms). For
- * potential plural forms you always provide a singular variant and an english
- * simple plural variant. No implementation supports multiple different plural
- * forms in one single message.
+ * This interface follows the interfaces of XLIFF, gettext, Symfony Translations and Zend_Translate.
+ * For singular forms you just provide a plain string (with optional placeholders without effects on the plural forms).
+ * For potential plural forms you always provide a singular variant and an English simple plural variant.
+ * An instance of this class can be cast to a string. In such case whether to use singular or plural form is determined
+ * based on the value of first element of $values array (it needs to be 1 for singular, anything else for plural).
+ * If plurality cannot be inferred from $values, a plural form is assumed as default. To force singular form,
+ * use {@see \Ibexa\Contracts\Core\Repository\Values\Translation\Message} instead.
  *
- * The singular / plural string could, for Symfony2, for example be converted
+ * No implementation supports multiple different plural forms in one single message.
+ *
+ * The singular / plural string could, for Symfony, for example be converted
  * to "$singular|$plural", and you would call gettext like: ngettext(
  * $singular, $plural, $count ).
  */
@@ -35,35 +38,28 @@ class Plural extends Translation
     /**
      * Singular string. Might use replacements like %foo%, which are replaced by
      * the values specified in the values array.
-     *
-     * @var string
      */
-    protected $singular;
+    protected string $singular;
 
     /**
      * Message string. Might use replacements like %foo%, which are replaced by
      * the values specified in the values array.
-     *
-     * @var string
      */
-    protected $plural;
+    protected string $plural;
 
     /**
-     * Translation value objects. May not contain any numbers, which might
-     * result in requiring plural forms. Use MessagePlural for that.
+     * Translation value objects.
      *
-     * @var array
+     * @var array<string, scalar>
      */
-    protected $values;
+    protected array $values;
 
     /**
      * Construct plural message from singular, plural and value array.
      *
-     * @param string $singular
-     * @param string $plural
-     * @param array $values
+     * @param array<string, scalar> $values
      */
-    public function __construct($singular, $plural, array $values)
+    public function __construct(string $singular, string $plural, array $values)
     {
         $this->singular = $singular;
         $this->plural = $plural;

--- a/tests/lib/Repository/Values/Translation/MessageTest.php
+++ b/tests/lib/Repository/Values/Translation/MessageTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository\Values\Translation;
+
+use Ibexa\Contracts\Core\Repository\Values\Translation\Message;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ibexa\Contracts\Core\Repository\Values\Translation\Message
+ */
+final class MessageTest extends TestCase
+{
+    /**
+     * @dataProvider getDataForTestStringable
+     */
+    public function testStringable(Message $message, string $expectedString): void
+    {
+        self::assertSame($expectedString, (string)$message);
+    }
+
+    /**
+     * @return array<string, array{\Ibexa\Contracts\Core\Repository\Values\Translation\Message, string}>
+     */
+    public static function getDataForTestStringable(): iterable
+    {
+        yield 'message with substitution values' => [
+            new Message(
+                'Anna has some oranges in %object%',
+                [
+                    '%object%' => 'a basket',
+                ]
+            ),
+            'Anna has some oranges in a basket',
+        ];
+
+        yield 'message with multiple substitution values' => [
+            new Message(
+                '%first_name% has some data in %storage_type%',
+                [
+                    '%first_name%' => 'Anna',
+                    '%storage_type%' => 'her database',
+                ]
+            ),
+            'Anna has some data in her database',
+        ];
+
+        yield 'message with no substitution values' => [
+            new Message(
+                'This value is not correct',
+                []
+            ),
+            'This value is not correct',
+        ];
+    }
+}

--- a/tests/lib/Repository/Values/Translation/PluralTest.php
+++ b/tests/lib/Repository/Values/Translation/PluralTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository\Values\Translation;
+
+use Ibexa\Contracts\Core\Repository\Values\Translation\Plural;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ibexa\Contracts\Core\Repository\Values\Translation\Plural
+ */
+final class PluralTest extends TestCase
+{
+    /**
+     * @dataProvider getDataForTestStringable
+     */
+    public function testStringable(Plural $message, string $expectedString): void
+    {
+        self::assertSame($expectedString, (string)$message);
+    }
+
+    /**
+     * @return array<string, array{\Ibexa\Contracts\Core\Repository\Values\Translation\Plural, string}>
+     */
+    public static function getDataForTestStringable(): iterable
+    {
+        yield 'singular form' => [
+            new Plural(
+                'John has %apple_count% apple',
+                'John has %apple_count% apples',
+                [
+                    '%apple_count%' => 1,
+                ]
+            ),
+            'John has 1 apple',
+        ];
+
+        yield 'plural form' => [
+            new Plural(
+                'John has %apple_count% apple',
+                'John has %apple_count% apples',
+                [
+                    '%apple_count%' => 2,
+                ]
+            ),
+            'John has 2 apples',
+        ];
+
+        yield 'no substitution values' => [
+            new Plural(
+                'John has some apples',
+                'John has a lot of apples',
+                []
+            ),
+            'John has a lot of apples',
+        ];
+    }
+}


### PR DESCRIPTION
> [!WARNING]
> Pending 3.3 backport

| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:

When an instance of `Plural` value object was cast to string, it produced results opposite to the expected. For plural result it used singular message and for singular result - a plural one.

TBD if my assumptions here are correct and if so this needs to be re-targeted to either 3.3 or 4.6

Fixed the issue via a042cf08e9. The other commits introduce more strictness.

#### For QA:

TBD if QA is needed / feasible.