### PR TITLE
[PHPDoc] Improved ContentService doc for API reference

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -356,12 +356,12 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceAuthorizationTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$array_arg of function usort expects TArray of array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$array_arg of function usort expects TArray of array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function array_keys expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function array_keys expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -383,6 +383,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 1
+			path: tests/integration/Core/Repository/ContentServiceTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-

--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -6,17 +6,17 @@ parameters:
 			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function array_filter expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function array_filter expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function array_slice expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function array_slice expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
@@ -171,7 +171,7 @@ parameters:
 			path: src/lib/MVC/Symfony/Component/Serializer/AbstractPropertyWhitelistNormalizer.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function array_keys expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$input of function array_keys expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
 
@@ -351,7 +351,7 @@ parameters:
 			path: tests/integration/Core/Repository/BaseTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 4
 			path: tests/integration/Core/Repository/ContentServiceAuthorizationTest.php
 
@@ -381,13 +381,8 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
-			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-

--- a/phpstan-baseline-gte-8.0.neon
+++ b/phpstan-baseline-gte-8.0.neon
@@ -6,17 +6,17 @@ parameters:
 			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_filter expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function array_filter expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_slice expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function array_slice expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
@@ -171,7 +171,7 @@ parameters:
 			path: src/lib/MVC/Symfony/Component/Serializer/AbstractPropertyWhitelistNormalizer.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_keys expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function array_keys expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
 
@@ -306,12 +306,12 @@ parameters:
 			path: tests/integration/Core/Repository/BaseTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 4
 			path: tests/integration/Core/Repository/ContentServiceAuthorizationTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_keys expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function array_keys expects array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\> given\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -321,7 +321,7 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function usort expects TArray of array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function usort expects TArray of array, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -336,12 +336,12 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -48536,7 +48536,7 @@ parameters:
 			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/FileSystemTwigIntegrationTestCase.php
 
 		-
-			message: "#^Anonymous function should return string but returns string\\|false\\.$#"
+			message: "#^Anonymous function should return non\\-empty\\-string but returns non\\-empty\\-string\\|false\\.$#"
 			count: 1
 			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10946,6 +10946,11 @@ parameters:
 			path: src/lib/IO/IOService.php
 
 		-
+			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
+			count: 1
+			path: src/lib/IO/IOService.php
+
+		-
 			message: "#^Property Ibexa\\\\Contracts\\\\Core\\\\IO\\\\BinaryFile\\:\\:\\$uri \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 2
 			path: src/lib/IO/IOService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,7 +231,7 @@ parameters:
 			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
 
 		-
-			message: "#^Cannot access offset int on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\.$#"
+			message: "#^Cannot access offset int on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/RegenerateUrlAliasesCommand.php
 
@@ -5551,11 +5551,6 @@ parameters:
 			path: src/contracts/Persistence/User/Policy.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\ContentService\\:\\:loadContentByContentInfo\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Repository/ContentService.php
-
-		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\ContentService\\:\\:validate\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Repository/ContentService.php
@@ -5564,21 +5559,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\ContentService\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Repository/ContentService.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$contentId with type mixed is not subtype of native type int\\.$#"
-			count: 1
-			path: src/contracts/Repository/ContentService.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\\\Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Language\\|null if not set the draft is created with the initialLanguage code of the source version or if not present with the main language\\.\\)\\: Unexpected token \"if\", expected variable at offset 870$#"
-			count: 1
-			path: src/contracts/Repository/ContentService.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Decorator\\\\ContentServiceDecorator\\:\\:loadContentByContentInfo\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Repository/Decorator/ContentServiceDecorator.php
 
 		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Decorator\\\\ContentServiceDecorator\\:\\:validate\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
@@ -8606,7 +8586,7 @@ parameters:
 			path: src/lib/Base/Utils/DeprecationWarnerInterface.php
 
 		-
-			message: "#^Parameter \\#1 \\$locations of class Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Events\\\\Content\\\\DeleteContentEvent constructor expects array, array\\|iterable\\<int\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$locations of class Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Events\\\\Content\\\\DeleteContentEvent constructor expects array, array\\|iterable\\<int, int\\> given\\.$#"
 			count: 1
 			path: src/lib/Event/ContentService.php
 
@@ -10962,11 +10942,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$buffer of method Ibexa\\\\Contracts\\\\Core\\\\IO\\\\MimeTypeDetector\\:\\:getFromBuffer\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/lib/IO/IOService.php
-
-		-
-			message: "#^Parameter \\#2 \\$length of function fread expects int\\<1, max\\>, int\\<0, max\\> given\\.$#"
 			count: 1
 			path: src/lib/IO/IOService.php
 
@@ -19776,11 +19751,6 @@ parameters:
 			path: src/lib/Repository/ContentService.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\ContentService\\:\\:loadContentByContentInfo\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/ContentService.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\ContentService\\:\\:loadContentByRemoteId\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Repository/ContentService.php
@@ -19831,7 +19801,7 @@ parameters:
 			path: src/lib/Repository/ContentService.php
 
 		-
-			message: "#^Parameter \\#3 \\$prioritizedLanguages of method Ibexa\\\\Core\\\\Repository\\\\Mapper\\\\ContentDomainMapper\\:\\:buildContentDomainObjectFromPersistence\\(\\) expects array\\<string\\>, array\\<string\\>\\|null given\\.$#"
+			message: "#^Parameter \\#3 \\$prioritizedLanguages of method Ibexa\\\\Core\\\\Repository\\\\Mapper\\\\ContentDomainMapper\\:\\:buildContentDomainObjectFromPersistence\\(\\) expects array\\<string\\>, array\\<int, string\\>\\|null given\\.$#"
 			count: 1
 			path: src/lib/Repository/ContentService.php
 
@@ -20784,11 +20754,6 @@ parameters:
 			message: "#^Parameter \\#3 \\$serializedValue of method Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\Setting\\\\Handler\\:\\:update\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/lib/Repository/SettingService.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\SiteAccessAware\\\\ContentService\\:\\:loadContentByContentInfo\\(\\) has parameter \\$languages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/SiteAccessAware/ContentService.php
 
 		-
 			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\SiteAccessAware\\\\ContentService\\:\\:validate\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
@@ -27121,52 +27086,62 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
+			message: "#^Cannot access offset 0 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
 			count: 12
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
 			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 11
+			count: 7
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
+			message: "#^Cannot access offset 0 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			count: 4
+			path: tests/integration/Core/Repository/ContentServiceTest.php
+
+		-
+			message: "#^Cannot access offset 1 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
 			count: 4
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
 			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 3
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 2 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 3 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 4 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/ContentServiceTest.php
-
-		-
-			message: "#^Cannot access offset 5 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
 			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset mixed on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\>\\.$#"
+			message: "#^Cannot access offset 1 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset mixed on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			message: "#^Cannot access offset 2 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			count: 1
+			path: tests/integration/Core/Repository/ContentServiceTest.php
+
+		-
+			message: "#^Cannot access offset 3 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			count: 1
+			path: tests/integration/Core/Repository/ContentServiceTest.php
+
+		-
+			message: "#^Cannot access offset 4 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			count: 1
+			path: tests/integration/Core/Repository/ContentServiceTest.php
+
+		-
+			message: "#^Cannot access offset 5 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			count: 2
+			path: tests/integration/Core/Repository/ContentServiceTest.php
+
+		-
+			message: "#^Cannot access offset mixed on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\>\\.$#"
+			count: 1
+			path: tests/integration/Core/Repository/ContentServiceTest.php
+
+		-
+			message: "#^Cannot access offset int on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -27256,7 +27231,7 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testAddRelation\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
+			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testAddRelation\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> but returns iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -27371,7 +27346,7 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testCreateContentDraftWithRelations\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
+			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testCreateContentDraftWithRelations\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> but returns iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -27871,7 +27846,7 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testLoadVersions\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\ContentServiceTest\\:\\:testLoadVersions\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> but returns iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
@@ -30726,7 +30701,7 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/RelationIntegrationTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$relations of method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\RelationIntegrationTest\\:\\:normalizeRelations\\(\\) expects array\\<Ibexa\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$relations of method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\RelationIntegrationTest\\:\\:normalizeRelations\\(\\) expects array\\<Ibexa\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 5
 			path: tests/integration/Core/Repository/FieldType/RelationIntegrationTest.php
 
@@ -30826,7 +30801,7 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/RelationListIntegrationTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$relations of method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\RelationListIntegrationTest\\:\\:normalizeRelations\\(\\) expects array\\<Ibexa\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$relations of method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\RelationListIntegrationTest\\:\\:normalizeRelations\\(\\) expects array\\<Ibexa\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>, iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 5
 			path: tests/integration/Core/Repository/FieldType/RelationListIntegrationTest.php
 
@@ -48561,7 +48536,7 @@ parameters:
 			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/FileSystemTwigIntegrationTestCase.php
 
 		-
-			message: "#^Anonymous function should return non\\-empty\\-string but returns non\\-empty\\-string\\|false\\.$#"
+			message: "#^Anonymous function should return string but returns string\\|false\\.$#"
 			count: 1
 			path: tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
 
@@ -56101,7 +56076,7 @@ parameters:
 			path: tests/lib/Repository/Decorator/ContentServiceDecoratorTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$contentIds of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\ContentService\\:\\:loadContentInfoList\\(\\) expects array\\<int\\>, array\\<int, string\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$contentIds of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\ContentService\\:\\:loadContentInfoList\\(\\) expects array\\<int, int\\>, array\\<int, string\\> given\\.$#"
 			count: 1
 			path: tests/lib/Repository/Decorator/ContentServiceDecoratorTest.php
 

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -110,7 +110,7 @@ interface ContentService
      *
      * @param array<int, string> $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
-     * @param int|null $versionNo the version number. If not given the current version is returned from $contentInfo.
+     * @param int|null $versionNo The version number. If not given the current version is returned from $contentInfo.
      * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
      */
     public function loadContentByContentInfo(ContentInfo $contentInfo, array $languages = null, ?int $versionNo = null, bool $useAlwaysAvailable = true): Content;
@@ -136,7 +136,7 @@ interface ContentService
      *
      * @param array<int, string> $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
-     * @param int|null $versionNo the version number. If not given the current version is returned.
+     * @param int|null $versionNo The version number. If not given the current version is returned.
      * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
      */
     public function loadContent(int $contentId, array $languages = null, ?int $versionNo = null, bool $useAlwaysAvailable = true): Content;
@@ -186,9 +186,9 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if there is a provided remote ID which exists in the system or multiple Locations
      *                                                                        are under the same parent or if the a field value is not accepted by the field type
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException If a required field is missing or is set to an empty value.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException if a required field is missing or is set to an empty value.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct} for each location parent under which a location should be created for the content.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs An array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct} for each location parent under which a location should be created for the content.
      *                                                                                                While optional, it's highly recommended to use Locations for content as a lot of features in the system is usually tied to the tree structure (including default Role policies).
      * @param string[]|null $fieldIdentifiersToValidate List of field identifiers for partial validation or null
      *                      for case of full validation. Empty identifiers array is equal to no validation.
@@ -526,7 +526,7 @@ interface ContentService
     /**
      * Fetches Content items from the Repository filtered by the given conditions.
      *
-     * @param array<int, string> $languages a list of language codes to be added as additional constraints.
+     * @param array<int, string> $languages A list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
      */
@@ -537,7 +537,7 @@ interface ContentService
      *
      * Count total number of items returned by {@see ContentService::find()} with the same parameters.
      *
-     * @param array<int, string> $languages a list of language codes to be added as additional constraints.
+     * @param array<int, string> $languages A list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
      */

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -471,7 +471,7 @@ interface ContentService
      * Adds a relation of type common.
      *
      * The source of the relation is the content and version
-     * referenced by $versionInfo.
+     * referenced by $sourceVersion.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to edit this version
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -74,10 +74,10 @@ interface ContentService
     /**
      * Loads a version info of the given content object.
      *
-     * If no version number is given, the method returns the current version
+     * If no version number is given, the method returns the current version.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      * @param int|null $versionNo the version number. If not given the current version is returned.
@@ -89,10 +89,10 @@ interface ContentService
     /**
      * Loads a version info of the given content object id.
      *
-     * If no version number is given, the method returns the current version
+     * If no version number is given, the method returns the current version.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version.
      *
      * @param int $contentId
      * @param int|null $versionNo the version number. If not given the current version is returned.
@@ -104,7 +104,7 @@ interface ContentService
     /**
      * Bulk-load VersionInfo items by the list of ContentInfo Value Objects.
      *
-     * @param array<\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo> $contentInfoList
+     * @param array<int, \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo> $contentInfoList
      *
      * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo> List of VersionInfo items with Content Ids as keys
      *
@@ -125,8 +125,8 @@ interface ContentService
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      * @param array $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
-     * @param int|null $versionNo the version number. If not given the current version is returned from $contentInfo
-     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if alwaysAvailable is true
+     * @param int|null $versionNo the version number. If not given the current version is returned from $contentInfo.
+     * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
@@ -135,12 +135,12 @@ interface ContentService
     /**
      * Loads content in the version given by version info.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
-     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if alwaysAvailable is true
+     * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
@@ -154,11 +154,10 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given id and languages does not exist
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to read content and in case of un-published content: read versions
      *
-     * @param mixed $contentId
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
-     * @param int|null $versionNo the version number. If not given the current version is returned
-     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if alwaysAvailable is true
+     * @param int|null $versionNo the version number. If not given the current version is returned.
+     * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
@@ -176,7 +175,7 @@ interface ContentService
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
      * @param int|null $versionNo the version number. If not given the current version is returned
-     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if alwaysAvailable is true
+     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
@@ -192,7 +191,7 @@ interface ContentService
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo[] $contentInfoList
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                            returned value object. If not given all languages are returned.
-     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if alwaysAvailable is true,
+     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true,
      *                                 unless all languages have been asked for.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content[] list of Content items with Content Ids as keys
@@ -215,7 +214,7 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException if a required field is missing or is set to an empty value
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct $contentCreateStruct
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct} for each location parent under which a location should be created for the content
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct} for each location parent under which a location should be created for the content.
      *                                                                                                While optional, it's highly recommended to use Locations for content as a lot of features in the system is usually tied to the tree structure (including default Role policies).
      * @param string[]|null $fieldIdentifiersToValidate List of field identifiers for partial validation or null
      *                      for case of full validation. Empty identifiers array is equal to no validation.
@@ -227,7 +226,7 @@ interface ContentService
     /**
      * Updates the metadata.
      *
-     * See {@see ContentMetadataUpdateStruct} of a content object - to update fields use updateContent
+     * To update fields use {@see ContentService::updateContent()}
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to update the content meta data
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the remoteId in $contentMetadataUpdateStruct is set but already exists
@@ -262,7 +261,7 @@ interface ContentService
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo|null $versionInfo
      * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $creator Used as creator of the draft if given - otherwise uses current-user
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Language|null if not set the draft is created with the initialLanguage code of the source version or if not present with the main language.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Language|null $language if not set the draft is created with the initialLanguage code of the source version or if not present with the main language.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content - the newly created content draft
      */
@@ -276,7 +275,7 @@ interface ContentService
     /**
      * Counts drafts for a user.
      *
-     * If no user is given the number of drafts for the authenticated user are returned
+     * If no user is given the number of drafts for the authenticated user are returned.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\User $user The user to load drafts for, if defined, otherwise drafts for current-user
      *
@@ -289,7 +288,7 @@ interface ContentService
     /**
      * Loads drafts for a user.
      *
-     * If no user is given the drafts for the authenticated user are returned
+     * If no user is given the drafts for the authenticated user are returned.
      *
      * @deprecated Please use {@see ContentService::loadContentDraftList()} instead to avoid risking loading too much data.
      *
@@ -297,14 +296,14 @@ interface ContentService
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\User $user The user to load drafts for, if defined, otherwise drafts for current-user
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo[] the drafts ({@see VersionInfo}) owned by the given user
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo[] the drafts owned by the given user
      */
     public function loadContentDrafts(?User $user = null): iterable;
 
     /**
      * Loads drafts for a user when content is not in the trash. The list is sorted by modification date.
      *
-     * If no user is given the drafts for the authenticated user are returned
+     * If no user is given the drafts for the authenticated user are returned.
      *
      * @since 7.5.5
      *
@@ -319,18 +318,18 @@ interface ContentService
     /**
      * Updates the fields of a draft.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to update this version
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException if a field in the $contentUpdateStruct is not valid
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException if a required field is set to an empty value
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if a field value is not accepted by the field type
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to update this version.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException if a field in the $contentUpdateStruct is not valid.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException if a required field is set to an empty value.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if a field value is not accepted by the field type.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct $contentUpdateStruct
      * @param string[]|null $fieldIdentifiersToValidate List of field identifiers for partial validation or null
      *                      for case of full validation. Empty identifiers array is equal to no validation.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content the content draft with the updated fields
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content the content draft with the updated fields.
      */
     public function updateContent(VersionInfo $versionInfo, ContentUpdateStruct $contentUpdateStruct, ?array $fieldIdentifiersToValidate = null): Content;
 
@@ -342,13 +341,13 @@ interface ContentService
      *
      * @todo Introduce null|int ContentType->versionArchiveLimit to be able to let admins override this per type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
      * @param string[] $translations List of language codes of translations which will be included
      *                               in a published version.
-     *                               By default all translations from the current version will be published.
+     *                               By default, all translations from the current version will be published.
      *                               If the list is provided but does not cover all currently published translations,
      *                               the missing ones will be copied from the currently published version,
      *                               overriding those in the current version.
@@ -377,7 +376,7 @@ interface ContentService
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      * @param int|null $status
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo[] an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo} sorted by creation date
+     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo> an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo} sorted by creation date
      */
     public function loadVersions(ContentInfo $contentInfo, ?int $status = null): iterable;
 
@@ -435,7 +434,7 @@ interface ContentService
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      *
-     * @return int The number of reverse relations ({@see \Ibexa\Contracts\Core\Repository\Values\Content\Relation})
+     * @return int The number of reverse relations ({@see Relation})
      */
     public function countReverseRelations(ContentInfo $contentInfo): int;
 
@@ -456,8 +455,7 @@ interface ContentService
      * Loads all incoming relations for a content object.
      *
      * The relations come only from published versions of the source content objects.
-     * If the user is not allowed to read specific version then UnauthorizedRelationListItem is returned
-     * {@see \Ibexa\Contracts\Core\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem}
+     * If the user is not allowed to read specific version then {@see \Ibexa\Contracts\Core\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem} is returned.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      * @param int $offset
@@ -468,30 +466,34 @@ interface ContentService
     public function loadReverseRelationList(ContentInfo $contentInfo, int $offset = 0, int $limit = -1): RelationList;
 
     /**
-     * Adds a relation of type common.
+     * Adds a common relation.
      *
      * The source of the relation is the content and version
      * referenced by $sourceVersion.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to edit this version
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to edit this version.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $sourceVersion
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $destinationContent the destination of the relation
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $sourceVersion the source content's version in relation with the destination.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $destinationContent the destination of the relation.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation the newly created relation
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation the newly created relation.
+     *
+     * @see Relation::COMMON
      */
     public function addRelation(VersionInfo $sourceVersion, ContentInfo $destinationContent): Relation;
 
     /**
-     * Removes a relation of type COMMON from a draft.
+     * Removes a common relation from a draft.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed edit this version
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if there is no relation of type COMMON for the given destination
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed edit this version.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if there is no relation of type {@see Relation::COMMON} for the given destination.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $sourceVersion
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $destinationContent
+     *
+     * @see Relation::COMMON
      */
     public function deleteRelation(VersionInfo $sourceVersion, ContentInfo $destinationContent): void;
 
@@ -517,7 +519,7 @@ interface ContentService
     /**
      * Delete specified Translation from a Content Draft.
      *
-     * When using together with ContentService::publishVersion() method, make sure to not provide deleted translation
+     * When using together with {@see ContentService::publishVersion()} method, make sure to not provide deleted translation
      * in translations array, as it is going to be copied again from published version.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the specified Translation
@@ -528,10 +530,10 @@ interface ContentService
      *         is invalid for the given Draft.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if specified Version was not found
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo Content Version Draft
-     * @param string $languageCode Language code of the Translation to be removed
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo Content Version Draft.
+     * @param string $languageCode Language code of the Translation to be removed.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content Content Draft w/o the specified Translation
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content Content Draft without the specified Translation.
      *
      * @since 6.12
      */
@@ -539,9 +541,10 @@ interface ContentService
 
     /**
      * Hides Content by making all the Locations appear hidden.
+     *
      * It does not persist hidden state on Location object itself.
      *
-     * Content hidden by this API can be revealed by revealContent API.
+     * Content hidden by this API can be revealed by {@see ContentService::revealContent()} API.
      *
      * @see ContentService::revealContent()
      *
@@ -551,6 +554,7 @@ interface ContentService
 
     /**
      * Reveals Content hidden by hideContent API.
+     *
      * Locations which were hidden before hiding Content will remain hidden.
      *
      * @see ContentService::hideContent()
@@ -562,7 +566,7 @@ interface ContentService
     /**
      * Instantiates a new content create struct object.
      *
-     * alwaysAvailable is set to the ContentType's defaultAlwaysAvailable
+     * {@see ContentCreateStruct::$alwaysAvailable} is set to the {@see ContentType::$defaultAlwaysAvailable}
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType $contentType
      * @param string $mainLanguageCode
@@ -589,7 +593,7 @@ interface ContentService
      * Validates given content related ValueObject returning field errors structure as a result.
      *
      * @param array $context Additional context parameters to be used by validators.
-     * @param string[]|null $fieldIdentifiersToValidate List of field identifiers for partial validation or null
+     * @param array<int, string>|null $fieldIdentifiersToValidate List of field identifiers for partial validation, or null
      *                      for case of full validation. Empty identifiers array is equal to no validation.
      *
      * @return array Validation errors grouped by field definition and language code, in format:
@@ -600,18 +604,20 @@ interface ContentService
     public function validate(ValueObject $object, array $context, ?array $fieldIdentifiersToValidate = null): array;
 
     /**
-     * Fetch Content items from the Repository filtered by the given conditions.
+     * Fetches Content items from the Repository filtered by the given conditions.
      *
-     * @param string[] $languages a list of language codes to be added as additional constraints.
+     * @param array<int, string> $languages a list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
      */
     public function find(Filter $filter, ?array $languages = null): ContentList;
 
     /**
-     * Count total number of items returned by {@see ContentService::find()} method.
+     * Gets the total number of fetchable Content items.
      *
-     * @param string[] $languages a list of language codes to be added as additional constraints.
+     * Count total number of items returned by {@see ContentService::find()} with the same parameters.
+     *
+     * @param array<int, string> $languages a list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
      */

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -49,7 +49,7 @@ interface ContentService
      *
      * @param array<int, int> $contentIds
      *
-     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo> List of ContentInfo with Content Ids as keys
+     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo> List of ContentInfo with content ids as keys
      */
     public function loadContentInfoList(array $contentIds): iterable;
 
@@ -132,7 +132,9 @@ interface ContentService
      * If no version number is given, the method returns the current version
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given id and languages doesn't exist.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to "read content", or, in case of un-published content, "read versions".
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user lacks:
+     *                         - `content/read` permission for published content, or
+     *                         - `content/read` and `content/versionread` permissions for draft content.
      *
      * @param array<int, string> $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
@@ -147,7 +149,9 @@ interface ContentService
      * If no version is given, the method returns the current version
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given remote id doesn't exist.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to "read content", or, in case of un-published content, "read versions".
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user lacks:
+     *                         - `content/read` permission for published content, or
+     *                         - `content/read` and `content/versionread` permissions for draft content.
      *
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
@@ -261,7 +265,7 @@ interface ContentService
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the current user is not allowed to load the draft list
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $user The user to load drafts for, if defined; otherwise drafts for current user.
+     * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $user The user to load drafts for. If `null`, the current user's drafts are loaded.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo[] The drafts owned by the given user.
      */

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -214,7 +214,7 @@ interface ContentService
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete the content (in one of the locations of the given content object).
      *
-     * @return array<int, int> Affected Location ID's (List of Location IDs of the Content that was deleted).
+     * @return array<int, int> Affected Location IDs (List of Location IDs of the Content that was deleted).
      */
     public function deleteContent(ContentInfo $contentInfo): iterable;
 
@@ -535,7 +535,7 @@ interface ContentService
     /**
      * Gets the total number of fetchable Content items.
      *
-     * Count total number of items returned by {@see ContentService::find()} with the same parameters.
+     * Counts total number of items returned by {@see ContentService::find()} with the same parameters.
      *
      * @param array<int, string> $languages A list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -226,7 +226,7 @@ interface ContentService
     /**
      * Updates the metadata.
      *
-     * To update fields, use {@see ContentService::updateContent()}
+     * To update fields, use {@see ContentService::updateContent()}.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to update the content meta data
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the remoteId in $contentMetadataUpdateStruct is set but already exists

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -339,7 +339,7 @@ interface ContentService
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to copy the content to the given location.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct $destinationLocationCreateStruct the target location where the content is copied to
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct $destinationLocationCreateStruct The target location where the content is copied to.
      */
     public function copyContent(ContentInfo $contentInfo, LocationCreateStruct $destinationLocationCreateStruct, ?VersionInfo $versionInfo = null): Content;
 

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -37,23 +37,19 @@ interface ContentService
      *
      * To load fields use loadContent
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read the content
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content with the given id does not exist
-     *
-     * @param int $contentId
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read the content.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content with the given id doesn't exist.
      */
     public function loadContentInfo(int $contentId): ContentInfo;
 
     /**
      * Bulk-load ContentInfo items by id's.
      *
-     * Note: It does not throw exceptions on load, just skips erroneous (NotFound or Unauthorized) ContentInfo items.
+     * Note: It doesn't throw exceptions on load, just skips erroneous (NotFound or Unauthorized) ContentInfo items.
      *
-     * @param int[] $contentIds
+     * @param array<int, int> $contentIds
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo[] list of ContentInfo with Content Ids as keys
+     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo> List of ContentInfo with Content Ids as keys
      */
     public function loadContentInfoList(array $contentIds): iterable;
 
@@ -62,12 +58,8 @@ interface ContentService
      *
      * To load fields use loadContent
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read the content
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content with the given remote id does not exist
-     *
-     * @param string $remoteId
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read the content.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content with the given remote id doesn't exist.
      */
     public function loadContentInfoByRemoteId(string $remoteId): ContentInfo;
 
@@ -76,13 +68,10 @@ interface ContentService
      *
      * If no version number is given, the method returns the current version.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number doesn't exist.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      * @param int|null $versionNo the version number. If not given the current version is returned.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo
      */
     public function loadVersionInfo(ContentInfo $contentInfo, ?int $versionNo = null): VersionInfo;
 
@@ -91,13 +80,10 @@ interface ContentService
      *
      * If no version number is given, the method returns the current version.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number doesn't exist.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version.
      *
-     * @param int $contentId
      * @param int|null $versionNo the version number. If not given the current version is returned.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo
      */
     public function loadVersionInfoById(int $contentId, ?int $versionNo = null): VersionInfo;
 
@@ -119,16 +105,13 @@ interface ContentService
      *
      * If no version number is given, the method returns the current version
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if version with the given number does not exist
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if version with the given number doesn't exist.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     * @param array $languages A language priority, filters returned fields and is used as prioritized language code on
+     * @param array<int, string> $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
      * @param int|null $versionNo the version number. If not given the current version is returned from $contentInfo.
      * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
     public function loadContentByContentInfo(ContentInfo $contentInfo, array $languages = null, ?int $versionNo = null, bool $useAlwaysAvailable = true): Content;
 
@@ -137,12 +120,9 @@ interface ContentService
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
      * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
     public function loadContentByVersionInfo(VersionInfo $versionInfo, array $languages = null, bool $useAlwaysAvailable = true): Content;
 
@@ -151,15 +131,13 @@ interface ContentService
      *
      * If no version number is given, the method returns the current version
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given id and languages does not exist
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to read content and in case of un-published content: read versions
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given id and languages doesn't exist.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to "read content", or, in case of un-published content, "read versions".
      *
-     * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
+     * @param array<int, string> $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
      * @param int|null $versionNo the version number. If not given the current version is returned.
      * @param bool $useAlwaysAvailable Add Main language to $languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
     public function loadContent(int $contentId, array $languages = null, ?int $versionNo = null, bool $useAlwaysAvailable = true): Content;
 
@@ -168,33 +146,30 @@ interface ContentService
      *
      * If no version is given, the method returns the current version
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given remote id does not exist
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to read content and in case of un-published content: read versions
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given remote id doesn't exist.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to "read content", or, in case of un-published content, "read versions".
      *
-     * @param string $remoteId
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
      * @param int|null $versionNo the version number. If not given the current version is returned
      * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
     public function loadContentByRemoteId(string $remoteId, array $languages = null, ?int $versionNo = null, bool $useAlwaysAvailable = true): Content;
 
     /**
      * Bulk-load Content items by the list of ContentInfo Value Objects.
      *
-     * Note: it does not throw exceptions on load, just ignores erroneous Content item.
+     * Note: it doesn't throw exceptions on load, just ignores erroneous Content item.
      * Moreover, since the method works on pre-loaded ContentInfo list, it is assumed that user is
      * allowed to access every Content on the list.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo[] $contentInfoList
-     * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
+     * @param array<int, \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo> $contentInfoList
+     * @param array<int, string> $languages A language priority, filters returned fields and is used as prioritized language code on
      *                            returned value object. If not given all languages are returned.
      * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true,
      *                                 unless all languages have been asked for.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content[] list of Content items with Content Ids as keys
+     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\Content> List of Content items with Content Ids as keys
      */
     public function loadContentListByContentInfo(array $contentInfoList, array $languages = [], bool $useAlwaysAvailable = true): iterable;
 
@@ -203,23 +178,22 @@ interface ContentService
      *
      * If a different userId is given in $contentCreateStruct it is assigned to the given user
      * but this required special rights for the authenticated user
-     * (this is useful for content staging where the transfer process does not
+     * (this is useful for content staging where the transfer process doesn't
      * have to authenticate with the user which created the content object in the source server).
      * The user has to publish the draft if it should be visible.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to create the content in the given location
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to create the content in the given location.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if there is a provided remote ID which exists in the system or multiple Locations
      *                                                                        are under the same parent or if the a field value is not accepted by the field type
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException If a required field is missing or is set to an empty value.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct $contentCreateStruct
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct} for each location parent under which a location should be created for the content.
      *                                                                                                While optional, it's highly recommended to use Locations for content as a lot of features in the system is usually tied to the tree structure (including default Role policies).
      * @param string[]|null $fieldIdentifiersToValidate List of field identifiers for partial validation or null
      *                      for case of full validation. Empty identifiers array is equal to no validation.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content - the newly created content draft
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content The newly created content draft.
      */
     public function createContent(ContentCreateStruct $contentCreateStruct, array $locationCreateStructs = [], ?array $fieldIdentifiersToValidate = null): Content;
 
@@ -228,24 +202,19 @@ interface ContentService
      *
      * To update fields, use {@see ContentService::updateContent()}.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to update the content meta data
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the remoteId in $contentMetadataUpdateStruct is set but already exists
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to update the content metadata.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the remoteId in $contentMetadataUpdateStruct is set but already exists.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentMetadataUpdateStruct $contentMetadataUpdateStruct
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content the content with the updated attributes
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content The content with the updated attributes.
      */
     public function updateContentMetadata(ContentInfo $contentInfo, ContentMetadataUpdateStruct $contentMetadataUpdateStruct): Content;
 
     /**
      * Deletes a content object including all its versions and locations including their subtrees.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete the content (in one of the locations of the given content object)
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete the content (in one of the locations of the given content object).
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return int[] Affected Location Id's (List of Locations of the Content that was deleted)
+     * @return array<int, int> Affected Location ID's (List of Location IDs of the Content that was deleted).
      */
     public function deleteContent(ContentInfo $contentInfo): iterable;
 
@@ -256,14 +225,12 @@ interface ContentService
      * 4.x: The draft is created with the initialLanguage code of the source version or if not present with the main language.
      * It can be changed on updating the version.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the current-user is not allowed to create the draft
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the current user is not allowed to create the draft.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo|null $versionInfo
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $creator Used as creator of the draft if given - otherwise uses current-user
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Language|null $language if not set the draft is created with the initialLanguage code of the source version or if not present with the main language.
+     * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $creator Used as creator of the draft if given; otherwise uses current user.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Language|null $language If not set the draft is created with the initialLanguage code of the source version or if not present with the main language.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content - the newly created content draft
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content The newly created content draft.
      */
     public function createContentDraft(
         ContentInfo $contentInfo,
@@ -277,9 +244,9 @@ interface ContentService
      *
      * If no user is given the number of drafts for the authenticated user are returned.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\User $user The user to load drafts for, if defined, otherwise drafts for current-user
+     * @param \Ibexa\Contracts\Core\Repository\Values\User\User $user The user to load drafts for, if defined, otherwise drafts for current user.
      *
-     * @return int The number of drafts ({@see VersionInfo}) owned by the given user
+     * @return int The number of drafts ({@see VersionInfo}) owned by the given user.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
@@ -292,11 +259,11 @@ interface ContentService
      *
      * @deprecated Please use {@see ContentService::loadContentDraftList()} instead to avoid risking loading too much data.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the current-user is not allowed to load the draft list
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the current user is not allowed to load the draft list
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\User $user The user to load drafts for, if defined, otherwise drafts for current-user
+     * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $user The user to load drafts for, if defined; otherwise drafts for current user.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo[] the drafts owned by the given user
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo[] The drafts owned by the given user.
      */
     public function loadContentDrafts(?User $user = null): iterable;
 
@@ -307,11 +274,7 @@ interface ContentService
      *
      * @since 7.5.5
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $user The user to load drafts for, if defined, otherwise drafts for current-user
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentDraftList
+     * @param \Ibexa\Contracts\Core\Repository\Values\User\User|null $user The user to load drafts for, if defined; otherwise drafts for current user.
      */
     public function loadContentDraftList(?User $user = null, int $offset = 0, int $limit = -1): ContentDraftList;
 
@@ -324,12 +287,10 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException if a required field is set to an empty value.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if a field value is not accepted by the field type.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct $contentUpdateStruct
-     * @param string[]|null $fieldIdentifiersToValidate List of field identifiers for partial validation or null
+     * @param array<int, string>|null $fieldIdentifiersToValidate List of field identifiers for partial validation or null
      *                      for case of full validation. Empty identifiers array is equal to no validation.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content the content draft with the updated fields.
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content The content draft with the updated fields.
      */
     public function updateContent(VersionInfo $versionInfo, ContentUpdateStruct $contentUpdateStruct, ?array $fieldIdentifiersToValidate = null): Content;
 
@@ -344,15 +305,12 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
-     * @param string[] $translations List of language codes of translations which will be included
+     * @param array<int, string> $translations List of language codes of translations which will be included
      *                               in a published version.
      *                               By default, all translations from the current version will be published.
-     *                               If the list is provided but does not cover all currently published translations,
+     *                               If the list is provided but doesn't cover all currently published translations,
      *                               the missing ones will be copied from the currently published version,
      *                               overriding those in the current version.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
     public function publishVersion(VersionInfo $versionInfo, array $translations = Language::ALL): Content;
 
@@ -360,23 +318,18 @@ interface ContentService
      * Removes the given version.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is in
-     *         published state or is a last version of Content in non draft state
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
+     *         published state or is a last version of Content in non-draft state.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version.
      */
     public function deleteVersion(VersionInfo $versionInfo): void;
 
     /**
      * Loads all versions for the given content.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the given status is invalid
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to list versions.
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the given status is invalid.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     * @param int|null $status
-     *
-     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo> an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo} sorted by creation date
+     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo> An array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo} sorted by creation date.
      */
     public function loadVersions(ContentInfo $contentInfo, ?int $status = null): iterable;
 
@@ -384,24 +337,20 @@ interface ContentService
      * Copies the content to a new location. If no version is given,
      * all versions are copied, otherwise only the given version.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to copy the content to the given location
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to copy the content to the given location.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct $destinationLocationCreateStruct the target location where the content is copied to
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
     public function copyContent(ContentInfo $contentInfo, LocationCreateStruct $destinationLocationCreateStruct, ?VersionInfo $versionInfo = null): Content;
 
     /**
      * Loads all outgoing relations for the given version.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read this version
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read this version.
      *
-     * @deprecated 4.5.7 The "ContentService::loadRelations()" method is deprecated, will be removed in 5.0.
+     * @deprecated 4.5.7 It will be removed in 5.0. Use {@see ContentService::loadRelationList()} instead.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation[]
+     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\Relation>
      */
     public function loadRelations(VersionInfo $versionInfo): iterable;
 
@@ -432,9 +381,7 @@ interface ContentService
     /**
      * Counts all incoming relations for the given content object.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return int The number of reverse relations ({@see Relation})
+     * @return int The number of reverse relations ({@see Relation}).
      */
     public function countReverseRelations(ContentInfo $contentInfo): int;
 
@@ -443,11 +390,9 @@ interface ContentService
      *
      * The relations come only from published versions of the source content objects
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read this version
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read this version.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation[]
+     * @return array<int, \Ibexa\Contracts\Core\Repository\Values\Content\Relation>
      */
     public function loadReverseRelations(ContentInfo $contentInfo): iterable;
 
@@ -455,13 +400,7 @@ interface ContentService
      * Loads all incoming relations for a content object.
      *
      * The relations come only from published versions of the source content objects.
-     * If the user is not allowed to read specific version then {@see \Ibexa\Contracts\Core\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem} is returned.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\RelationList
+     * If the user is not allowed to read specific version then {@see \Ibexa\Contracts\Core\Repository\Values\Content\RelationList\Item\UnauthorizedRelationListItem} is returned
      */
     public function loadReverseRelationList(ContentInfo $contentInfo, int $offset = 0, int $limit = -1): RelationList;
 
@@ -474,10 +413,10 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to edit this version.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $sourceVersion the source content's version in relation with the destination.
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $destinationContent the destination of the relation.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $sourceVersion The source content's version in relation with the destination.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $destinationContent The destination of the relation.
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation the newly created relation.
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation The newly created relation.
      *
      * @see Relation::COMMON
      */
@@ -489,9 +428,6 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed edit this version.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if there is no relation of type {@see Relation::COMMON} for the given destination.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $sourceVersion
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $destinationContent
      *
      * @see Relation::COMMON
      */
@@ -506,11 +442,8 @@ interface ContentService
      *         is the Main Translation of a Content Item.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed
      *         to delete the content (in one of the locations of the given Content Item).
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if languageCode argument
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if $languageCode argument
      *         is invalid for the given content.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
-     * @param string $languageCode
      *
      * @since 6.13
      */
@@ -528,7 +461,7 @@ interface ContentService
      *         to edit the Content (in one of the locations of the given Content Object).
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if languageCode argument
      *         is invalid for the given Draft.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if specified Version was not found
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if specified Version was not found.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo Content Version Draft.
      * @param string $languageCode Language code of the Translation to be removed.
@@ -542,13 +475,11 @@ interface ContentService
     /**
      * Hides Content by making all the Locations appear hidden.
      *
-     * It does not persist hidden state on Location object itself.
+     * It doesn't persist hidden state on Location object itself.
      *
      * Content hidden by this API can be revealed by {@see ContentService::revealContent()} API.
      *
      * @see ContentService::revealContent()
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      */
     public function hideContent(ContentInfo $contentInfo): void;
 
@@ -558,34 +489,23 @@ interface ContentService
      * Locations which were hidden before hiding Content will remain hidden.
      *
      * @see ContentService::hideContent()
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
      */
     public function revealContent(ContentInfo $contentInfo): void;
 
     /**
      * Instantiates a new content create struct object.
      *
-     * {@see ContentCreateStruct::$alwaysAvailable} is set to the {@see ContentType::$defaultAlwaysAvailable}
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType $contentType
-     * @param string $mainLanguageCode
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct
+     * {@see ContentCreateStruct::$alwaysAvailable} is set to the {@see ContentType::$defaultAlwaysAvailable}.
      */
     public function newContentCreateStruct(ContentType $contentType, string $mainLanguageCode): ContentCreateStruct;
 
     /**
      * Instantiates a new content meta data update struct.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentMetadataUpdateStruct
      */
     public function newContentMetadataUpdateStruct(): ContentMetadataUpdateStruct;
 
     /**
      * Instantiates a new content update struct.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentUpdateStruct
      */
     public function newContentUpdateStruct(): ContentUpdateStruct;
 

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -175,7 +175,7 @@ interface ContentService
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
      *                         returned value object. If not given all languages are returned.
      * @param int|null $versionNo the version number. If not given the current version is returned
-     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true
+     * @param bool $useAlwaysAvailable Add Main language to \$languages if true (default) and if {@see ContentInfo::$alwaysAvailable} is true.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
@@ -211,7 +211,7 @@ interface ContentService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if there is a provided remote ID which exists in the system or multiple Locations
      *                                                                        are under the same parent or if the a field value is not accepted by the field type
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException if a required field is missing or is set to an empty value
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException If a required field is missing or is set to an empty value.
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct $contentCreateStruct
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs an array of {@see \Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct} for each location parent under which a location should be created for the content.

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -226,7 +226,7 @@ interface ContentService
     /**
      * Updates the metadata.
      *
-     * To update fields use {@see ContentService::updateContent()}
+     * To update fields, use {@see ContentService::updateContent()}
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to update the content meta data
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the remoteId in $contentMetadataUpdateStruct is set but already exists

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -38,7 +38,7 @@ interface ContentService
      * To load fields use loadContent
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read the content
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException - if the content with the given id does not exist
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content with the given id does not exist
      *
      * @param int $contentId
      *
@@ -63,7 +63,7 @@ interface ContentService
      * To load fields use loadContent
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to read the content
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException - if the content with the given remote id does not exist
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content with the given remote id does not exist
      *
      * @param string $remoteId
      *
@@ -76,7 +76,7 @@ interface ContentService
      *
      * If no version number is given, the method returns the current version
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException - if the version with the given number does not exist
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
@@ -91,7 +91,7 @@ interface ContentService
      *
      * If no version number is given, the method returns the current version
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException - if the version with the given number does not exist
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the version with the given number does not exist
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version
      *
      * @param int $contentId
@@ -119,7 +119,7 @@ interface ContentService
      *
      * If no version number is given, the method returns the current version
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException - if version with the given number does not exist
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if version with the given number does not exist
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to load this version
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo $contentInfo
@@ -152,7 +152,7 @@ interface ContentService
      * If no version number is given, the method returns the current version
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given id and languages does not exist
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException If the user has no access to read content and in case of un-published content: read versions
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to read content and in case of un-published content: read versions
      *
      * @param mixed $contentId
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on
@@ -169,8 +169,8 @@ interface ContentService
      *
      * If no version is given, the method returns the current version
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException - if the content or version with the given remote id does not exist
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException If the user has no access to read content and in case of un-published content: read versions
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException if the content or version with the given remote id does not exist
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user has no access to read content and in case of un-published content: read versions
      *
      * @param string $remoteId
      * @param string[] $languages A language priority, filters returned fields and is used as prioritized language code on


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Enhance `ContentService` doc:
- Rewording (e.g.  `ContentService::loadContent`)
- Format PHPDoc (capitalize description except `@thows`, trailing period, etc.)
- Enhance a bit (add few `@see`, etc.)

PHP API Reference output:

- Preview rendering of those changes in PHP API Reference: https://ez-systems-developer-documentation--2413.com.readthedocs.build/en/2413/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html
- Compare with current 4.6.7: https://doc.ibexa.co/en/latest/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html

Notice that by inheritance, it also changes the doc for `ContentServiceDecorator`:
- https://ez-systems-developer-documentation--2413.com.readthedocs.build/en/2413/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Decorator-ContentServiceDecorator.html
- https://doc.ibexa.co/en/latest/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Decorator-ContentServiceDecorator.html

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
