### PR TITLE
Wrapped `iterable`s used as arrays with `iterator_to_array`

### DIFF
--- a/phpstan-baseline-gte-8.0.neon
+++ b/phpstan-baseline-gte-8.0.neon
@@ -356,18 +356,8 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceAuthorizationTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_keys expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$array of function array_values expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> given\\.$#"
 			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function usort expects TArray of array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
-			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
@@ -404,16 +394,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Language\\> given\\.$#"
 			count: 2
 			path: tests/integration/Core/Repository/LanguageServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function array_filter expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\> given\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LocationServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function array_keys expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> given\\.$#"
-			count: 3
-			path: tests/integration/Core/Repository/LocationServiceTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$array of function array_filter expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\Policy\\> given\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,22 +231,12 @@ parameters:
 			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
 
 		-
-			message: "#^Cannot access offset int on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\RegenerateUrlAliasesCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\RegenerateUrlAliasesCommand\\:\\:loadSpecificLocations\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\RegenerateUrlAliasesCommand\\:\\:processLocations\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
 
@@ -11956,11 +11946,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Routing/Generator/RouteReferenceGeneratorInterface.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\>\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Routing\\\\Generator\\\\UrlAliasGenerator\\:\\:__construct\\(\\) has parameter \\$unsafeCharMap with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -17071,11 +17056,6 @@ parameters:
 			path: src/lib/Persistence/Legacy/Content/ObjectState/Handler.php
 
 		-
-			message: "#^Cannot access offset int on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\Content\\\\Language\\>\\.$#"
-			count: 4
-			path: src/lib/Persistence/Legacy/Content/ObjectState/Mapper.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\ObjectState\\\\Mapper\\:\\:createObjectStateFromData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Persistence/Legacy/Content/ObjectState/Mapper.php
@@ -19841,16 +19821,6 @@ parameters:
 			path: src/lib/Repository/ContentService.php
 
 		-
-			message: "#^Cannot access offset int on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\ContentType\\>\\.$#"
-			count: 1
-			path: src/lib/Repository/ContentService.php
-
-		-
-			message: "#^Cannot access offset string on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\>\\.$#"
-			count: 1
-			path: src/lib/Repository/ContentService.php
-
-		-
 			message: "#^Cannot access property \\$defaultValue on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition\\|null\\.$#"
 			count: 2
 			path: src/lib/Repository/ContentService.php
@@ -20187,11 +20157,6 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$mainLanguageCode\\.$#"
-			count: 1
-			path: src/lib/Repository/Mapper/ContentDomainMapper.php
-
-		-
-			message: "#^Cannot access offset mixed on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\Content\\>\\.$#"
 			count: 1
 			path: src/lib/Repository/Mapper/ContentDomainMapper.php
 
@@ -23079,16 +23044,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$length of function random_bytes expects int\\<1, max\\>, int given\\.$#"
 			count: 1
 			path: src/lib/Token/RandomBytesGenerator.php
-
-		-
-			message: "#^Cannot access offset string on iterable\\<string, Ibexa\\\\Contracts\\\\Core\\\\Variation\\\\VariationHandler\\>\\.$#"
-			count: 3
-			path: src/lib/Variation/VariationHandlerRegistry.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Variation\\\\VariationHandlerRegistry\\:\\:__construct\\(\\) has parameter \\$variationHandlers with no value type specified in iterable type iterable\\.$#"
-			count: 1
-			path: src/lib/Variation/VariationHandlerRegistry.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\CacheFactoryTest\\:\\:providerGetService\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -27276,66 +27231,6 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Language\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 5
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
-			count: 12
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 11
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
-			count: 4
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 3
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 2 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 3 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 4 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 5 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 2
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset mixed on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset mixed on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
 			message: "#^Cannot access property \\$sortField on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
@@ -28117,11 +28012,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testPublishVersionInTransactionWithRollback\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testPublishVersionNotCreatingUnlimitedArchives\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -34091,16 +33981,6 @@ parameters:
 			path: tests/integration/Core/Repository/LanguageServiceMaximumSupportedLanguagesTest.php
 
 		-
-			message: "#^Cannot access offset 'eng\\-NZ' on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Language\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LanguageServiceTest.php
-
-		-
-			message: "#^Cannot access offset mixed on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Language\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LanguageServiceTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\LanguageServiceTest\\:\\:loadLanguagesReturnsAnEmptyArrayByDefault\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/LanguageServiceTest.php
@@ -34261,11 +34141,6 @@ parameters:
 			path: tests/integration/Core/Repository/Limitation/PermissionResolver/LocationLimitationIntegrationTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LocationServiceAuthorizationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\LocationServiceAuthorizationTest\\:\\:testCopySubtreeThrowsUnauthorizedException\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/LocationServiceAuthorizationTest.php
@@ -34342,21 +34217,6 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ValueObject\\:\\:\\$id\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LocationServiceTest.php
-
-		-
-			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LocationServiceTest.php
-
-		-
-			message: "#^Cannot access offset 5 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 2
-			path: tests/integration/Core/Repository/LocationServiceTest.php
-
-		-
-			message: "#^Cannot access offset int\\|false on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/LocationServiceTest.php
 
@@ -34742,16 +34602,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\LocationServiceTest\\:\\:testUpdateLocationWithSameRemoteId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LocationServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function array_column expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> given\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/LocationServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function array_column expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\> given\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/LocationServiceTest.php
 
@@ -35311,11 +35161,6 @@ parameters:
 			path: tests/integration/Core/Repository/PermissionResolverTest.php
 
 		-
-			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\Policy\\>\\.$#"
-			count: 3
-			path: tests/integration/Core/Repository/PermissionResolverTest.php
-
-		-
 			message: "#^Cannot access property \\$text on Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\|null\\.$#"
 			count: 2
 			path: tests/integration/Core/Repository/PermissionResolverTest.php
@@ -35539,11 +35384,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\Regression\\\\EZP21798Test\\:\\:testRoleChanges\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/Regression/EZP21798Test.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 2
-			path: tests/integration/Core/Repository/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\Regression\\\\EZP21906SearchOneContentMultipleLocationsTest\\:\\:searchContentQueryProvider\\(\\) has no return type specified\\.$#"
@@ -35841,16 +35681,6 @@ parameters:
 			path: tests/integration/Core/Repository/RepositoryTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\Policy\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/RoleServiceAuthorizationTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserGroupRoleAssignment\\|Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserRoleAssignment\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/RoleServiceAuthorizationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\RoleServiceAuthorizationTest\\:\\:testAssignRoleToUserGroupThrowsUnauthorizedException\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/RoleServiceAuthorizationTest.php
@@ -35958,21 +35788,6 @@ parameters:
 		-
 			message: "#^Access to protected property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserGroupRoleAssignment\\:\\:\\$id\\.$#"
 			count: 1
-			path: tests/integration/Core/Repository/RoleServiceTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\RoleAssignment\\>\\.$#"
-			count: 4
-			path: tests/integration/Core/Repository/RoleServiceTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserGroupRoleAssignment\\>\\.$#"
-			count: 4
-			path: tests/integration/Core/Repository/RoleServiceTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserGroupRoleAssignment\\|Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserRoleAssignment\\>\\.$#"
-			count: 2
 			path: tests/integration/Core/Repository/RoleServiceTest.php
 
 		-
@@ -36142,11 +35957,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\RoleServiceTest\\:\\:testDeleteRoleDraft\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/RoleServiceTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\RoleServiceTest\\:\\:testGetRoleAssignments\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\RoleAssignment\\> but returns array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\RoleAssignment\\>\\|\\(ArrayAccess&iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\RoleAssignment\\>\\)\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/RoleServiceTest.php
 
@@ -38431,11 +38241,6 @@ parameters:
 			path: tests/integration/Core/Repository/TokenServiceTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/TrashServiceAuthorizationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\TrashServiceAuthorizationTest\\:\\:testDeleteTrashItemThrowsUnauthorizedException\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/TrashServiceAuthorizationTest.php
@@ -38666,11 +38471,6 @@ parameters:
 			path: tests/integration/Core/Repository/URLAliasService/CustomUrlAliasForMultilingualContentTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/URLAliasService/UrlAliasLookupTest.php
-
-		-
 			message: "#^Cannot access property \\$id on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/URLAliasService/UrlAliasLookupTest.php
@@ -38704,11 +38504,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$locationId of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\LocationService\\:\\:loadLocation\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/URLAliasServiceAuthorizationTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/URLAliasServiceTest.php
 
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
@@ -39429,11 +39224,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\UserServiceAuthorizationTest\\:\\:testUpdateUserThrowsUnauthorizedException\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/UserServiceAuthorizationTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\User\\>\\.$#"
-			count: 2
-			path: tests/integration/Core/Repository/UserServiceTest.php
 
 		-
 			message: "#^Cannot call method add\\(\\) on DateTimeImmutable\\|false\\|null\\.$#"
@@ -57596,16 +57386,6 @@ parameters:
 			path: tests/lib/Repository/Mapper/ContentLocationMapper/DecoratedLocationServiceTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 1
-			path: tests/lib/Repository/Mapper/ContentLocationMapper/DecoratedLocationServiceTest.php
-
-		-
-			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
-			count: 1
-			path: tests/lib/Repository/Mapper/ContentLocationMapper/DecoratedLocationServiceTest.php
-
-		-
 			message: "#^Cannot access property \\$locations on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>\\.$#"
 			count: 2
 			path: tests/lib/Repository/Mapper/ContentLocationMapper/DecoratedLocationServiceTest.php
@@ -59664,11 +59444,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\SearchTest\\:\\:\\$repositoryMock has no type specified\\.$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/SearchTest.php
-
-		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\>\\.$#"
-			count: 3
-			path: tests/lib/Repository/Service/Mock/UrlAliasTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\UrlAliasTest\\:\\:getPartlyMockedURLAliasServiceService\\(\\) has parameter \\$prioritizedLanguages with no value type specified in iterable type array\\.$#"

--- a/src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
+++ b/src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
@@ -185,7 +185,7 @@ EOT
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location[] $locations
      * @param \Symfony\Component\Console\Helper\ProgressBar $progressBar
      */
-    private function processLocations(array $locations, ProgressBar $progressBar)
+    private function processLocations(array $locations, ProgressBar $progressBar): void
     {
         $contentList = $this->repository->sudo(
             static function (Repository $repository) use ($locations) {
@@ -204,6 +204,7 @@ EOT
                 );
             }
         );
+        $contentList = iterator_to_array($contentList);
         foreach ($locations as $location) {
             try {
                 // ignore missing Content items

--- a/src/contracts/Repository/LanguageService.php
+++ b/src/contracts/Repository/LanguageService.php
@@ -108,7 +108,7 @@ interface LanguageService
      *
      * @param int[] $languageIds
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Language[] list of Languages with id as keys
+     * @return iterable<int, \Ibexa\Contracts\Core\Repository\Values\Content\Language> list of Languages with id as keys
      */
     public function loadLanguageListById(array $languageIds): iterable;
 

--- a/src/contracts/Repository/Values/Content/Content.php
+++ b/src/contracts/Repository/Values/Content/Content.php
@@ -79,7 +79,7 @@ abstract class Content extends ValueObject
      *
      * @param string|null $languageCode
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Field[] An array of {@link Field} with field identifier as keys
+     * @return iterable<string, \Ibexa\Contracts\Core\Repository\Values\Content\Field> An array of {@link Field} with field identifier as keys
      */
     abstract public function getFieldsByLanguage(?string $languageCode = null): iterable;
 

--- a/src/contracts/Repository/Values/User/RoleAssignment.php
+++ b/src/contracts/Repository/Values/User/RoleAssignment.php
@@ -24,7 +24,12 @@ abstract class RoleAssignment extends ValueObject
      *
      * @var int
      */
-    protected $id;
+    protected int $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
 
     /**
      * Returns the limitation of the role assignment.

--- a/src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -187,12 +187,14 @@ class UrlAliasGenerator extends Generator
         if ($siteAccess) {
             // We generate for a different SiteAccess, so potentially in a different language.
             $languages = $this->configResolver->getParameter('languages', null, $siteAccess);
-            $urlAliases = $urlAliasService->listLocationAliases($location, false, null, null, $languages);
+            $urlAliases = iterator_to_array(
+                $urlAliasService->listLocationAliases($location, false, null, null, $languages)
+            );
             // Use the target SiteAccess root location
             $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', null, $siteAccess);
         } else {
             $languages = null;
-            $urlAliases = $urlAliasService->listLocationAliases($location, false);
+            $urlAliases = iterator_to_array($urlAliasService->listLocationAliases($location, false));
             $rootLocationId = $this->rootLocationId;
         }
 

--- a/src/lib/Persistence/Legacy/Content/ObjectState/Mapper.php
+++ b/src/lib/Persistence/Legacy/Content/ObjectState/Mapper.php
@@ -49,7 +49,7 @@ class Mapper
         foreach ($data as $stateTranslation) {
             $languageIds[] = (int)$stateTranslation['ezcobj_state_language_language_id'] & ~1;
         }
-        $languages = $this->languageHandler->loadList($languageIds);
+        $languages = iterator_to_array($this->languageHandler->loadList($languageIds));
 
         $objectState->id = (int)$data[0]['ezcobj_state_id'];
         $objectState->groupId = (int)$data[0]['ezcobj_state_group_id'];
@@ -104,7 +104,7 @@ class Mapper
         foreach ($data as $groupTranslation) {
             $languageIds[] = (int)$groupTranslation['ezcobj_state_group_language_real_language_id'];
         }
-        $languages = $this->languageHandler->loadList($languageIds);
+        $languages = iterator_to_array($this->languageHandler->loadList($languageIds));
 
         $objectStateGroup->id = (int)$data[0]['ezcobj_state_group_id'];
         $objectStateGroup->identifier = $data[0]['ezcobj_state_group_identifier'];

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -556,9 +556,11 @@ class ContentService implements ContentServiceInterface
             $contentIds,
             $translations
         );
-        $contentTypeList = $this->repository->getContentTypeService()->loadContentTypeList(
-            array_unique($contentTypeIds),
-            $languages
+        $contentTypeList = iterator_to_array(
+            $this->repository->getContentTypeService()->loadContentTypeList(
+                array_unique($contentTypeIds),
+                $languages
+            )
         );
         foreach ($spiContentList as $contentId => $spiContent) {
             $contentInfo = $spiContent->versionInfo->contentInfo;
@@ -1522,7 +1524,9 @@ class ContentService implements ContentServiceInterface
         }
 
         $mainLanguageCode = $publishedContent->getVersionInfo()->getContentInfo()->getMainLanguageCode();
-        $publishedContentFieldsInMainLanguage = $publishedContent->getFieldsByLanguage($mainLanguageCode);
+        $publishedContentFieldsInMainLanguage = iterator_to_array(
+            $publishedContent->getFieldsByLanguage($mainLanguageCode)
+        );
 
         $fieldValues = [];
         $persistenceFields = [];

--- a/src/lib/Repository/Mapper/ContentDomainMapper.php
+++ b/src/lib/Repository/Mapper/ContentDomainMapper.php
@@ -619,7 +619,9 @@ class ContentDomainMapper extends ProxyAwareDomainMapper implements LoggerAwareI
         }
 
         $missingContentList = [];
-        $contentList = $this->contentHandler->loadContentList($contentIds, array_unique($translations));
+        $contentList = iterator_to_array(
+            $this->contentHandler->loadContentList($contentIds, array_unique($translations))
+        );
         $contentTypeList = $this->contentTypeHandler->loadContentTypeList(array_unique($contentTypeIds));
         foreach ($result->searchHits as $key => $hit) {
             if (isset($contentList[$hit->valueObject->id])) {

--- a/src/lib/Variation/VariationHandlerRegistry.php
+++ b/src/lib/Variation/VariationHandlerRegistry.php
@@ -10,20 +10,18 @@ namespace Ibexa\Core\Variation;
 
 use Ibexa\Contracts\Core\Exception\InvalidArgumentException;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
-use Traversable;
 
 final class VariationHandlerRegistry
 {
-    /** @var iterable<string, \Ibexa\Contracts\Core\Variation\VariationHandler> */
-    private iterable $variationHandlers;
+    /** @var array<string, \Ibexa\Contracts\Core\Variation\VariationHandler> */
+    private array $variationHandlers;
 
+    /**
+     * @param iterable<string, \Ibexa\Contracts\Core\Variation\VariationHandler> $variationHandlers
+     */
     public function __construct(iterable $variationHandlers)
     {
-        $handlers = $variationHandlers instanceof Traversable
-            ? iterator_to_array($variationHandlers)
-            : $variationHandlers;
-
-        foreach ($handlers as $identifier => $handler) {
+        foreach ($variationHandlers as $identifier => $handler) {
             $this->setVariationHandler($identifier, $handler);
         }
     }

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -665,7 +665,7 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testLoadContentInfoList()
     {
         $mediaFolderId = $this->generateId('object', self::MEDIA_CONTENT_ID);
-        $list = $this->contentService->loadContentInfoList([$mediaFolderId]);
+        $list = iterator_to_array($this->contentService->loadContentInfoList([$mediaFolderId]));
 
         self::assertCount(1, $list);
         self::assertEquals([$mediaFolderId], array_keys($list), 'Array key was not content id');
@@ -867,7 +867,7 @@ class ContentServiceTest extends BaseContentServiceTest
      */
     public function testLoadVersionInfoByIdGetLanguages(VersionInfo $versionInfo): void
     {
-        $actualLanguages = $versionInfo->getLanguages();
+        $actualLanguages = iterator_to_array($versionInfo->getLanguages());
 
         $expectedLanguages = ['eng-US'];
         foreach ($expectedLanguages as $i => $expectedLanguage) {
@@ -2000,12 +2000,12 @@ class ContentServiceTest extends BaseContentServiceTest
      *
      * @depends testPublishVersionFromContentDraft
      */
-    public function testPublishVersionNotCreatingUnlimitedArchives()
+    public function testPublishVersionNotCreatingUnlimitedArchives(): void
     {
         $content = $this->createContentVersion1();
 
         // load first to make sure list gets updated also (cache)
-        $versionInfoList = $this->contentService->loadVersions($content->contentInfo);
+        $versionInfoList = iterator_to_array($this->contentService->loadVersions($content->contentInfo));
         self::assertCount(1, $versionInfoList);
         self::assertEquals(1, $versionInfoList[0]->versionNo);
 
@@ -2033,7 +2033,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $draftedContentVersion = $this->contentService->createContentDraft($content->contentInfo);
         $this->contentService->publishVersion($draftedContentVersion->getVersionInfo());
 
-        $versionInfoList = $this->contentService->loadVersions($content->contentInfo);
+        $versionInfoList = iterator_to_array($this->contentService->loadVersions($content->contentInfo));
 
         self::assertCount(6, $versionInfoList);
         self::assertEquals(2, $versionInfoList[0]->versionNo);
@@ -2433,7 +2433,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->createContentDraft($demoDesignContentInfo);
 
         // Now $contentDrafts should contain two drafted versions
-        $draftedVersions = $this->contentService->loadContentDrafts();
+        $draftedVersions = iterator_to_array($this->contentService->loadContentDrafts());
 
         $actual = [
             $draftedVersions[0]->status,
@@ -2479,8 +2479,8 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->permissionResolver->setCurrentUserReference($oldCurrentUser);
 
         // Now $contentDrafts for the previous current user and the new user
-        $newCurrentUserDrafts = $this->contentService->loadContentDrafts($user);
-        $oldCurrentUserDrafts = $this->contentService->loadContentDrafts();
+        $newCurrentUserDrafts = iterator_to_array($this->contentService->loadContentDrafts($user));
+        $oldCurrentUserDrafts = iterator_to_array($this->contentService->loadContentDrafts());
 
         self::assertSame([], $oldCurrentUserDrafts);
 
@@ -3178,7 +3178,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // Delete the previously created draft
         $this->contentService->deleteVersion($draft->getVersionInfo());
 
-        $versions = $this->contentService->loadVersions($content->getVersionInfo()->getContentInfo());
+        $versions = iterator_to_array(
+            $this->contentService->loadVersions($content->getVersionInfo()->getContentInfo())
+        );
 
         self::assertCount(1, $versions);
         self::assertEquals(
@@ -3659,7 +3661,7 @@ class ContentServiceTest extends BaseContentServiceTest
     {
         $draft = $this->createContentWithRelations();
 
-        $relations = $this->contentService->loadRelations($draft->getVersionInfo());
+        $relations = iterator_to_array($this->contentService->loadRelations($draft->getVersionInfo()));
 
         usort(
             $relations,
@@ -3732,7 +3734,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $trashService->trash($demoDesignLocation);
 
         // Load all relations
-        $relations = $this->contentService->loadRelations($draft->getVersionInfo());
+        $relations = iterator_to_array($this->contentService->loadRelations($draft->getVersionInfo()));
 
         self::assertCount(1, $relations);
         self::assertEquals(
@@ -3783,7 +3785,7 @@ class ContentServiceTest extends BaseContentServiceTest
             $demoDesign
         );
 
-        $relations = $this->contentService->loadRelations($mediaDraft->getVersionInfo());
+        $relations = iterator_to_array($this->contentService->loadRelations($mediaDraft->getVersionInfo()));
 
         self::assertCount(1, $relations);
         self::assertEquals(
@@ -3970,7 +3972,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->publishVersion($demoDesignDraft->getVersionInfo());
 
         $relations = $this->contentService->loadRelations($versionInfo);
-        $reverseRelations = $this->contentService->loadReverseRelations($contentInfo);
+        $reverseRelations = iterator_to_array($this->contentService->loadReverseRelations($contentInfo));
 
         self::assertEquals($contentInfo->id, $relation1->getDestinationContentInfo()->id);
         self::assertEquals($mediaDraft->id, $relation1->getSourceContentInfo()->id);
@@ -4062,7 +4064,7 @@ class ContentServiceTest extends BaseContentServiceTest
 
         // Load all relations
         $relations = $this->contentService->loadRelations($versionInfo);
-        $reverseRelations = $this->contentService->loadReverseRelations($contentInfo);
+        $reverseRelations = iterator_to_array($this->contentService->loadReverseRelations($contentInfo));
 
         self::assertEquals($contentInfo->id, $relation1->getDestinationContentInfo()->id);
         self::assertEquals($mediaDraft->id, $relation1->getSourceContentInfo()->id);
@@ -4126,7 +4128,7 @@ class ContentServiceTest extends BaseContentServiceTest
         // will not be loaded as reverse relation for "Media" page
 
         $relations = $this->contentService->loadRelations($media->versionInfo);
-        $reverseRelations = $this->contentService->loadReverseRelations($media->contentInfo);
+        $reverseRelations = iterator_to_array($this->contentService->loadReverseRelations($media->contentInfo));
 
         self::assertEquals($media->contentInfo->id, $relation1->getDestinationContentInfo()->id);
         self::assertEquals($newDraftVersionInfo->contentInfo->id, $relation1->getSourceContentInfo()->id);
@@ -5998,7 +6000,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->updateFolder($content, [self::ENG_GB => 'Foo3']);
         $this->updateFolder($content, [self::ENG_GB => 'Foo4']);
 
-        $versions = $this->contentService->loadVersions($content->contentInfo);
+        $versions = iterator_to_array($this->contentService->loadVersions($content->contentInfo));
 
         foreach ($versions as $key => $version) {
             if ($version->isDraft()) {
@@ -6518,7 +6520,7 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $this->contentService->hideContent($publishedContent->contentInfo);
 
-        $locations = $this->locationService->loadLocations($publishedContent->contentInfo);
+        $locations = iterator_to_array($this->locationService->loadLocations($publishedContent->contentInfo));
 
         $childContentCreate = $this->contentService->newContentCreateStruct($contentType, self::ENG_US);
         $childContentCreate->setField('name', 'Child');
@@ -6534,7 +6536,7 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $publishedChildContent = $this->contentService->publishVersion($childContent->versionInfo);
 
-        $childLocations = $this->locationService->loadLocations($publishedChildContent->contentInfo);
+        $childLocations = iterator_to_array($this->locationService->loadLocations($publishedChildContent->contentInfo));
 
         self::assertTrue($locations[0]->hidden);
         self::assertTrue($locations[0]->invisible);

--- a/tests/integration/Core/Repository/LanguageServiceTest.php
+++ b/tests/integration/Core/Repository/LanguageServiceTest.php
@@ -182,7 +182,7 @@ class LanguageServiceTest extends BaseTest
             $language
         );
 
-        $languages = $languageService->loadLanguageListById([$languageId]);
+        $languages = iterator_to_array($languageService->loadLanguageListById([$languageId]));
 
         self::assertIsIterable($languages);
         self::assertCount(1, $languages);
@@ -377,7 +377,7 @@ class LanguageServiceTest extends BaseTest
             $language
         );
 
-        $languages = $languageService->loadLanguageListByCode(['eng-NZ']);
+        $languages = iterator_to_array($languageService->loadLanguageListByCode(['eng-NZ']));
 
         self::assertIsIterable($languages);
         self::assertCount(1, $languages);

--- a/tests/integration/Core/Repository/LocationServiceAuthorizationTest.php
+++ b/tests/integration/Core/Repository/LocationServiceAuthorizationTest.php
@@ -225,7 +225,7 @@ class LocationServiceAuthorizationTest extends BaseTest
         $editorGroupContentInfo = $repository->getContentService()->loadContentInfo($editorsGroupId);
 
         // this should return one location for admin
-        $locations = $locationService->loadLocations($editorGroupContentInfo);
+        $locations = iterator_to_array($locationService->loadLocations($editorGroupContentInfo));
         self::assertCount(1, $locations);
         self::assertInstanceOf(Location::class, $locations[0]);
 

--- a/tests/integration/Core/Repository/LocationServiceTest.php
+++ b/tests/integration/Core/Repository/LocationServiceTest.php
@@ -686,7 +686,7 @@ class LocationServiceTest extends BaseTest
 
         // 5 is the ID of an existing location, 442 is a non-existing id
         $locationService = $repository->getLocationService();
-        $locations = $locationService->loadLocationList([5, 442]);
+        $locations = iterator_to_array($locationService->loadLocationList([5, 442]));
 
         self::assertIsIterable($locations);
         self::assertCount(1, $locations);
@@ -731,7 +731,7 @@ class LocationServiceTest extends BaseTest
 
         // 5 is the ID of an existing location, 442 is a non-existing id
         $locationService = $repository->getLocationService();
-        $locations = $locationService->loadLocationList([5, 442], ['pol-PL'], true);
+        $locations = iterator_to_array($locationService->loadLocationList([5, 442], ['pol-PL'], true));
 
         self::assertIsIterable($locations);
         self::assertCount(1, $locations);
@@ -751,7 +751,7 @@ class LocationServiceTest extends BaseTest
 
         // 1 is the ID of an root location
         $locationService = $repository->getLocationService();
-        $locations = $locationService->loadLocationList([1]);
+        $locations = iterator_to_array($locationService->loadLocationList([1]));
 
         self::assertIsIterable($locations);
         self::assertCount(1, $locations);
@@ -778,7 +778,7 @@ class LocationServiceTest extends BaseTest
         // Call loadLocation to cache it in memory as it might possibly affect list order
         $locationService->loadLocation($cachedLocationId);
 
-        $locations = $locationService->loadLocationList($locationIdsToLoad);
+        $locations = iterator_to_array($locationService->loadLocationList($locationIdsToLoad));
         $locationIds = array_column($locations, 'id');
 
         self::assertEquals($locationIdsToLoad, $locationIds);
@@ -1723,15 +1723,15 @@ class LocationServiceTest extends BaseTest
         $urlAlias = $urlAliasService->createUrlAlias($location1, '/custom-location1', 'eng-GB', false, true);
         $urlAliasService->createUrlAlias($location1, '/custom-location1', 'pol-PL', false, true);
         $urlAliasService->createUrlAlias($location2, '/custom-location2', 'eng-GB', false, true);
-        $location1UrlAliases = $urlAliasService->listLocationAliases($location1);
-        $location2UrlAliases = $urlAliasService->listLocationAliases($location2);
+        $location1UrlAliases = iterator_to_array($urlAliasService->listLocationAliases($location1));
+        $location2UrlAliases = iterator_to_array($urlAliasService->listLocationAliases($location2));
 
         $locationService->swapLocation($location1, $location2);
         $location1 = $locationService->loadLocation($location1->contentInfo->mainLocationId);
         $location2 = $locationService->loadLocation($location2->contentInfo->mainLocationId);
 
-        $location1UrlAliasesAfterSwap = $urlAliasService->listLocationAliases($location1);
-        $location2UrlAliasesAfterSwap = $urlAliasService->listLocationAliases($location2);
+        $location1UrlAliasesAfterSwap = iterator_to_array($urlAliasService->listLocationAliases($location1));
+        $location2UrlAliasesAfterSwap = iterator_to_array($urlAliasService->listLocationAliases($location2));
 
         $keyUrlAlias = array_search($urlAlias->id, array_column($location1UrlAliasesAfterSwap, 'id'));
 
@@ -3745,8 +3745,7 @@ class LocationServiceTest extends BaseTest
         Location $location,
         URLAliasServiceInterface $urlAliasService
     ): void {
-        $articleAliasesBeforeDelete = $urlAliasService
-            ->listLocationAliases($location);
+        $articleAliasesBeforeDelete = iterator_to_array($urlAliasService->listLocationAliases($location));
 
         self::assertNotEmpty(
             array_filter(

--- a/tests/integration/Core/Repository/PermissionResolverTest.php
+++ b/tests/integration/Core/Repository/PermissionResolverTest.php
@@ -1029,7 +1029,7 @@ class PermissionResolverTest extends BaseTest
             [],
             [
                 new LookupPolicyLimitations(
-                    $role->getPolicies()[1],
+                    [...$role->getPolicies()][1],
                     [
                         new Limitation\LanguageLimitation(['limitationValues' => ['eng-US']]),
                         new Limitation\SectionLimitation(['limitationValues' => [2]]),
@@ -1091,7 +1091,7 @@ class PermissionResolverTest extends BaseTest
             [],
             [
                 new LookupPolicyLimitations(
-                    $role->getPolicies()[1],
+                    [...$role->getPolicies()][1],
                     [
                         1 => new Limitation\SectionLimitation(['limitationValues' => [2]]),
                     ]
@@ -1147,7 +1147,7 @@ class PermissionResolverTest extends BaseTest
             [$roleLimitation],
             [
                 new LookupPolicyLimitations(
-                    $role->getPolicies()[1],
+                    [...$role->getPolicies()][1],
                     [new Limitation\LanguageLimitation(['limitationValues' => ['eng-US']])]
                 ),
             ]

--- a/tests/integration/Core/Repository/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
+++ b/tests/integration/Core/Repository/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
@@ -38,7 +38,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             [$locationService->newLocationCreateStruct(2)]
         );
         $folder1 = $contentService->publishVersion($draft1->versionInfo);
-        $locationsFolder1 = $locationService->loadLocations($folder1->contentInfo);
+        $locationsFolder1 = iterator_to_array($locationService->loadLocations($folder1->contentInfo));
 
         $contentCreateStruct2 = $contentService->newContentCreateStruct(
             $contentTypeService->loadContentTypeByIdentifier('folder'),
@@ -50,7 +50,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             [$locationService->newLocationCreateStruct(2)]
         );
         $folder2 = $contentService->publishVersion($draft2->versionInfo);
-        $locationsFolder2 = $locationService->loadLocations($folder2->contentInfo);
+        $locationsFolder2 = iterator_to_array($locationService->loadLocations($folder2->contentInfo));
 
         $feedbackFormContentInfo = $contentService->loadContentInfo(58);
         $locationCreateStruct1 = $locationService->newLocationCreateStruct($locationsFolder1[0]->id);

--- a/tests/integration/Core/Repository/RoleServiceAuthorizationTest.php
+++ b/tests/integration/Core/Repository/RoleServiceAuthorizationTest.php
@@ -9,6 +9,8 @@ namespace Ibexa\Tests\Integration\Core\Repository;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation;
+use Ibexa\Contracts\Core\Repository\Values\User\PolicyDraft;
+use Ibexa\Contracts\Core\Repository\Values\User\UserRoleAssignment;
 
 /**
  * Test case for operations in the RoleService using in memory storage.
@@ -279,7 +281,9 @@ class RoleServiceAuthorizationTest extends BaseTest
         $permissionResolver->setCurrentUserReference($user);
 
         // This call will fail with an "UnauthorizedException"
-        $roleService->removePolicyByRoleDraft($roleDraft, $roleDraft->getPolicies()[0]);
+        $policyDraft = [...$roleDraft->getPolicies()][0];
+        self::assertInstanceOf(PolicyDraft::class, $policyDraft);
+        $roleService->removePolicyByRoleDraft($roleDraft, $policyDraft);
         /* END: Use Case */
     }
 
@@ -613,11 +617,12 @@ class RoleServiceAuthorizationTest extends BaseTest
         $repository->getPermissionResolver()->setCurrentUserReference($user);
         /* END: Use Case */
 
-        $roleAssignments = $roleService->getRoleAssignmentsForUser($user);
+        $roleAssignments = iterator_to_array($roleService->getRoleAssignmentsForUser($user));
         self::assertCount(1, $roleAssignments);
 
         $roleAssignment = $roleAssignments[0];
-        self::assertSame($user, $roleAssignment->user);
+        self::assertInstanceOf(UserRoleAssignment::class, $roleAssignment);
+        self::assertSame($user, $roleAssignment->getUser());
     }
 
     /**

--- a/tests/integration/Core/Repository/RoleServiceTest.php
+++ b/tests/integration/Core/Repository/RoleServiceTest.php
@@ -1799,7 +1799,7 @@ class RoleServiceTest extends BaseTest
         $role = $roleService->loadRole($roleDraft->id);
         $roleService->assignRoleToUserGroup($role, $userGroup);
 
-        $roleAssignmentsBeforeNewPolicy = $roleService->getRoleAssignments($role)[0];
+        $roleAssignmentsBeforeNewPolicy = [...$roleService->getRoleAssignments($role)][0];
 
         /* Add new policy to existing role */
         $roleUpdateDraft = $roleService->createRoleDraft($role);
@@ -1810,10 +1810,10 @@ class RoleServiceTest extends BaseTest
         $roleService->publishRoleDraft($roleUpdateDraft);
 
         $roleAfterUpdate = $roleService->loadRole($role->id);
-        $roleAssignmentsAfterNewPolicy = $roleService->getRoleAssignments($roleAfterUpdate)[0];
+        $roleAssignmentsAfterNewPolicy = [...$roleService->getRoleAssignments($roleAfterUpdate)][0];
         /* END: Use Case */
 
-        self::assertNotEquals($roleAssignmentsBeforeNewPolicy->id, $roleAssignmentsAfterNewPolicy->id);
+        self::assertNotEquals($roleAssignmentsBeforeNewPolicy->getId(), $roleAssignmentsAfterNewPolicy->getId());
     }
 
     /**
@@ -1840,9 +1840,9 @@ class RoleServiceTest extends BaseTest
         // Assignment to user
         $role = $roleService->loadRole(2);
         $roleService->assignRoleToUser($role, $user);
-        $userRoleAssignments = $roleService->getRoleAssignmentsForUser($user);
+        $userRoleAssignments = iterator_to_array($roleService->getRoleAssignmentsForUser($user));
 
-        $userRoleAssignment = $roleService->loadRoleAssignment($userRoleAssignments[0]->id);
+        $userRoleAssignment = $roleService->loadRoleAssignment($userRoleAssignments[0]->getId());
         /* END: Use Case */
 
         self::assertInstanceOf(UserGroupRoleAssignment::class, $groupRoleAssignment);
@@ -1886,7 +1886,7 @@ class RoleServiceTest extends BaseTest
         $role = $roleService->loadRoleByIdentifier('Editor');
 
         // Load all assigned users and user groups
-        $roleAssignments = $roleService->getRoleAssignments($role);
+        $roleAssignments = iterator_to_array($roleService->getRoleAssignments($role));
 
         /* END: Use Case */
 
@@ -1937,7 +1937,7 @@ class RoleServiceTest extends BaseTest
 
         $loadedRole = $roleService->loadRole($role->id);
 
-        $roleAssignments = $roleService->loadRoleAssignments($loadedRole, 0, 1);
+        $roleAssignments = iterator_to_array($roleService->loadRoleAssignments($loadedRole, 0, 1));
 
         self::assertCount(1, $roleAssignments);
         self::assertInstanceOf(UserRoleAssignment::class, $roleAssignments[0]);
@@ -2800,7 +2800,7 @@ class RoleServiceTest extends BaseTest
         $newAssignmentCount = count($roleService->getRoleAssignmentsForUser($user));
         self::assertEquals($originalAssignmentCount + 1, $newAssignmentCount);
 
-        $assignments = $roleService->getRoleAssignmentsForUser($user);
+        $assignments = iterator_to_array($roleService->getRoleAssignmentsForUser($user));
         $roleService->removeRoleAssignment($assignments[0]);
         $finalAssignmentCount = count($roleService->getRoleAssignmentsForUser($user));
         self::assertEquals($newAssignmentCount - 1, $finalAssignmentCount);
@@ -2822,7 +2822,7 @@ class RoleServiceTest extends BaseTest
 
         try {
             $adminUserGroup = $repository->getUserService()->loadUserGroup(12);
-            $assignments = $roleService->getRoleAssignmentsForUserGroup($adminUserGroup);
+            $assignments = iterator_to_array($roleService->getRoleAssignmentsForUserGroup($adminUserGroup));
             $roleService->removeRoleAssignment($assignments[0]);
         } catch (Exception $e) {
             self::fail(
@@ -2847,7 +2847,7 @@ class RoleServiceTest extends BaseTest
 
         try {
             $editorsUserGroup = $repository->getUserService()->loadUserGroup(13);
-            $assignments = $roleService->getRoleAssignmentsForUserGroup($editorsUserGroup);
+            $assignments = iterator_to_array($roleService->getRoleAssignmentsForUserGroup($editorsUserGroup));
             $roleService->removeRoleAssignment($assignments[0]);
         } catch (Exception $e) {
             self::fail(

--- a/tests/integration/Core/Repository/TrashServiceAuthorizationTest.php
+++ b/tests/integration/Core/Repository/TrashServiceAuthorizationTest.php
@@ -312,8 +312,8 @@ class TrashServiceAuthorizationTest extends BaseTrashServiceTest
             $objectStateService->loadObjectStateGroup(2),
             $objectStateService->loadObjectState(2)
         );
-        $parentLocation = $locationService->loadLocations($parentContent->contentInfo)[0];
-        $childContent = $this->createFolder(['eng-US' => 'Child Folder'], $parentLocation->id);
+        $parentLocation = [...$locationService->loadLocations($parentContent->contentInfo)][0];
+        $this->createFolder(['eng-US' => 'Child Folder'], $parentLocation->id);
 
         $this->refreshSearch($repository);
         $this->expectException(UnauthorizedException::class);

--- a/tests/integration/Core/Repository/URLAliasService/UrlAliasLookupTest.php
+++ b/tests/integration/Core/Repository/URLAliasService/UrlAliasLookupTest.php
@@ -28,7 +28,7 @@ final class UrlAliasLookupTest extends RepositoryTestCase
             $folderMainLocation->id,
             $urlAlias->destination
         );
-        $systemUrlAliasList = $urlAliasService->listLocationAliases($folderMainLocation, false);
+        $systemUrlAliasList = iterator_to_array($urlAliasService->listLocationAliases($folderMainLocation, false));
         self::assertCount(1, $systemUrlAliasList);
         self::assertEquals($urlAlias, $systemUrlAliasList[0]);
     }

--- a/tests/integration/Core/Repository/URLAliasServiceTest.php
+++ b/tests/integration/Core/Repository/URLAliasServiceTest.php
@@ -1064,7 +1064,7 @@ class URLAliasServiceTest extends BaseTest
 
         // 5. Navigate to "Article"
         $urlAliasService->lookup('/My-Folder/My-Article');
-        $aliases = $urlAliasService->listLocationAliases($articleLocation, false);
+        $aliases = iterator_to_array($urlAliasService->listLocationAliases($articleLocation, false));
 
         self::assertEquals('/My-Folder-Modified/My-Article', $aliases[0]->path);
     }

--- a/tests/integration/Core/Repository/UserServiceTest.php
+++ b/tests/integration/Core/Repository/UserServiceTest.php
@@ -1589,7 +1589,7 @@ class UserServiceTest extends BaseTest
         $user = $this->createUserVersion1();
 
         // Load the newly created user
-        $usersReloaded = $userService->loadUsersByEmail('user@example.com', Language::ALL);
+        $usersReloaded = iterator_to_array($userService->loadUsersByEmail('user@example.com', Language::ALL));
 
         self::assertCount(1, $usersReloaded);
         $this->assertIsSameUser($user, $usersReloaded[0]);
@@ -1775,7 +1775,7 @@ class UserServiceTest extends BaseTest
         self::assertInstanceOf(User::class, $updatedUser);
 
         // Check that we can load user by email
-        $users = $userService->loadUsersByEmail('user2@example.com');
+        $users = iterator_to_array($userService->loadUsersByEmail('user2@example.com'));
         self::assertCount(1, $users);
         self::assertInstanceOf(User::class, $users[0]);
     }

--- a/tests/lib/Repository/Mapper/ContentLocationMapper/DecoratedLocationServiceTest.php
+++ b/tests/lib/Repository/Mapper/ContentLocationMapper/DecoratedLocationServiceTest.php
@@ -132,7 +132,7 @@ class DecoratedLocationServiceTest extends TestCase
             ->method('setMapping')
             ->withConsecutive([1, 2], [3, 4]);
 
-        $actualLocations = $this->locationService->loadLocations($contentInfo);
+        $actualLocations = iterator_to_array($this->locationService->loadLocations($contentInfo));
 
         $location1 = $actualLocations[0];
         self::assertInstanceOf(Location::class, $location1);

--- a/tests/lib/Repository/Service/Mock/UrlAliasTest.php
+++ b/tests/lib/Repository/Service/Mock/UrlAliasTest.php
@@ -753,7 +753,7 @@ class UrlAliasTest extends BaseServiceMockTest
             ->willReturn([$spiUrlAlias]);
 
         $location = $this->getLocationStub();
-        $urlAliases = $urlAliasService->listLocationAliases($location, false, null);
+        $urlAliases = iterator_to_array($urlAliasService->listLocationAliases($location, false));
 
         self::assertCount(1, $urlAliases);
         self::assertInstanceOf(URLAlias::class, $urlAliases[0]);
@@ -809,12 +809,14 @@ class UrlAliasTest extends BaseServiceMockTest
             ->willReturn([$spiUrlAlias]);
 
         $location = $this->getLocationStub();
-        $urlAliases = $urlAliasService->listLocationAliases(
-            $location,
-            false,
-            null,
-            true,
-            ['fre-FR']
+        $urlAliases = iterator_to_array(
+            $urlAliasService->listLocationAliases(
+                $location,
+                false,
+                null,
+                true,
+                ['fre-FR']
+            )
         );
 
         self::assertCount(1, $urlAliases);
@@ -2417,7 +2419,7 @@ class UrlAliasTest extends BaseServiceMockTest
                 ]
         );
 
-        $urlAliases = $urlAliasService->listGlobalAliases();
+        $urlAliases = iterator_to_array($urlAliasService->listGlobalAliases());
 
         self::assertCount(1, $urlAliases);
         self::assertInstanceOf(URLAlias::class, $urlAliases[0]);


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/371

#### Description:
This is a follow-up to #371. We declare often that a method returns `iterable`, but return internally an array and when consuming, we treat the result as array. It works because we use arrays internally, however not all `iterables` can be used as array without `iterator_to_array` call.

Since PHP 8.2 we no longer need to do `if ($list instanceof \Traversable)` before calling `iterator_to_array`, therefore fixing this for 5.0.x-dev only.

#### For QA:

Regressions (?), RegenerateUrlAliasesCommand sanities.

Note: QA on 5.0 is postponed until we reach some milestone allowing smooth manual testing and regressions passing.