### PR TITLE
IBX-8138: Fixed RepositoryFactory ambiguity in DI container

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,16 +11,6 @@ parameters:
 			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$repositoryClass with no type specified\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:buildRepository\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Repository but returns object\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
 			message: "#^Property Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:\\$policyMap type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -7792,16 +7782,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$policyMap with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$repositoryClass with no type specified\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:buildRepository\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Repository but returns object\\.$#"
 			count: 1
 			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7781,16 +7781,6 @@ parameters:
 			path: src/contracts/Variation/VariationPurger.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$policyMap with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:\\$policyMap type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\Compiler\\\\AbstractFieldTypeBasedPass\\:\\:getFieldTypeServiceIds\\(\\) return type has no value type specified in iterable type iterable\\.$#"
 			count: 1
 			path: src/lib/Base/Container/Compiler/AbstractFieldTypeBasedPass.php
@@ -20751,11 +20741,6 @@ parameters:
 			path: src/lib/Repository/RoleService.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:__construct\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/RoleService.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:buildRoleAssignmentsFromPersistence\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Repository/RoleService.php
@@ -20816,11 +20801,6 @@ parameters:
 			path: src/lib/Repository/RoleService.php
 
 		-
-			message: "#^Parameter \\#1 \\$identifier of method Ibexa\\\\Core\\\\Repository\\\\Permission\\\\LimitationService\\:\\:getLimitationType\\(\\) expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/lib/Repository/RoleService.php
-
-		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_diff expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/lib/Repository/RoleService.php
@@ -20833,11 +20813,6 @@ parameters:
 		-
 			message: "#^Parameter \\#3 \\$limitations of method Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:validatePolicy\\(\\) expects array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\Limitation\\>, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\Limitation\\> given\\.$#"
 			count: 3
-			path: src/lib/Repository/RoleService.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:\\$settings type has no value type specified in iterable type array\\.$#"
-			count: 1
 			path: src/lib/Repository/RoleService.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,36 +6,6 @@ parameters:
 			path: src/bundle/Core/ApiLoader/CacheFactory.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:__construct\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:getDefaultRepositoryAlias\\(\\) should return string\\|null but returns int\\|string\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:getRepositoryConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Property Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:\\$repositories type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Cannot call method getRepositoryConfig\\(\\) on object\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$policyMap with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -66,34 +36,9 @@ parameters:
 			path: src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Cannot call method getParameter\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Cannot call method has\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactory\\:\\:getConnection\\(\\) should return Doctrine\\\\DBAL\\\\Connection but returns object\\|null\\.$#"
 			count: 1
 			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function array_keys expects array, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactory\\:\\:registerStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageEngineFactory.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Cache\\\\Warmer\\\\ProxyCacheWarmer\\:\\:warmUp\\(\\) has parameter \\$cacheDir with no type specified\\.$#"
@@ -109,11 +54,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\CheckURLsCommand\\:\\:getTotalCount\\(\\) should return int but returns int\\|null\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CheckURLsCommand.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Driver\\\\Connection\\:\\:createQueryBuilder\\(\\)\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\CleanupVersionsCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
@@ -10839,11 +10779,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Core\\\\Helper\\\\FieldsGroups\\\\FieldsGroupsList\\:\\:getGroups\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Helper/FieldsGroups/FieldsGroupsList.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactory\\:\\:build\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
 
 		-
 			message: "#^Method Ibexa\\\\Core\\\\Helper\\\\TranslationHelper\\:\\:__construct\\(\\) has parameter \\$siteAccessesByLanguage with no value type specified in iterable type array\\.$#"
@@ -23201,96 +23136,6 @@ parameters:
 			path: tests/bundle/Core/ApiLoader/CacheFactoryTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:providerForRepositories\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetCurrentRepositoryAlias\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetDefaultRepositoryAlias\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetRepositoryConfigNotSpecifiedRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetRepositoryConfigSpecifiedRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetRepositoryConfigUndefinedRepository\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:getConfigResolverMock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:getConnectionProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:getContainerMock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnection\\(\\) has parameter \\$doctrineConnection with no type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnection\\(\\) has parameter \\$repositoryAlias with no type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnectionInvalidConnection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnectionInvalidRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:getPersistenceHandlerMock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:testBuildInvalidStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:testBuildStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:testRegisterStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ChainConfigResolverTest\\:\\:buildMock\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/bundle/Core/ChainConfigResolverTest.php
@@ -24719,11 +24564,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\DependencyInjection\\\\Stub\\\\StubYamlPolicyProvider\\:\\:\\$files type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/bundle/Core/DependencyInjection/Stub/StubYamlPolicyProvider.php
-
-		-
-			message: "#^Call to an undefined method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:method\\(\\)\\.$#"
-			count: 3
-			path: tests/bundle/Core/Entity/EntityManagerFactoryTest.php
 
 		-
 			message: "#^Property Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Entity\\\\EntityManagerFactoryTest\\:\\:\\$serviceLocator is never read, only written\\.$#"
@@ -44594,21 +44434,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\ArrayTranslatorFieldsGroupsListTest\\:\\:\\$translatorMock has no type specified\\.$#"
 			count: 1
 			path: tests/lib/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactoryTest\\:\\:testBuild\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactoryTest\\:\\:\\$repositoryConfigMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactoryTest\\:\\:\\$translatorMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Helper\\\\PreviewLocationProviderTest\\:\\:testGetPreviewLocation\\(\\) has no return type specified\\.$#"

--- a/src/bundle/Core/ApiLoader/Exception/InvalidRepositoryException.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidRepositoryException.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidRepositoryException extends InvalidArgumentException
+final class InvalidRepositoryException extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngine.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngine.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidSearchEngine extends InvalidArgumentException
+final class InvalidSearchEngine extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngineIndexer.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngineIndexer.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidSearchEngineIndexer extends InvalidArgumentException
+final class InvalidSearchEngineIndexer extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/Exception/InvalidStorageEngine.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidStorageEngine.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidStorageEngine extends InvalidArgumentException
+final class InvalidStorageEngine extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
+++ b/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
@@ -4,72 +4,42 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader;
 
-use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException;
-use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 
 /**
- * The repository configuration provider.
+ * @deprecated 5.0.0 The "\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider" class is deprecated, will be removed in 6.0.0.
+ * Inject {@see \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface} from Dependency Injection Container instead.
  */
-class RepositoryConfigurationProvider
+final class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
 {
-    private const REPOSITORY_STORAGE = 'storage';
-    private const REPOSITORY_CONNECTION = 'connection';
-    private const DEFAULT_CONNECTION_NAME = 'default';
+    private RepositoryConfigurationProviderInterface $inner;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
-
-    /** @var array */
-    private $repositories;
-
-    public function __construct(ConfigResolverInterface $configResolver, array $repositories)
+    public function __construct(RepositoryConfigurationProviderInterface $configurationProvider)
     {
-        $this->configResolver = $configResolver;
-        $this->repositories = $repositories;
+        $this->inner = $configurationProvider;
     }
 
-    /**
-     * @return array
-     *
-     * @throws \Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException
-     */
-    public function getRepositoryConfig()
+    public function getRepositoryConfig(): array
     {
-        // Takes configured repository as the reference, if it exists.
-        // If not, the first configured repository is considered instead.
-        $repositoryAlias = $this->configResolver->getParameter('repository');
-        $repositoryAlias = $repositoryAlias ?: $this->getDefaultRepositoryAlias();
-
-        if (empty($repositoryAlias) || !isset($this->repositories[$repositoryAlias])) {
-            throw new InvalidRepositoryException(
-                "Undefined Repository '$repositoryAlias'. Check if the Repository is configured in your project's ibexa.yaml."
-            );
-        }
-
-        return ['alias' => $repositoryAlias] + $this->repositories[$repositoryAlias];
+        return $this->inner->getRepositoryConfig();
     }
 
     public function getCurrentRepositoryAlias(): string
     {
-        return $this->getRepositoryConfig()['alias'];
+        return $this->inner->getCurrentRepositoryAlias();
     }
 
     public function getDefaultRepositoryAlias(): ?string
     {
-        $aliases = array_keys($this->repositories);
-
-        return array_shift($aliases);
+        return $this->inner->getDefaultRepositoryAlias();
     }
 
     public function getStorageConnectionName(): string
     {
-        $repositoryConfig = $this->getRepositoryConfig();
-
-        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION]
-            ? $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION]
-            : self::DEFAULT_CONNECTION_NAME;
+        return $this->inner->getStorageConnectionName();
     }
 }

--- a/src/bundle/Core/ApiLoader/RepositoryFactory.php
+++ b/src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -31,7 +31,13 @@ use Ibexa\Core\Search\Common\BackgroundIndexer;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-class RepositoryFactory implements ContainerAwareInterface
+/**
+ * @internal
+ *
+ * @deprecated 5.0.0 The "\Ibexa\Bundle\Core\ApiLoader\RepositoryFactory" class is deprecated, will be removed in 6.0.
+ * Use {@see \Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory instead}.
+ */
+class RepositoryFactory
 {
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
     private $configResolver;

--- a/src/bundle/Core/ApiLoader/RepositoryFactory.php
+++ b/src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Bundle\Core\ApiLoader;
 
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Persistence\Filter\Content\Handler as ContentFilteringHandler;
 use Ibexa\Contracts\Core\Persistence\Filter\Location\Handler as LocationFilteringHandler;
 use Ibexa\Contracts\Core\Persistence\Handler as PersistenceHandler;
@@ -54,11 +55,14 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \Ibexa\Contracts\Core\Repository\LanguageResolver */
     private $languageResolver;
 
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
@@ -66,6 +70,7 @@ class RepositoryFactory implements ContainerAwareInterface
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = $logger ?? new NullLogger();
+        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }
 
     /**
@@ -94,9 +99,9 @@ class RepositoryFactory implements ContainerAwareInterface
         LocationFilteringHandler $locationFilteringHandler,
         PasswordValidatorInterface $passwordValidator,
         ConfigResolverInterface $configResolver,
-        NameSchemaServiceInterface $nameSchemaService
+        NameSchemaServiceInterface $nameSchemaService,
     ): Repository {
-        $config = $this->container->get(RepositoryConfigurationProvider::class)->getRepositoryConfig();
+        $config = $this->repositoryConfigurationProvider->getRepositoryConfig();
 
         return new $this->repositoryClass(
             $persistenceHandler,

--- a/src/bundle/Core/ApiLoader/RepositoryFactory.php
+++ b/src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -25,22 +25,16 @@ use Ibexa\Core\Repository\Helper\RelationProcessor;
 use Ibexa\Core\Repository\Mapper;
 use Ibexa\Core\Repository\Permission\LimitationService;
 use Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
+use Ibexa\Core\Repository\Repository as CoreRepository;
 use Ibexa\Core\Repository\User\PasswordValidatorInterface;
 use Ibexa\Core\Search\Common\BackgroundIndexer;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 class RepositoryFactory implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
-
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
     private $configResolver;
-
-    /** @var string */
-    private $repositoryClass;
 
     /**
      * Map of system configured policies.
@@ -59,14 +53,12 @@ class RepositoryFactory implements ContainerAwareInterface
 
     public function __construct(
         ConfigResolverInterface $configResolver,
-        $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
         RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
-        $this->repositoryClass = $repositoryClass;
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = $logger ?? new NullLogger();
@@ -103,7 +95,7 @@ class RepositoryFactory implements ContainerAwareInterface
     ): Repository {
         $config = $this->repositoryConfigurationProvider->getRepositoryConfig();
 
-        return new $this->repositoryClass(
+        return new CoreRepository(
             $persistenceHandler,
             $searchHandler,
             $backgroundIndexer,

--- a/src/bundle/Core/ApiLoader/SearchEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/SearchEngineFactory.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Search\Handler as SearchHandler;
 
 /**
@@ -15,8 +16,7 @@ use Ibexa\Contracts\Core\Search\Handler as SearchHandler;
  */
 class SearchEngineFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * Hash of registered search engines.
@@ -26,7 +26,7 @@ class SearchEngineFactory
      */
     protected $searchEngines = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }

--- a/src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
+++ b/src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
@@ -9,6 +9,7 @@ namespace Ibexa\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngineIndexer;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Core\Search\Common\Indexer as SearchEngineIndexer;
 
 /**
@@ -16,8 +17,7 @@ use Ibexa\Core\Search\Common\Indexer as SearchEngineIndexer;
  */
 class SearchEngineIndexerFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * Hash of registered search engine indexers.
@@ -27,7 +27,7 @@ class SearchEngineIndexerFactory
      */
     protected $searchEngineIndexers = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }

--- a/src/bundle/Core/ApiLoader/StorageEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/StorageEngineFactory.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidStorageEngine;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Persistence\Handler as PersistenceHandler;
 
 /**
@@ -15,8 +16,7 @@ use Ibexa\Contracts\Core\Persistence\Handler as PersistenceHandler;
  */
 class StorageEngineFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * Hash of registered storage engines.
@@ -24,9 +24,9 @@ class StorageEngineFactory
      *
      * @var \Ibexa\Contracts\Core\Persistence\Handler[]
      */
-    protected $storageEngines = [];
+    protected array $storageEngines = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }
@@ -35,11 +35,8 @@ class StorageEngineFactory
      * Registers $persistenceHandler as a valid storage engine, with identifier $storageEngineIdentifier.
      *
      * Note: It is strongly recommenced to register a lazy persistent handler.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Handler $persistenceHandler
-     * @param string $storageEngineIdentifier
      */
-    public function registerStorageEngine(PersistenceHandler $persistenceHandler, $storageEngineIdentifier)
+    public function registerStorageEngine(PersistenceHandler $persistenceHandler, string $storageEngineIdentifier): void
     {
         $this->storageEngines[$storageEngineIdentifier] = $persistenceHandler;
     }
@@ -47,7 +44,7 @@ class StorageEngineFactory
     /**
      * @return \Ibexa\Contracts\Core\Persistence\Handler[]
      */
-    public function getStorageEngines()
+    public function getStorageEngines(): array
     {
         return $this->storageEngines;
     }
@@ -55,7 +52,7 @@ class StorageEngineFactory
     /**
      * Builds storage engine identified by $storageEngineIdentifier (the "alias" attribute in the service tag).
      *
-     * @throws \Ibexa\Bundle\Core\ApiLoader\Exception\InvalidStorageEngine
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     public function buildStorageEngine(): PersistenceHandler
     {
@@ -73,9 +70,9 @@ class StorageEngineFactory
 
         if (!isset($this->storageEngines[$storageEngineAlias])) {
             throw new InvalidStorageEngine(
-                "Invalid storage engine '{$storageEngineAlias}'. " .
+                "Invalid storage engine '$storageEngineAlias'. " .
                 'Could not find any service tagged with ibexa.storage ' .
-                "with alias {$storageEngineAlias}."
+                "with alias $storageEngineAlias."
             );
         }
 

--- a/src/bundle/Core/Command/CleanupVersionsCommand.php
+++ b/src/bundle/Core/Command/CleanupVersionsCommand.php
@@ -9,11 +9,10 @@ namespace Ibexa\Bundle\Core\Command;
 
 use Doctrine\DBAL\Connection;
 use Exception;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
-use PDO;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -44,18 +43,16 @@ EOT;
         self::VERSION_PUBLISHED => VersionInfo::STATUS_PUBLISHED,
     ];
 
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /** @var \Doctrine\DBAL\Driver\Connection */
     private $connection;
 
     public function __construct(
         Repository $repository,
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         Connection $connection
     ) {
         $this->repository = $repository;

--- a/src/bundle/Core/Command/CleanupVersionsCommand.php
+++ b/src/bundle/Core/Command/CleanupVersionsCommand.php
@@ -47,8 +47,7 @@ EOT;
 
     private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    /** @var \Doctrine\DBAL\Driver\Connection */
-    private $connection;
+    private Connection $connection;
 
     public function __construct(
         Repository $repository,
@@ -272,9 +271,10 @@ EOT
                 )->setParameter(':contentTypes', $excludedContentTypes, Connection::PARAM_STR_ARRAY);
         }
 
+        /** @var \Doctrine\DBAL\ForwardCompatibility\Result<int> $stmt */
         $stmt = $query->execute();
 
-        return $stmt->fetchAll(PDO::FETCH_COLUMN);
+        return $stmt->fetchFirstColumn();
     }
 
     /**

--- a/src/bundle/Core/Entity/EntityManagerFactory.php
+++ b/src/bundle/Core/Entity/EntityManagerFactory.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\Core\Entity;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
@@ -17,8 +17,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class EntityManagerFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /** @var \Symfony\Component\DependencyInjection\ServiceLocator */
     private $serviceLocator;
@@ -30,7 +29,7 @@ class EntityManagerFactory
     private $entityManagers;
 
     public function __construct(
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         ServiceLocator $serviceLocator,
         string $defaultConnection,
         array $entityManagers

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -12,11 +12,11 @@ services:
     # API
     Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
         arguments:
-            - '@ibexa.config.resolver'
-            - Ibexa\Core\Repository\Repository
-            - '%ibexa.api.role.policy_map%'
-            - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
-            - "@?logger"
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $policyMap: '%ibexa.api.role.policy_map%'
+            $languageResolver: '@Ibexa\Contracts\Core\Repository\LanguageResolver'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
+            $logger: "@?logger"
         calls:
             - [setContainer, ["@service_container"]]
 

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -17,8 +17,6 @@ services:
             $languageResolver: '@Ibexa\Contracts\Core\Repository\LanguageResolver'
             $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
             $logger: "@?logger"
-        calls:
-            - [setContainer, ["@service_container"]]
 
     Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory:
         arguments:

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -11,6 +11,10 @@ parameters:
 services:
     # API
     Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
+        deprecated:
+            package: 'ibexa/core'
+            version: '5.0'
+            message: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated and will be removed in 6.0. Use Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory instead'
         arguments:
             $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
             $policyMap: '%ibexa.api.role.policy_map%'

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -21,28 +21,24 @@ services:
             - [setContainer, ["@service_container"]]
 
     Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory:
-        class: Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     ibexa.api.persistence_handler:
         #To disable cache, switch alias to Ibexa\Contracts\Core\Persistence\Handler
         alias: Ibexa\Core\Persistence\Cache\Handler
 
     Ibexa\Contracts\Core\Persistence\Handler:
-        class: Ibexa\Contracts\Core\Persistence\Handler
         factory: ['@Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory', buildStorageEngine]
         public: false
 
     Ibexa\Bundle\Core\ApiLoader\SearchEngineFactory:
-        class: Ibexa\Bundle\Core\ApiLoader\SearchEngineFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Bundle\Core\ApiLoader\SearchEngineIndexerFactory:
-            class: Ibexa\Bundle\Core\ApiLoader\SearchEngineIndexerFactory
             arguments:
-                - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+                $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     ibexa.spi.search:
         alias: Ibexa\Contracts\Core\Search\VersatileHandler

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -232,9 +232,8 @@ services:
             - "@translator"
 
     Ibexa\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory:
-        class: Ibexa\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $configProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Core\QueryType\QueryParameterContentViewQueryTypeMapper:
         class: Ibexa\Core\QueryType\QueryParameterContentViewQueryTypeMapper
@@ -316,11 +315,10 @@ services:
             - { name: console.command }
 
     Ibexa\Bundle\Core\Command\CleanupVersionsCommand:
-        class: Ibexa\Bundle\Core\Command\CleanupVersionsCommand
         arguments:
-            - '@Ibexa\Core\Event\Repository'
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
-            - '@ibexa.persistence.connection'
+            $repository: '@Ibexa\Core\Event\Repository'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
+            $connection: '@ibexa.persistence.connection'
         tags:
             - { name: console.command }
 
@@ -365,7 +363,7 @@ services:
     ibexa.doctrine.orm.entity_manager_factory:
         class: Ibexa\Bundle\Core\Entity\EntityManagerFactory
         arguments:
-            $repositoryConfigurationProvider: '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
             $defaultConnection: '%doctrine.default_connection%'
             $entityManagers: '%doctrine.entity_managers%'
 

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -1,14 +1,9 @@
 services:
-    Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface:
-        alias: Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
-
-    Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider:
-        arguments:
-            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
-            $repositories: '%ibexa.repositories%'
-
     Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider:
-        deprecated: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated, will be removed in 6.0. Use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface instead'
+        deprecated:
+            package: 'ibexa/core'
+            version: '5.0'
+            message: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated and will be removed in 6.0. Use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface instead'
         arguments:
             $configurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -1,17 +1,22 @@
 services:
-    Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider:
-        public: true # @todo should be private
-        class: Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider
+    Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface:
+        alias: Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
+
+    Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider:
         arguments:
-            - '@ibexa.config.resolver'
-            - '%ibexa.repositories%'
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $repositories: '%ibexa.repositories%'
+
+    Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider:
+        deprecated: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated, will be removed in 6.0. Use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface instead'
+        arguments:
+            $configurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory:
-        class: Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
         calls:
-            - [setContainer, ["@service_container"]]
+            - [setContainer, ['@service_container']]
 
     ibexa.persistence.connection:
         public: true # @todo should be private

--- a/src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
+++ b/src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
@@ -7,7 +7,7 @@
 
 namespace Ibexa\Bundle\LegacySearchEngine\ApiLoader;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
@@ -16,10 +16,9 @@ class ConnectionFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    protected $repositoryConfigurationProvider;
+    protected RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }

--- a/src/bundle/LegacySearchEngine/Resources/config/services.yml
+++ b/src/bundle/LegacySearchEngine/Resources/config/services.yml
@@ -1,10 +1,9 @@
 services:
     Ibexa\Bundle\LegacySearchEngine\ApiLoader\ConnectionFactory:
-        class: Ibexa\Bundle\LegacySearchEngine\ApiLoader\ConnectionFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
         calls:
-            - [setContainer, ["@service_container"]]
+            - [setContainer, ['@service_container']]
 
     ibexa.api.search_engine.legacy.connection:
         class: Doctrine\DBAL\Connection

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -8,8 +8,8 @@
 namespace Ibexa\Bundle\RepositoryInstaller\Command;
 
 use Doctrine\DBAL\Connection;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Bundle\Core\Command\BackwardCompatibleCommand;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -38,8 +38,7 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
     /** @var \Ibexa\Bundle\RepositoryInstaller\Installer\Installer[] */
     private $installers = [];
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     public const EXIT_GENERAL_DATABASE_ERROR = 4;
     public const EXIT_PARAMETERS_NOT_FOUND = 5;
@@ -51,7 +50,7 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
         array $installers,
         CacheItemPoolInterface $cachePool,
         string $environment,
-        RepositoryConfigurationProvider $repositoryConfigurationProvider
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider
     ) {
         $this->connection = $connection;
         $this->installers = $installers;

--- a/src/bundle/RepositoryInstaller/Resources/config/services.yml
+++ b/src/bundle/RepositoryInstaller/Resources/config/services.yml
@@ -22,7 +22,7 @@ services:
             $installers: []
             $cachePool: '@ibexa.cache_pool'
             $environment: "%kernel.environment%"
-            $repositoryConfigurationProvider: '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
         tags:
             - { name: console.command }
 

--- a/src/contracts/Container/ApiLoader/RepositoryConfigurationProviderInterface.php
+++ b/src/contracts/Container/ApiLoader/RepositoryConfigurationProviderInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Container\ApiLoader;
+
+/**
+ * @phpstan-type TRepositoryStorageConfiguration array{engine: string, connection: string, config?: array<string, mixed>}
+ * @phpstan-type TRepositorySearchConfiguration array{engine: string, connection: string}
+ * @phpstan-type TRepositoryConfiguration array{
+ *     alias: string,
+ *     storage: TRepositoryStorageConfiguration,
+ *     search: TRepositorySearchConfiguration,
+ *     fields_groups: array{default: string, list: string[]},
+ *     options: array<string, mixed>
+ * }
+ */
+interface RepositoryConfigurationProviderInterface
+{
+    /**
+     * @phpstan-return TRepositoryConfiguration
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getRepositoryConfig(): array;
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getCurrentRepositoryAlias(): string;
+
+    public function getDefaultRepositoryAlias(): ?string;
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getStorageConnectionName(): string;
+}

--- a/src/contracts/Repository/RoleService.php
+++ b/src/contracts/Repository/RoleService.php
@@ -23,6 +23,8 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 
 /**
  * This service provides methods for managing Roles and Policies.
+ *
+ * @phpstan-type TPolicyMap array<string, array<string, array<string, boolean|null>>>
  */
 interface RoleService
 {

--- a/src/lib/Base/Container/ApiLoader/RepositoryConfigurationProvider.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryConfigurationProvider.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Base\Container\ApiLoader;
+
+use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+
+/**
+ * @phpstan-import-type TRepositoryConfiguration from RepositoryConfigurationProviderInterface
+ * @phpstan-import-type TRepositoryStorageConfiguration from RepositoryConfigurationProviderInterface
+ * @phpstan-import-type TRepositorySearchConfiguration from RepositoryConfigurationProviderInterface
+ *
+ * @phpstan-type TRepositoryListItemConfiguration array{
+ *      storage: TRepositoryStorageConfiguration,
+ *      search: TRepositorySearchConfiguration,
+ *      fields_groups: array{default: string, list: string[]},
+ *      options: array<string, mixed>
+ * }
+ * @phpstan-type TRepositoryListConfiguration array<string, TRepositoryListItemConfiguration>
+ */
+final class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
+{
+    private const string REPOSITORY_STORAGE = 'storage';
+    private const string REPOSITORY_CONNECTION = 'connection';
+    private const string DEFAULT_CONNECTION_NAME = 'default';
+
+    private ConfigResolverInterface $configResolver;
+
+    /** @phpstan-var TRepositoryListConfiguration */
+    private array $repositories;
+
+    /**
+     * @phpstan-param TRepositoryListConfiguration $repositories
+     */
+    public function __construct(ConfigResolverInterface $configResolver, array $repositories)
+    {
+        $this->configResolver = $configResolver;
+        $this->repositories = $repositories;
+    }
+
+    public function getRepositoryConfig(): array
+    {
+        // Takes configured repository as the reference, if it exists.
+        // If not, the first configured repository is considered instead.
+        /** @var string|null $repositoryAlias */
+        $repositoryAlias = $this->configResolver->getParameter('repository');
+        $repositoryAlias = $repositoryAlias ?? $this->getDefaultRepositoryAlias();
+
+        if (empty($repositoryAlias) || !isset($this->repositories[$repositoryAlias])) {
+            throw new InvalidRepositoryException(
+                "Undefined Repository '$repositoryAlias'. Check if the Repository is configured in your project's ibexa.yaml."
+            );
+        }
+
+        return ['alias' => $repositoryAlias] + $this->repositories[$repositoryAlias];
+    }
+
+    public function getCurrentRepositoryAlias(): string
+    {
+        return $this->getRepositoryConfig()['alias'];
+    }
+
+    public function getDefaultRepositoryAlias(): ?string
+    {
+        $aliases = array_keys($this->repositories);
+
+        return array_shift($aliases);
+    }
+
+    public function getStorageConnectionName(): string
+    {
+        $repositoryConfig = $this->getRepositoryConfig();
+
+        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION] ?? self::DEFAULT_CONNECTION_NAME;
+    }
+}

--- a/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
@@ -25,17 +25,15 @@ use Ibexa\Core\Repository\Helper\RelationProcessor;
 use Ibexa\Core\Repository\Mapper;
 use Ibexa\Core\Repository\Permission\LimitationService;
 use Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
+use Ibexa\Core\Repository\Repository as CoreRepository;
 use Ibexa\Core\Repository\User\PasswordValidatorInterface;
 use Ibexa\Core\Search\Common\BackgroundIndexer;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class RepositoryFactory implements ContainerAwareInterface
+final class RepositoryFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
-
-    /** @var string */
-    private $repositoryClass;
 
     /**
      * Policies map.
@@ -48,11 +46,9 @@ class RepositoryFactory implements ContainerAwareInterface
     private $languageResolver;
 
     public function __construct(
-        $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver
     ) {
-        $this->repositoryClass = $repositoryClass;
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
     }
@@ -88,7 +84,7 @@ class RepositoryFactory implements ContainerAwareInterface
         NameSchemaServiceInterface $nameSchemaService,
         array $languages
     ): Repository {
-        return new $this->repositoryClass(
+        return new CoreRepository(
             $persistenceHandler,
             $searchHandler,
             $backgroundIndexer,

--- a/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
@@ -35,22 +35,23 @@ use Psr\Log\NullLogger;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type TPolicyMap from \Ibexa\Contracts\Core\Repository\RoleService
  */
 final class RepositoryFactory implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    /**
-     * Policies map.
-     *
-     * @var array
-     */
+    /** @phpstan-var TPolicyMap */
     private array $policyMap;
 
     private LanguageResolver $languageResolver;
 
     private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
+    /**
+     * @phpstan-param TPolicyMap $policyMap
+     */
     public function __construct(
         array $policyMap,
         LanguageResolver $languageResolver,

--- a/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
@@ -28,19 +28,15 @@ use Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use Ibexa\Core\Repository\Repository as CoreRepository;
 use Ibexa\Core\Repository\User\PasswordValidatorInterface;
 use Ibexa\Core\Search\Common\BackgroundIndexer;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-final class RepositoryFactory implements ContainerAwareInterface
+final class RepositoryFactory
 {
-    use ContainerAwareTrait;
-
     /**
      * Policies map.
      *
      * @var array
      */
-    protected $policyMap = [];
+    private $policyMap = [];
 
     /** @var \Ibexa\Contracts\Core\Repository\LanguageResolver */
     private $languageResolver;

--- a/src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
+++ b/src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
@@ -7,7 +7,7 @@
 
 namespace Ibexa\Core\Helper\FieldsGroups;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -15,15 +15,17 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class RepositoryConfigFieldsGroupsListFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $configProvider;
+    private RepositoryConfigurationProviderInterface $configProvider;
 
-    public function __construct(RepositoryConfigurationProvider $configProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $configProvider)
     {
         $this->configProvider = $configProvider;
     }
 
-    public function build(TranslatorInterface $translator)
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function build(TranslatorInterface $translator): FieldsGroupsList
     {
         $repositoryConfig = $this->configProvider->getRepositoryConfig();
 

--- a/src/lib/Repository/RoleService.php
+++ b/src/lib/Repository/RoleService.php
@@ -42,6 +42,8 @@ use Ibexa\Core\Repository\Values\User\RoleCreateStruct;
 
 /**
  * This service provides methods for managing Roles and Policies.
+ *
+ * @phpstan-import-type TPolicyMap from \Ibexa\Contracts\Core\Repository\RoleService
  */
 class RoleService implements RoleServiceInterface
 {
@@ -57,8 +59,8 @@ class RoleService implements RoleServiceInterface
     /** @var \Ibexa\Core\Repository\Mapper\RoleDomainMapper */
     protected $roleDomainMapper;
 
-    /** @var array */
-    protected $settings;
+    /** @phpstan-var array{policyMap: TPolicyMap}|array{} */
+    protected array $settings;
 
     /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
     private $permissionResolver;
@@ -66,11 +68,7 @@ class RoleService implements RoleServiceInterface
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Repository $repository
-     * @param \Ibexa\Contracts\Core\Persistence\User\Handler $userHandler
-     * @param \Ibexa\Core\Repository\Permission\LimitationService $limitationService
-     * @param \Ibexa\Core\Repository\Mapper\RoleDomainMapper $roleDomainMapper
-     * @param array $settings
+     * @phpstan-param array{policyMap: TPolicyMap}|array{} $settings
      */
     public function __construct(
         RepositoryInterface $repository,

--- a/src/lib/Resources/settings/repository/autowire.yml
+++ b/src/lib/Resources/settings/repository/autowire.yml
@@ -1,4 +1,6 @@
 services:
+    Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface: '@Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider'
+
     Ibexa\Contracts\Core\Repository\Repository: '@ibexa.api.repository'
 
     Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface: '@ibexa.config.resolver'

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -9,7 +9,6 @@ services:
     Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
         class: Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory
         arguments:
-            - Ibexa\Core\Repository\Repository
             - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
         calls:

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -13,33 +13,33 @@ services:
 
     Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory:
         arguments:
-            - '%ibexa.api.role.policy_map%'
-            - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
+            $policyMap: '%ibexa.api.role.policy_map%'
+            $languageResolver: '@Ibexa\Contracts\Core\Repository\LanguageResolver'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Core\Repository\Repository:
         factory: ['@Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory', buildRepository]
         arguments:
-            - '@ibexa.api.persistence_handler'
-            - '@ibexa.spi.search'
-            - '@Ibexa\Bundle\Core\EventListener\BackgroundIndexingTerminateListener'
-            - '@Ibexa\Core\Repository\Helper\RelationProcessor'
-            - '@Ibexa\Core\FieldType\FieldTypeRegistry'
-            - '@Ibexa\Core\Repository\User\PasswordHashService'
-            - '@Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
-            - '@Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactory'
-            - '@Ibexa\Core\Repository\Mapper\ContentDomainMapper'
-            - '@Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper'
-            - '@Ibexa\Core\Repository\Mapper\RoleDomainMapper'
-            - '@Ibexa\Core\Repository\Mapper\ContentMapper'
-            - '@Ibexa\Contracts\Core\Repository\Validator\ContentValidator'
-            - '@Ibexa\Core\Repository\Permission\LimitationService'
-            - '@Ibexa\Contracts\Core\Repository\PermissionService'
-            - '@Ibexa\Contracts\Core\Persistence\Filter\Content\Handler'
-            - '@Ibexa\Contracts\Core\Persistence\Filter\Location\Handler'
-            - '@Ibexa\Core\Repository\User\PasswordValidatorInterface'
-            - '@ibexa.config.resolver'
-            - '@Ibexa\Contracts\Core\Repository\NameSchema\NameSchemaServiceInterface'
-            - '%languages%'
+            $persistenceHandler: '@ibexa.api.persistence_handler'
+            $searchHandler: '@ibexa.spi.search'
+            $backgroundIndexer: '@Ibexa\Bundle\Core\EventListener\BackgroundIndexingTerminateListener'
+            $relationProcessor: '@Ibexa\Core\Repository\Helper\RelationProcessor'
+            $fieldTypeRegistry: '@Ibexa\Core\FieldType\FieldTypeRegistry'
+            $passwordHashService: '@Ibexa\Core\Repository\User\PasswordHashService'
+            $thumbnailStrategy: '@Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
+            $proxyDomainMapperFactory: '@Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactory'
+            $contentDomainMapper: '@Ibexa\Core\Repository\Mapper\ContentDomainMapper'
+            $contentTypeDomainMapper: '@Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper'
+            $roleDomainMapper: '@Ibexa\Core\Repository\Mapper\RoleDomainMapper'
+            $contentMapper: '@Ibexa\Core\Repository\Mapper\ContentMapper'
+            $contentValidator: '@Ibexa\Contracts\Core\Repository\Validator\ContentValidator'
+            $limitationService: '@Ibexa\Core\Repository\Permission\LimitationService'
+            $permissionService: '@Ibexa\Contracts\Core\Repository\PermissionService'
+            $contentFilteringHandler: '@Ibexa\Contracts\Core\Persistence\Filter\Content\Handler'
+            $locationFilteringHandler: '@Ibexa\Contracts\Core\Persistence\Filter\Location\Handler'
+            $passwordValidator: '@Ibexa\Core\Repository\User\PasswordValidatorInterface'
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $nameSchemaService: '@Ibexa\Contracts\Core\Repository\NameSchema\NameSchemaServiceInterface'
 
     Ibexa\Core\Repository\ContentService:
         class: Ibexa\Core\Repository\ContentService

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -6,14 +6,18 @@ parameters:
 
     # intentionally defined class parameter to be used by the Repository Factory
 services:
-    Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
-        class: Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory
+    Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider:
+        arguments:
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $repositories: '%ibexa.repositories%'
+
+    Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory:
         arguments:
             - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
 
     Ibexa\Core\Repository\Repository:
-        factory: ['@Ibexa\Bundle\Core\ApiLoader\RepositoryFactory', buildRepository]
+        factory: ['@Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory', buildRepository]
         arguments:
             - '@ibexa.api.persistence_handler'
             - '@ibexa.spi.search'

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -11,8 +11,6 @@ services:
         arguments:
             - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
-        calls:
-            - [setContainer, ["@service_container"]]
 
     Ibexa\Core\Repository\Repository:
         factory: ['@Ibexa\Bundle\Core\ApiLoader\RepositoryFactory', buildRepository]

--- a/tests/bundle/Core/ApiLoader/BaseRepositoryConfigurationProviderTestCase.php
+++ b/tests/bundle/Core/ApiLoader/BaseRepositoryConfigurationProviderTestCase.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Core\ApiLoader;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type TRepositoryListItemConfiguration from \Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
+ */
+abstract class BaseRepositoryConfigurationProviderTestCase extends TestCase
+{
+    protected const string MAIN_REPOSITORY_ALIAS = 'main';
+    protected const array MAIN_REPOSITORY_CONFIG = [
+        'storage' => ['engine' => 'foo', 'connection' => 'some_connection'],
+        'search' => ['engine' => 'foo_search', 'connection' => 'some_connection'],
+        'fields_groups' => ['default' => 'meta', 'list' => ['content', 'meta']],
+        'options' => [],
+    ];
+    protected const array REPOSITORIES_CONFIG = [
+        self::MAIN_REPOSITORY_ALIAS => self::MAIN_REPOSITORY_CONFIG,
+        'another' => [
+            'storage' => ['engine' => 'bar', 'connection' => 'bar_connection'],
+            'search' => ['engine' => 'bar_search', 'connection' => 'bar_search_connection'],
+            'fields_groups' => ['default' => 'content', 'list' => ['meta', 'content']],
+            'options' => [],
+        ],
+    ];
+
+    /**
+     * @phpstan-return TRepositoryListItemConfiguration
+     */
+    protected function buildNormalizedSingleRepositoryConfig(
+        string $storageEngine,
+        string $storageConnection = 'default_connection'
+    ): array {
+        return [
+                'storage' => [
+                    'engine' => $storageEngine,
+                    'connection' => $storageConnection,
+                ],
+            ] + self::MAIN_REPOSITORY_CONFIG;
+    }
+}

--- a/tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
+++ b/tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
@@ -4,74 +4,67 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
-use PHPUnit\Framework\TestCase;
+use Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider;
 
-class RepositoryConfigurationProviderTest extends TestCase
+/**
+ * @covers \Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
+ *
+ * @phpstan-import-type TRepositoryListConfiguration from \Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
+ */
+final class RepositoryConfigurationProviderTest extends BaseRepositoryConfigurationProviderTestCase
 {
-    public function testGetRepositoryConfigSpecifiedRepository()
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testGetRepositoryConfigSpecifiedRepository(): void
     {
         $configResolver = $this->getConfigResolverMock();
-        $repositoryAlias = 'main';
-        $repositoryConfig = [
-            'engine' => 'foo',
-            'connection' => 'some_connection',
-        ];
-        $repositories = [
-            $repositoryAlias => $repositoryConfig,
-            'another' => [
-                'engine' => 'bar',
-            ],
-        ];
-        $provider = new RepositoryConfigurationProvider($configResolver, $repositories);
+        // providing normalized configuration, expected at this point
+        // see \Ibexa\Bundle\Core\DependencyInjection\Configuration::addRepositoriesSection for more details
+        $provider = new RepositoryConfigurationProvider($configResolver, self::REPOSITORIES_CONFIG);
 
         $configResolver
-            ->expects(self::once())
             ->method('getParameter')
             ->with('repository')
-            ->will(self::returnValue($repositoryAlias));
+            ->willReturn(self::MAIN_REPOSITORY_ALIAS);
 
         self::assertSame(
-            ['alias' => $repositoryAlias] + $repositoryConfig,
+            ['alias' => self::MAIN_REPOSITORY_ALIAS] + self::MAIN_REPOSITORY_CONFIG,
             $provider->getRepositoryConfig()
         );
     }
 
-    public function testGetRepositoryConfigNotSpecifiedRepository()
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testGetRepositoryConfigNotSpecifiedRepository(): void
     {
         $configResolver = $this->getConfigResolverMock();
-        $repositoryAlias = 'main';
-        $repositoryConfig = [
-            'engine' => 'foo',
-            'connection' => 'some_connection',
-        ];
-        $repositories = [
-            $repositoryAlias => $repositoryConfig,
-            'another' => [
-                'engine' => 'bar',
-            ],
-        ];
-        $provider = new RepositoryConfigurationProvider($configResolver, $repositories);
+        $provider = new RepositoryConfigurationProvider($configResolver, self::REPOSITORIES_CONFIG);
 
         $configResolver
-            ->expects(self::once())
             ->method('getParameter')
             ->with('repository')
-            ->will(self::returnValue(null));
+            ->willReturn(null);
 
         self::assertSame(
-            ['alias' => $repositoryAlias] + $repositoryConfig,
+            ['alias' => self::MAIN_REPOSITORY_ALIAS] + self::MAIN_REPOSITORY_CONFIG,
             $provider->getRepositoryConfig()
         );
     }
 
     /**
      * @dataProvider providerForRepositories
+     *
+     * @phpstan-param TRepositoryListConfiguration $repositories
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     public function testGetRepositoryConfigUndefinedRepository(array $repositories): void
     {
@@ -80,17 +73,20 @@ class RepositoryConfigurationProviderTest extends TestCase
         $configResolver = $this->getConfigResolverMock();
 
         $configResolver
-            ->expects(self::once())
             ->method('getParameter')
             ->with('repository')
-            ->will(self::returnValue('undefined_repository'));
+            ->willReturn('undefined_repository');
 
         $provider = new RepositoryConfigurationProvider($configResolver, $repositories);
-        $provider->getRepositoryConfig();
+        self::assertSame([], $provider->getRepositoryConfig());
     }
 
     /**
      * @dataProvider providerForRepositories
+     *
+     * @phpstan-param TRepositoryListConfiguration $repositories
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     public function testGetDefaultRepositoryAlias(array $repositories): void
     {
@@ -99,11 +95,13 @@ class RepositoryConfigurationProviderTest extends TestCase
         $provider = new RepositoryConfigurationProvider($configResolver, $repositories);
         $provider->getRepositoryConfig();
 
-        self::assertSame('first', $provider->getDefaultRepositoryAlias());
+        self::assertSame(self::MAIN_REPOSITORY_ALIAS, $provider->getDefaultRepositoryAlias());
     }
 
     /**
      * @dataProvider providerForRepositories
+     *
+     * @phpstan-param TRepositoryListConfiguration $repositories
      */
     public function testGetCurrentRepositoryAlias(array $repositories): void
     {
@@ -112,29 +110,23 @@ class RepositoryConfigurationProviderTest extends TestCase
         $provider = new RepositoryConfigurationProvider($configResolver, $repositories);
         $provider->getRepositoryConfig();
 
-        self::assertSame('first', $provider->getCurrentRepositoryAlias());
+        self::assertSame(self::MAIN_REPOSITORY_ALIAS, $provider->getCurrentRepositoryAlias());
     }
 
+    /**
+     * @phpstan-return list<list<TRepositoryListConfiguration>> $repositories
+     */
     public function providerForRepositories(): array
     {
         return [
-            [
-                [
-                    'first' => [
-                        'engine' => 'foo',
-                    ],
-                    'second' => [
-                        'engine' => 'bar',
-                    ],
-                ],
-            ],
+            [self::REPOSITORIES_CONFIG],
         ];
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
+     * @return \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getConfigResolverMock()
+    protected function getConfigResolverMock(): ConfigResolverInterface
     {
         return $this->createMock(ConfigResolverInterface::class);
     }

--- a/tests/bundle/Core/DependencyInjection/Compiler/EntityManagerFactoryServiceLocatorPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/EntityManagerFactoryServiceLocatorPassTest.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Compiler;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\EntityManagerFactoryServiceLocatorPass;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,7 +25,7 @@ class EntityManagerFactoryServiceLocatorPassTest extends AbstractCompilerPassTes
         $this->setDefinition(
             'ibexa.doctrine.orm.entity_manager_factory',
             new Definition(null, [
-                '$repositoryConfigurationProvider' => new Reference(RepositoryConfigurationProvider::class),
+                '$repositoryConfigurationProvider' => new Reference(RepositoryConfigurationProviderInterface::class),
                 '$defaultConnection' => '%doctrine.default_connection%',
                 '$entityManagers' => '%doctrine.entity_managers%',
             ])

--- a/tests/bundle/Core/Entity/EntityManagerFactoryTest.php
+++ b/tests/bundle/Core/Entity/EntityManagerFactoryTest.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Bundle\Core\Entity;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Bundle\Core\Entity\EntityManagerFactory;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -25,8 +25,8 @@ class EntityManagerFactoryTest extends TestCase
         'ibexa_invalid' => self::INVALID_ENTITY_MANAGER,
     ];
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    /** @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /** @var \Doctrine\ORM\EntityManagerInterface */
     private $entityManager;
@@ -133,11 +133,11 @@ class EntityManagerFactoryTest extends TestCase
     }
 
     /**
-     * @return \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider|\PHPUnit\Framework\MockObject\MockObject
+     * @return \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface&\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getRepositoryConfigurationProvider(): RepositoryConfigurationProvider
+    protected function getRepositoryConfigurationProvider(): RepositoryConfigurationProviderInterface
     {
-        return $this->createMock(RepositoryConfigurationProvider::class);
+        return $this->createMock(RepositoryConfigurationProviderInterface::class);
     }
 
     /**

--- a/tests/integration/Core/Resources/settings/integration_legacy.yml
+++ b/tests/integration/Core/Resources/settings/integration_legacy.yml
@@ -14,6 +14,22 @@ parameters:
 
     ibexa.site_access.config.default.user_content_type_identifier: ['user']
 
+    ibexa.repositories:
+        default:
+            storage: ~
+            search:
+                engine: '%env(SEARCH_ENGINE)%'
+                connection: default
+            fields_groups:
+                list: [content, metadata]
+                default: content
+            options:
+                default_version_archive_limit: 5
+                remove_archived_versions_on_publish: true
+
+    ibexa.site_access.config.default.repository: default
+    ibexa.site_access.config.default.languages: '%languages%'
+
 services:
     Ibexa\Core\FieldType\ImageAsset\AssetMapper:
         arguments:

--- a/tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
+++ b/tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
@@ -7,18 +7,19 @@
 
 namespace Ibexa\Tests\Core\Helper\FieldsGroups;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
 {
-    private $repositoryConfigMock;
+    private RepositoryConfigurationProviderInterface & MockObject $repositoryConfigMock;
 
-    private $translatorMock;
+    private TranslatorInterface & MockObject $translatorMock;
 
-    public function testBuild()
+    public function testBuild(): void
     {
         $this->getRepositoryConfigMock()
             ->expects(self::once())
@@ -26,9 +27,8 @@ class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
             ->willReturn(['fields_groups' => ['list' => ['group_a', 'group_b'], 'default' => 'group_a']]);
 
         $this->getTranslatorMock()
-            ->expects(self::any())
             ->method('trans')
-            ->will(self::returnArgument(0));
+            ->willReturnArgument(0);
 
         $factory = new RepositoryConfigFieldsGroupsListFactory($this->getRepositoryConfigMock());
         $list = $factory->build($this->getTranslatorMock());
@@ -37,22 +37,16 @@ class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
         self::assertEquals('group_a', $list->getDefaultGroup());
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider
-     */
-    protected function getRepositoryConfigMock()
+    protected function getRepositoryConfigMock(): RepositoryConfigurationProviderInterface & MockObject
     {
         if (!isset($this->repositoryConfigMock)) {
-            $this->repositoryConfigMock = $this->createMock(RepositoryConfigurationProvider::class);
+            $this->repositoryConfigMock = $this->createMock(RepositoryConfigurationProviderInterface::class);
         }
 
         return $this->repositoryConfigMock;
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Symfony\Contracts\Translation\TranslatorInterface
-     */
-    protected function getTranslatorMock()
+    protected function getTranslatorMock(): TranslatorInterface & MockObject
     {
         if (!isset($this->translatorMock)) {
             $this->translatorMock = $this->createMock(TranslatorInterface::class);


### PR DESCRIPTION
| :ticket: Issue | Related to IBX-8138 |
|----------------|-----------|

#### Related PRs:

- https://github.com/ibexa/core/pull/383
- https://github.com/ibexa/core/pull/384

#### Description:

Recommended to do prior the actual Symfony 5x Rector refactoring.
More details TBD - maybe will be split into 2 PRs.

List of changes:

- **Changed Core Bundle ApiLoader Exception to be Repository Exceptions**
- **Extracted an interface from RepositoryConfigurationProvider**
- **Fixed strict type of CleanupVersionsCommand::$connection property**
- **[Tests] Aligned tests with  RepositoryConfigurationProvider changes**
- **[PHPStan] Aligned baseline with the changes**
- **Dropped support for dynamic Core Repository class in RepositoryFactory**
- **Made RepositoryFactory not Container-aware**
- **Deprecated Core Bundle RepositoryFactory in favor of Repository's one**
- **[PHPStan] Aligned baseline with the changes**
- **Combined Bundle and core RepositoryFactory into one**
- **[Tests] Added needed RepositoryFactory configuration to test setup**


#### For QA:

Regression tests should be enough.
