### PR TITLE
IBX-8012: `UrlAliasGenerator` should load location with provided `languages`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11981,11 +11981,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Routing\\\\Generator\\\\UrlAliasGenerator\\:\\:getPathPrefixByRootLocationId\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Routing\\\\Generator\\\\UrlAliasGenerator\\:\\:loadLocation\\(\\) should return Ibexa\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location but returns Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php

--- a/src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -103,10 +103,12 @@ class UrlAliasGenerator extends Generator
      * Returns path corresponding to $rootLocationId.
      *
      * @param int $rootLocationId
-     * @param array $languages
+     * @param array<string>|null $languages
      * @param string $siteaccess
      *
      * @return string
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
     public function getPathPrefixByRootLocationId($rootLocationId, $languages = null, $siteaccess = null)
     {
@@ -122,7 +124,7 @@ class UrlAliasGenerator extends Generator
             $this->pathPrefixMap[$siteaccess][$rootLocationId] = $this->repository
                 ->getURLAliasService()
                 ->reverseLookup(
-                    $this->loadLocation($rootLocationId),
+                    $this->loadLocation($rootLocationId, $languages),
                     null,
                     false,
                     $languages
@@ -157,15 +159,16 @@ class UrlAliasGenerator extends Generator
      * Not to be used for link generation.
      *
      * @param int $locationId
+     * @param array<string>|null $languages
      *
      * @return \Ibexa\Core\Repository\Values\Content\Location
      */
-    public function loadLocation($locationId)
+    public function loadLocation($locationId, ?array $languages = null)
     {
         return $this->repository->sudo(
-            static function (Repository $repository) use ($locationId) {
+            static function (Repository $repository) use ($locationId, $languages) {
                 /* @var $repository \Ibexa\Core\Repository\Repository */
-                return $repository->getLocationService()->loadLocation($locationId);
+                return $repository->getLocationService()->loadLocation($locationId, $languages);
             }
         );
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-8012 |
|----------------|-----------|

#### Description:
When a location is loaded for `reverseLookup` and one is in default site access that cannot load such location because of languages configuration and `alwaysAvailable` flag turned off for this location's content it would result in an exception. If one is providing `languages` parameter for URL to be generated these languages should be utilized when loading such a location to avoid mentioned exceptions as one should be able to generate URL for a different site access in which such a location can be loaded properly.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
