### PR TITLE
IBX-8119: [GHA] Bumped PHP to 8.3 in gha-docker-solr.yaml workflow

### DIFF
--- a/.github/workflows/gha-docker-solr.yaml
+++ b/.github/workflows/gha-docker-solr.yaml
@@ -42,7 +42,7 @@ jobs:
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: 8.3
                   coverage: none
             
             - name: Add solr dependency

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -7,6 +7,9 @@ RUN git clone --depth=1 https://github.com/ibexa/solr.git solr
 RUN ./solr/bin/generate-solr-config.sh --destination-dir=config --solr-version=8.6.3
 
 FROM solr:8.6.3
+LABEL org.opencontainers.image.source=https://github.com/ibexa/core/blob/main/docker/solr/Dockerfile
+LABEL org.opencontainers.image.description="Configured Ibexa Solr Bundle image, created by 'Build and publish Solr Docker image' GHA workflow"
+LABEL org.opencontainers.image.licenses=GPL-2.0-only
 USER root
 RUN rm -rf server/solr/configsets/_default/conf/*
 USER solr


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|
| Workflow run | https://github.com/ibexa/core/actions/runs/8983666592/job/24673908758

#### Related PRs: 
- https://github.com/ibexa/core/pull/358

#### Description:
This is a follow-up to #358. GHA "Build and publish Solr Docker image" workflow also used PHP 7.4 which now [is not working](https://github.com/ibexa/core/actions/runs/8982539486/job/24670367202):
```
Run ${GITHUB_ACTION_PATH}/bin/composer_install.sh \
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires php  >=8.3 but your php version (7.4.33) does not satisfy that requirement.
```

Added also `LABEL` to published Docker image, to better find source of that image from [there](https://github.com/ibexa/core/pkgs/container/core%2Fsolr).