### PR TITLE
Link AfterEvent to SF's Event

### DIFF
--- a/src/contracts/Repository/Event/AfterEvent.php
+++ b/src/contracts/Repository/Event/AfterEvent.php
@@ -12,6 +12,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event emitted after action execution.
+ *
+ * @link https://github.com/symfony/symfony/blob/5.4/src/Symfony/Contracts/EventDispatcher/Event.php Symfony\Contracts\EventDispatcher\Event
  */
 abstract class AfterEvent extends Event
 {


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

As this is outside the actual PHP API Ref Ibexa\Contracts scope, `Symfony\Contracts\EventDispatcher\Event` isn't documented. Those `@link` tags can help.

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
