### PR TITLE
IBX-8399: Moved RepositoryConfigurationProvider to Repository layer

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,36 +6,6 @@ parameters:
 			path: src/bundle/Core/ApiLoader/CacheFactory.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:__construct\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:getDefaultRepositoryAlias\\(\\) should return string\\|null but returns int\\|string\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:getRepositoryConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Property Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:\\$repositories type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Cannot call method getRepositoryConfig\\(\\) on object\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$policyMap with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -66,36 +36,6 @@ parameters:
 			path: src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
 
 		-
-			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Cannot call method getParameter\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Cannot call method has\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactory\\:\\:getConnection\\(\\) should return Doctrine\\\\DBAL\\\\Connection but returns object\\|null\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of function array_keys expects array, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageConnectionFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactory\\:\\:registerStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/StorageEngineFactory.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Cache\\\\Warmer\\\\ProxyCacheWarmer\\:\\:warmUp\\(\\) has parameter \\$cacheDir with no type specified\\.$#"
 			count: 1
 			path: src/bundle/Core/Cache/Warmer/ProxyCacheWarmer.php
@@ -109,11 +49,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\CheckURLsCommand\\:\\:getTotalCount\\(\\) should return int but returns int\\|null\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CheckURLsCommand.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Driver\\\\Connection\\:\\:createQueryBuilder\\(\\)\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\Command\\\\CleanupVersionsCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
@@ -10839,11 +10774,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Core\\\\Helper\\\\FieldsGroups\\\\FieldsGroupsList\\:\\:getGroups\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Helper/FieldsGroups/FieldsGroupsList.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactory\\:\\:build\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
 
 		-
 			message: "#^Method Ibexa\\\\Core\\\\Helper\\\\TranslationHelper\\:\\:__construct\\(\\) has parameter \\$siteAccessesByLanguage with no value type specified in iterable type array\\.$#"
@@ -23201,96 +23131,6 @@ parameters:
 			path: tests/bundle/Core/ApiLoader/CacheFactoryTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:providerForRepositories\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetCurrentRepositoryAlias\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetDefaultRepositoryAlias\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetRepositoryConfigNotSpecifiedRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetRepositoryConfigSpecifiedRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProviderTest\\:\\:testGetRepositoryConfigUndefinedRepository\\(\\) has parameter \\$repositories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/RepositoryConfigurationProviderTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:getConfigResolverMock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:getConnectionProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:getContainerMock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnection\\(\\) has parameter \\$doctrineConnection with no type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnection\\(\\) has parameter \\$repositoryAlias with no type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnectionInvalidConnection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageConnectionFactoryTest\\:\\:testGetConnectionInvalidRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:getPersistenceHandlerMock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:testBuildInvalidStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:testBuildStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ApiLoader\\\\StorageEngineFactoryTest\\:\\:testRegisterStorageEngine\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\ChainConfigResolverTest\\:\\:buildMock\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/bundle/Core/ChainConfigResolverTest.php
@@ -24719,11 +24559,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\DependencyInjection\\\\Stub\\\\StubYamlPolicyProvider\\:\\:\\$files type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/bundle/Core/DependencyInjection/Stub/StubYamlPolicyProvider.php
-
-		-
-			message: "#^Call to an undefined method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryConfigurationProvider\\:\\:method\\(\\)\\.$#"
-			count: 3
-			path: tests/bundle/Core/Entity/EntityManagerFactoryTest.php
 
 		-
 			message: "#^Property Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Entity\\\\EntityManagerFactoryTest\\:\\:\\$serviceLocator is never read, only written\\.$#"
@@ -44594,21 +44429,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\ArrayTranslatorFieldsGroupsListTest\\:\\:\\$translatorMock has no type specified\\.$#"
 			count: 1
 			path: tests/lib/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactoryTest\\:\\:testBuild\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactoryTest\\:\\:\\$repositoryConfigMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Helper\\\\FieldsGroups\\\\RepositoryConfigFieldsGroupsListFactoryTest\\:\\:\\$translatorMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Helper\\\\PreviewLocationProviderTest\\:\\:testGetPreviewLocation\\(\\) has no return type specified\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19651,7 +19651,7 @@ parameters:
 			path: src/lib/Persistence/Utf8Converter.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Persistence\\\\Utf8Converter\\:\\:toUnicodeCodepoint\\(\\) should return int but returns int\\<0, max\\>\\|false\\.$#"
+			message: "#^Method Ibexa\\\\Core\\\\Persistence\\\\Utf8Converter\\:\\:toUnicodeCodepoint\\(\\) should return int but returns int\\<0, 2147483647\\>\\|false\\.$#"
 			count: 1
 			path: src/lib/Persistence/Utf8Converter.php
 

--- a/src/bundle/Core/ApiLoader/Exception/InvalidRepositoryException.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidRepositoryException.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidRepositoryException extends InvalidArgumentException
+final class InvalidRepositoryException extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngine.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngine.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidSearchEngine extends InvalidArgumentException
+final class InvalidSearchEngine extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngineIndexer.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidSearchEngineIndexer.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidSearchEngineIndexer extends InvalidArgumentException
+final class InvalidSearchEngineIndexer extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/Exception/InvalidStorageEngine.php
+++ b/src/bundle/Core/ApiLoader/Exception/InvalidStorageEngine.php
@@ -4,11 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader\Exception;
 
-use InvalidArgumentException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 
-class InvalidStorageEngine extends InvalidArgumentException
+final class InvalidStorageEngine extends InvalidArgumentException
 {
 }

--- a/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
+++ b/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
@@ -14,32 +14,29 @@ use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInte
  * @deprecated 5.0.0 The "\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider" class is deprecated, will be removed in 6.0.0.
  * Inject {@see \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface} from Dependency Injection Container instead.
  */
-final class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
+final readonly class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
 {
-    private RepositoryConfigurationProviderInterface $inner;
-
-    public function __construct(RepositoryConfigurationProviderInterface $configurationProvider)
+    public function __construct(private RepositoryConfigurationProviderInterface $configurationProvider)
     {
-        $this->inner = $configurationProvider;
     }
 
     public function getRepositoryConfig(): array
     {
-        return $this->inner->getRepositoryConfig();
+        return $this->configurationProvider->getRepositoryConfig();
     }
 
     public function getCurrentRepositoryAlias(): string
     {
-        return $this->inner->getCurrentRepositoryAlias();
+        return $this->configurationProvider->getCurrentRepositoryAlias();
     }
 
     public function getDefaultRepositoryAlias(): ?string
     {
-        return $this->inner->getDefaultRepositoryAlias();
+        return $this->configurationProvider->getDefaultRepositoryAlias();
     }
 
     public function getStorageConnectionName(): string
     {
-        return $this->inner->getStorageConnectionName();
+        return $this->configurationProvider->getStorageConnectionName();
     }
 }

--- a/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
+++ b/src/bundle/Core/ApiLoader/RepositoryConfigurationProvider.php
@@ -4,72 +4,42 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\ApiLoader;
 
-use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException;
-use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 
 /**
- * The repository configuration provider.
+ * @deprecated 5.0.0 The "\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider" class is deprecated, will be removed in 6.0.0.
+ * Inject {@see \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface} from Dependency Injection Container instead.
  */
-class RepositoryConfigurationProvider
+final class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
 {
-    private const REPOSITORY_STORAGE = 'storage';
-    private const REPOSITORY_CONNECTION = 'connection';
-    private const DEFAULT_CONNECTION_NAME = 'default';
+    private RepositoryConfigurationProviderInterface $inner;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
-
-    /** @var array */
-    private $repositories;
-
-    public function __construct(ConfigResolverInterface $configResolver, array $repositories)
+    public function __construct(RepositoryConfigurationProviderInterface $configurationProvider)
     {
-        $this->configResolver = $configResolver;
-        $this->repositories = $repositories;
+        $this->inner = $configurationProvider;
     }
 
-    /**
-     * @return array
-     *
-     * @throws \Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException
-     */
-    public function getRepositoryConfig()
+    public function getRepositoryConfig(): array
     {
-        // Takes configured repository as the reference, if it exists.
-        // If not, the first configured repository is considered instead.
-        $repositoryAlias = $this->configResolver->getParameter('repository');
-        $repositoryAlias = $repositoryAlias ?: $this->getDefaultRepositoryAlias();
-
-        if (empty($repositoryAlias) || !isset($this->repositories[$repositoryAlias])) {
-            throw new InvalidRepositoryException(
-                "Undefined Repository '$repositoryAlias'. Check if the Repository is configured in your project's ibexa.yaml."
-            );
-        }
-
-        return ['alias' => $repositoryAlias] + $this->repositories[$repositoryAlias];
+        return $this->inner->getRepositoryConfig();
     }
 
     public function getCurrentRepositoryAlias(): string
     {
-        return $this->getRepositoryConfig()['alias'];
+        return $this->inner->getCurrentRepositoryAlias();
     }
 
     public function getDefaultRepositoryAlias(): ?string
     {
-        $aliases = array_keys($this->repositories);
-
-        return array_shift($aliases);
+        return $this->inner->getDefaultRepositoryAlias();
     }
 
     public function getStorageConnectionName(): string
     {
-        $repositoryConfig = $this->getRepositoryConfig();
-
-        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION]
-            ? $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION]
-            : self::DEFAULT_CONNECTION_NAME;
+        return $this->inner->getStorageConnectionName();
     }
 }

--- a/src/bundle/Core/ApiLoader/RepositoryFactory.php
+++ b/src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -55,14 +55,12 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \Ibexa\Contracts\Core\Repository\LanguageResolver */
     private $languageResolver;
 
-    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
-
     public function __construct(
         ConfigResolverInterface $configResolver,
         $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
-        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
+        private readonly RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
@@ -70,7 +68,6 @@ class RepositoryFactory implements ContainerAwareInterface
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = $logger ?? new NullLogger();
-        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }
 
     /**

--- a/src/bundle/Core/ApiLoader/RepositoryFactory.php
+++ b/src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Bundle\Core\ApiLoader;
 
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Persistence\Filter\Content\Handler as ContentFilteringHandler;
 use Ibexa\Contracts\Core\Persistence\Filter\Location\Handler as LocationFilteringHandler;
 use Ibexa\Contracts\Core\Persistence\Handler as PersistenceHandler;
@@ -54,11 +55,14 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \Ibexa\Contracts\Core\Repository\LanguageResolver */
     private $languageResolver;
 
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
@@ -66,6 +70,7 @@ class RepositoryFactory implements ContainerAwareInterface
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = $logger ?? new NullLogger();
+        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }
 
     /**
@@ -94,9 +99,9 @@ class RepositoryFactory implements ContainerAwareInterface
         LocationFilteringHandler $locationFilteringHandler,
         PasswordValidatorInterface $passwordValidator,
         ConfigResolverInterface $configResolver,
-        NameSchemaServiceInterface $nameSchemaService
+        NameSchemaServiceInterface $nameSchemaService,
     ): Repository {
-        $config = $this->container->get(RepositoryConfigurationProvider::class)->getRepositoryConfig();
+        $config = $this->repositoryConfigurationProvider->getRepositoryConfig();
 
         return new $this->repositoryClass(
             $persistenceHandler,

--- a/src/bundle/Core/ApiLoader/SearchEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/SearchEngineFactory.php
@@ -16,8 +16,6 @@ use Ibexa\Contracts\Core\Search\Handler as SearchHandler;
  */
 class SearchEngineFactory
 {
-    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
-
     /**
      * Hash of registered search engines.
      * Key is the search engine identifier, value search handler itself.
@@ -26,9 +24,9 @@ class SearchEngineFactory
      */
     protected $searchEngines = [];
 
-    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
-    {
-        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+    public function __construct(
+        private readonly RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
+    ) {
     }
 
     /**

--- a/src/bundle/Core/ApiLoader/SearchEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/SearchEngineFactory.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Search\Handler as SearchHandler;
 
 /**
@@ -15,8 +16,7 @@ use Ibexa\Contracts\Core\Search\Handler as SearchHandler;
  */
 class SearchEngineFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * Hash of registered search engines.
@@ -26,7 +26,7 @@ class SearchEngineFactory
      */
     protected $searchEngines = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }

--- a/src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
+++ b/src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
@@ -17,8 +17,6 @@ use Ibexa\Core\Search\Common\Indexer as SearchEngineIndexer;
  */
 class SearchEngineIndexerFactory
 {
-    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
-
     /**
      * Hash of registered search engine indexers.
      * Key is the search engine identifier, value indexer itself.
@@ -27,9 +25,9 @@ class SearchEngineIndexerFactory
      */
     protected $searchEngineIndexers = [];
 
-    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
-    {
-        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+    public function __construct(
+        private readonly RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
+    ) {
     }
 
     /**

--- a/src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
+++ b/src/bundle/Core/ApiLoader/SearchEngineIndexerFactory.php
@@ -9,6 +9,7 @@ namespace Ibexa\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngine;
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidSearchEngineIndexer;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Core\Search\Common\Indexer as SearchEngineIndexer;
 
 /**
@@ -16,8 +17,7 @@ use Ibexa\Core\Search\Common\Indexer as SearchEngineIndexer;
  */
 class SearchEngineIndexerFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * Hash of registered search engine indexers.
@@ -27,7 +27,7 @@ class SearchEngineIndexerFactory
      */
     protected $searchEngineIndexers = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }

--- a/src/bundle/Core/ApiLoader/StorageConnectionFactory.php
+++ b/src/bundle/Core/ApiLoader/StorageConnectionFactory.php
@@ -15,26 +15,16 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 /**
  * @internal
  */
-final class StorageConnectionFactory
+final readonly class StorageConnectionFactory
 {
-    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
-
-    private ServiceLocator $serviceLocator;
-
-    /** @var array<string, string> */
-    private array $doctrineConnections;
-
     /**
      * @param array<string, string> $doctrineConnections
      */
     public function __construct(
-        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
-        ServiceLocator $serviceLocator,
-        array $doctrineConnections,
+        private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
+        private ServiceLocator $serviceLocator,
+        private array $doctrineConnections,
     ) {
-        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
-        $this->serviceLocator = $serviceLocator;
-        $this->doctrineConnections = $doctrineConnections;
     }
 
     /**

--- a/src/bundle/Core/ApiLoader/StorageConnectionFactory.php
+++ b/src/bundle/Core/ApiLoader/StorageConnectionFactory.php
@@ -10,20 +10,16 @@ namespace Ibexa\Bundle\Core\ApiLoader;
 use Doctrine\DBAL\Connection;
 use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use InvalidArgumentException;
-use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
  * @internal
  */
 final readonly class StorageConnectionFactory
 {
-    /**
-     * @param array<string, string> $doctrineConnections
-     */
     public function __construct(
         private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
-        private ServiceLocator $serviceLocator,
-        private array $doctrineConnections,
+        private ServiceProviderInterface $serviceLocator,
     ) {
     }
 
@@ -45,7 +41,7 @@ final readonly class StorageConnectionFactory
         if (!$this->serviceLocator->has($connectionName)) {
             throw new InvalidArgumentException(
                 "Invalid Doctrine connection '$connectionName' for Repository '{$repositoryConfig['alias']}'. " .
-                'Valid connections are: ' . implode(', ', array_keys($this->doctrineConnections))
+                'Valid connections are: ' . implode(', ', array_keys($this->serviceLocator->getProvidedServices()))
             );
         }
 

--- a/src/bundle/Core/ApiLoader/StorageEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/StorageEngineFactory.php
@@ -16,8 +16,6 @@ use Ibexa\Contracts\Core\Persistence\Handler as PersistenceHandler;
  */
 class StorageEngineFactory
 {
-    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
-
     /**
      * Hash of registered storage engines.
      * Key is the storage engine identifier, value persistence handler itself.
@@ -26,9 +24,9 @@ class StorageEngineFactory
      */
     protected array $storageEngines = [];
 
-    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
-    {
-        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+    public function __construct(
+        private readonly RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
+    ) {
     }
 
     /**

--- a/src/bundle/Core/ApiLoader/StorageEngineFactory.php
+++ b/src/bundle/Core/ApiLoader/StorageEngineFactory.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidStorageEngine;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Persistence\Handler as PersistenceHandler;
 
 /**
@@ -15,8 +16,7 @@ use Ibexa\Contracts\Core\Persistence\Handler as PersistenceHandler;
  */
 class StorageEngineFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /**
      * Hash of registered storage engines.
@@ -24,9 +24,9 @@ class StorageEngineFactory
      *
      * @var \Ibexa\Contracts\Core\Persistence\Handler[]
      */
-    protected $storageEngines = [];
+    protected array $storageEngines = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }
@@ -35,11 +35,8 @@ class StorageEngineFactory
      * Registers $persistenceHandler as a valid storage engine, with identifier $storageEngineIdentifier.
      *
      * Note: It is strongly recommenced to register a lazy persistent handler.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Handler $persistenceHandler
-     * @param string $storageEngineIdentifier
      */
-    public function registerStorageEngine(PersistenceHandler $persistenceHandler, $storageEngineIdentifier)
+    public function registerStorageEngine(PersistenceHandler $persistenceHandler, string $storageEngineIdentifier): void
     {
         $this->storageEngines[$storageEngineIdentifier] = $persistenceHandler;
     }
@@ -47,7 +44,7 @@ class StorageEngineFactory
     /**
      * @return \Ibexa\Contracts\Core\Persistence\Handler[]
      */
-    public function getStorageEngines()
+    public function getStorageEngines(): array
     {
         return $this->storageEngines;
     }
@@ -55,7 +52,7 @@ class StorageEngineFactory
     /**
      * Builds storage engine identified by $storageEngineIdentifier (the "alias" attribute in the service tag).
      *
-     * @throws \Ibexa\Bundle\Core\ApiLoader\Exception\InvalidStorageEngine
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     public function buildStorageEngine(): PersistenceHandler
     {
@@ -73,9 +70,9 @@ class StorageEngineFactory
 
         if (!isset($this->storageEngines[$storageEngineAlias])) {
             throw new InvalidStorageEngine(
-                "Invalid storage engine '{$storageEngineAlias}'. " .
+                "Invalid storage engine '$storageEngineAlias'. " .
                 'Could not find any service tagged with ibexa.storage ' .
-                "with alias {$storageEngineAlias}."
+                "with alias $storageEngineAlias."
             );
         }
 

--- a/src/bundle/Core/Command/CleanupVersionsCommand.php
+++ b/src/bundle/Core/Command/CleanupVersionsCommand.php
@@ -43,11 +43,11 @@ EOT;
         self::VERSION_PUBLISHED => VersionInfo::STATUS_PUBLISHED,
     ];
 
-    private Repository $repository;
+    private readonly Repository $repository;
 
-    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
+    private readonly RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    private Connection $connection;
+    private readonly Connection $connection;
 
     public function __construct(
         Repository $repository,

--- a/src/bundle/Core/Command/CleanupVersionsCommand.php
+++ b/src/bundle/Core/Command/CleanupVersionsCommand.php
@@ -9,11 +9,10 @@ namespace Ibexa\Bundle\Core\Command;
 
 use Doctrine\DBAL\Connection;
 use Exception;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
-use PDO;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -44,18 +43,16 @@ EOT;
         self::VERSION_PUBLISHED => VersionInfo::STATUS_PUBLISHED,
     ];
 
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /** @var \Doctrine\DBAL\Driver\Connection */
     private $connection;
 
     public function __construct(
         Repository $repository,
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         Connection $connection
     ) {
         $this->repository = $repository;

--- a/src/bundle/Core/Command/CleanupVersionsCommand.php
+++ b/src/bundle/Core/Command/CleanupVersionsCommand.php
@@ -47,8 +47,7 @@ EOT;
 
     private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    /** @var \Doctrine\DBAL\Driver\Connection */
-    private $connection;
+    private Connection $connection;
 
     public function __construct(
         Repository $repository,
@@ -272,9 +271,10 @@ EOT
                 )->setParameter(':contentTypes', $excludedContentTypes, Connection::PARAM_STR_ARRAY);
         }
 
+        /** @var \Doctrine\DBAL\ForwardCompatibility\Result<int> $stmt */
         $stmt = $query->execute();
 
-        return $stmt->fetchAll(PDO::FETCH_COLUMN);
+        return $stmt->fetchFirstColumn();
     }
 
     /**

--- a/src/bundle/Core/DependencyInjection/Compiler/StorageConnectionFactoryPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/StorageConnectionFactoryPass.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
+
+use Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @internal
+ */
+final class StorageConnectionFactoryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has(StorageConnectionFactory::class) || !$container->hasParameter('doctrine.connections')) {
+            return;
+        }
+
+        /** @var array<string, string> $doctrineConnections a map of <code>[ connection_name => connection_service_id ]</code> */
+        $doctrineConnections = $container->getParameter('doctrine.connections');
+        $doctrineConnectionServices = array_map(
+            static fn (string $serviceId): Reference => new Reference($serviceId),
+            $doctrineConnections
+        );
+        $storageConnectionFactory = $container->findDefinition(StorageConnectionFactory::class);
+        $storageConnectionFactory->replaceArgument(
+            '$serviceLocator',
+            ServiceLocatorTagPass::register($container, $doctrineConnectionServices)
+        );
+    }
+}

--- a/src/bundle/Core/Entity/EntityManagerFactory.php
+++ b/src/bundle/Core/Entity/EntityManagerFactory.php
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class EntityManagerFactory
 {
-    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
-
     /** @var \Symfony\Component\DependencyInjection\ServiceLocator */
     private $serviceLocator;
 
@@ -29,12 +27,11 @@ class EntityManagerFactory
     private $entityManagers;
 
     public function __construct(
-        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
+        private readonly RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         ServiceLocator $serviceLocator,
         string $defaultConnection,
         array $entityManagers
     ) {
-        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
         $this->serviceLocator = $serviceLocator;
         $this->defaultConnection = $defaultConnection;
         $this->entityManagers = $entityManagers;

--- a/src/bundle/Core/Entity/EntityManagerFactory.php
+++ b/src/bundle/Core/Entity/EntityManagerFactory.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Bundle\Core\Entity;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
@@ -17,8 +17,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class EntityManagerFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     /** @var \Symfony\Component\DependencyInjection\ServiceLocator */
     private $serviceLocator;
@@ -30,7 +29,7 @@ class EntityManagerFactory
     private $entityManagers;
 
     public function __construct(
-        RepositoryConfigurationProvider $repositoryConfigurationProvider,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         ServiceLocator $serviceLocator,
         string $defaultConnection,
         array $entityManagers

--- a/src/bundle/Core/IbexaCoreBundle.php
+++ b/src/bundle/Core/IbexaCoreBundle.php
@@ -30,6 +30,7 @@ use Ibexa\Bundle\Core\DependencyInjection\Compiler\SecurityPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\SessionConfigurationPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\SiteAccessMatcherRegistryPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\SlugConverterConfigurationPass;
+use Ibexa\Bundle\Core\DependencyInjection\Compiler\StorageConnectionFactoryPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\StorageConnectionPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\TranslationCollectorPass;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\URLHandlerPass;
@@ -88,6 +89,7 @@ final class IbexaCoreBundle extends Bundle
 
         // Storage passes
         $container->addCompilerPass(new ExternalStorageRegistryPass());
+        $container->addCompilerPass(new StorageConnectionFactoryPass());
         // Legacy Storage passes
         $container->addCompilerPass(new FieldValueConverterRegistryPass());
         $container->addCompilerPass(new RoleLimitationConverterPass());

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -16,33 +16,30 @@ services:
             - Ibexa\Core\Repository\Repository
             - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
+            - '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
             - "@?logger"
         calls:
             - [setContainer, ["@service_container"]]
 
     Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory:
-        class: Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     ibexa.api.persistence_handler:
         #To disable cache, switch alias to Ibexa\Contracts\Core\Persistence\Handler
         alias: Ibexa\Core\Persistence\Cache\Handler
 
     Ibexa\Contracts\Core\Persistence\Handler:
-        class: Ibexa\Contracts\Core\Persistence\Handler
         factory: ['@Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory', buildStorageEngine]
         public: false
 
     Ibexa\Bundle\Core\ApiLoader\SearchEngineFactory:
-        class: Ibexa\Bundle\Core\ApiLoader\SearchEngineFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Bundle\Core\ApiLoader\SearchEngineIndexerFactory:
-            class: Ibexa\Bundle\Core\ApiLoader\SearchEngineIndexerFactory
             arguments:
-                - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+                $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     ibexa.spi.search:
         alias: Ibexa\Contracts\Core\Search\VersatileHandler

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -232,9 +232,8 @@ services:
             - "@translator"
 
     Ibexa\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory:
-        class: Ibexa\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $configProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Core\QueryType\QueryParameterContentViewQueryTypeMapper:
         class: Ibexa\Core\QueryType\QueryParameterContentViewQueryTypeMapper
@@ -316,11 +315,10 @@ services:
             - { name: console.command }
 
     Ibexa\Bundle\Core\Command\CleanupVersionsCommand:
-        class: Ibexa\Bundle\Core\Command\CleanupVersionsCommand
         arguments:
-            - '@Ibexa\Core\Event\Repository'
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
-            - '@ibexa.persistence.connection'
+            $repository: '@Ibexa\Core\Event\Repository'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
+            $connection: '@ibexa.persistence.connection'
         tags:
             - { name: console.command }
 
@@ -365,7 +363,7 @@ services:
     ibexa.doctrine.orm.entity_manager_factory:
         class: Ibexa\Bundle\Core\Entity\EntityManagerFactory
         arguments:
-            $repositoryConfigurationProvider: '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
             $defaultConnection: '%doctrine.default_connection%'
             $entityManagers: '%doctrine.entity_managers%'
 

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -1,17 +1,22 @@
 services:
-    Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider:
-        public: true # @todo should be private
-        class: Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider
+    Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface:
+        alias: Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
+
+    Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider:
         arguments:
-            - '@ibexa.config.resolver'
-            - '%ibexa.repositories%'
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $repositories: '%ibexa.repositories%'
+
+    Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider:
+        deprecated: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated, will be removed in 6.0. Use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface instead'
+        arguments:
+            $configurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory:
-        class: Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
         calls:
-            - [setContainer, ["@service_container"]]
+            - [setContainer, ['@service_container']]
 
     ibexa.persistence.connection:
         public: true # @todo should be private

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -16,7 +16,6 @@ services:
         autowire: true
         autoconfigure: true
         arguments:
-            $doctrineConnections: '%doctrine.connections%'
             $serviceLocator: ~
 
     ibexa.persistence.connection:

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -13,10 +13,11 @@ services:
             $configurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory:
+        autowire: true
+        autoconfigure: true
         arguments:
-            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
-        calls:
-            - [setContainer, ['@service_container']]
+            $doctrineConnections: '%doctrine.connections%'
+            $serviceLocator: ~
 
     ibexa.persistence.connection:
         public: true # @todo should be private

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -8,7 +8,10 @@ services:
             $repositories: '%ibexa.repositories%'
 
     Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider:
-        deprecated: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated, will be removed in 6.0. Use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface instead'
+        deprecated:
+            package: 'ibexa/core'
+            version: '5.0'
+            message: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated and will be removed in 6.0. Use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface instead'
         arguments:
             $configurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 

--- a/src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
+++ b/src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
@@ -7,7 +7,7 @@
 
 namespace Ibexa\Bundle\LegacySearchEngine\ApiLoader;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
@@ -16,10 +16,9 @@ class ConnectionFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    protected $repositoryConfigurationProvider;
+    protected RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }

--- a/src/bundle/LegacySearchEngine/Resources/config/services.yml
+++ b/src/bundle/LegacySearchEngine/Resources/config/services.yml
@@ -1,10 +1,9 @@
 services:
     Ibexa\Bundle\LegacySearchEngine\ApiLoader\ConnectionFactory:
-        class: Ibexa\Bundle\LegacySearchEngine\ApiLoader\ConnectionFactory
         arguments:
-            - '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
         calls:
-            - [setContainer, ["@service_container"]]
+            - [setContainer, ['@service_container']]
 
     ibexa.api.search_engine.legacy.connection:
         class: Doctrine\DBAL\Connection

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -8,8 +8,8 @@
 namespace Ibexa\Bundle\RepositoryInstaller\Command;
 
 use Doctrine\DBAL\Connection;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Bundle\Core\Command\BackwardCompatibleCommand;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -38,8 +38,7 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
     /** @var \Ibexa\Bundle\RepositoryInstaller\Installer\Installer[] */
     private $installers = [];
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
     public const EXIT_GENERAL_DATABASE_ERROR = 4;
     public const EXIT_PARAMETERS_NOT_FOUND = 5;
@@ -51,7 +50,7 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
         array $installers,
         CacheItemPoolInterface $cachePool,
         string $environment,
-        RepositoryConfigurationProvider $repositoryConfigurationProvider
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider
     ) {
         $this->connection = $connection;
         $this->installers = $installers;

--- a/src/bundle/RepositoryInstaller/Resources/config/services.yml
+++ b/src/bundle/RepositoryInstaller/Resources/config/services.yml
@@ -22,7 +22,7 @@ services:
             $installers: []
             $cachePool: '@ibexa.cache_pool'
             $environment: "%kernel.environment%"
-            $repositoryConfigurationProvider: '@Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
         tags:
             - { name: console.command }
 

--- a/src/contracts/Container/ApiLoader/RepositoryConfigurationProviderInterface.php
+++ b/src/contracts/Container/ApiLoader/RepositoryConfigurationProviderInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Container\ApiLoader;
+
+/**
+ * @phpstan-type TRepositoryStorageConfiguration array{engine: string, connection: string, config?: array<string, mixed>}
+ * @phpstan-type TRepositorySearchConfiguration array{engine: string, connection: string}
+ * @phpstan-type TRepositoryConfiguration array{
+ *     alias: string,
+ *     storage: TRepositoryStorageConfiguration,
+ *     search: TRepositorySearchConfiguration,
+ *     fields_groups: array{default: string, list: string[]},
+ *     options: array<string, mixed>
+ * }
+ */
+interface RepositoryConfigurationProviderInterface
+{
+    /**
+     * @phpstan-return TRepositoryConfiguration
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getRepositoryConfig(): array;
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getCurrentRepositoryAlias(): string;
+
+    public function getDefaultRepositoryAlias(): ?string;
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function getStorageConnectionName(): string;
+}

--- a/src/lib/Base/Container/ApiLoader/RepositoryConfigurationProvider.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryConfigurationProvider.php
@@ -25,24 +25,19 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
  * }
  * @phpstan-type TRepositoryListConfiguration array<string, TRepositoryListItemConfiguration>
  */
-final class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
+final readonly class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
 {
     private const string REPOSITORY_STORAGE = 'storage';
     private const string REPOSITORY_CONNECTION = 'connection';
     private const string DEFAULT_CONNECTION_NAME = 'default';
 
-    private ConfigResolverInterface $configResolver;
-
-    /** @phpstan-var TRepositoryListConfiguration */
-    private array $repositories;
-
     /**
      * @phpstan-param TRepositoryListConfiguration $repositories
      */
-    public function __construct(ConfigResolverInterface $configResolver, array $repositories)
-    {
-        $this->configResolver = $configResolver;
-        $this->repositories = $repositories;
+    public function __construct(
+        private ConfigResolverInterface $configResolver,
+        private array $repositories,
+    ) {
     }
 
     public function getRepositoryConfig(): array

--- a/src/lib/Base/Container/ApiLoader/RepositoryConfigurationProvider.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryConfigurationProvider.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Base\Container\ApiLoader;
+
+use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+
+/**
+ * @phpstan-import-type TRepositoryConfiguration from RepositoryConfigurationProviderInterface
+ * @phpstan-import-type TRepositoryStorageConfiguration from RepositoryConfigurationProviderInterface
+ * @phpstan-import-type TRepositorySearchConfiguration from RepositoryConfigurationProviderInterface
+ *
+ * @phpstan-type TRepositoryListItemConfiguration array{
+ *      storage: TRepositoryStorageConfiguration,
+ *      search: TRepositorySearchConfiguration,
+ *      fields_groups: array{default: string, list: string[]},
+ *      options: array<string, mixed>
+ * }
+ * @phpstan-type TRepositoryListConfiguration array<string, TRepositoryListItemConfiguration>
+ */
+final class RepositoryConfigurationProvider implements RepositoryConfigurationProviderInterface
+{
+    private const string REPOSITORY_STORAGE = 'storage';
+    private const string REPOSITORY_CONNECTION = 'connection';
+    private const string DEFAULT_CONNECTION_NAME = 'default';
+
+    private ConfigResolverInterface $configResolver;
+
+    /** @phpstan-var TRepositoryListConfiguration */
+    private array $repositories;
+
+    /**
+     * @phpstan-param TRepositoryListConfiguration $repositories
+     */
+    public function __construct(ConfigResolverInterface $configResolver, array $repositories)
+    {
+        $this->configResolver = $configResolver;
+        $this->repositories = $repositories;
+    }
+
+    public function getRepositoryConfig(): array
+    {
+        // Takes configured repository as the reference, if it exists.
+        // If not, the first configured repository is considered instead.
+        /** @var string|null $repositoryAlias */
+        $repositoryAlias = $this->configResolver->getParameter('repository');
+        $repositoryAlias = $repositoryAlias ?? $this->getDefaultRepositoryAlias();
+
+        if (empty($repositoryAlias) || !isset($this->repositories[$repositoryAlias])) {
+            throw new InvalidRepositoryException(
+                "Undefined Repository '$repositoryAlias'. Check if the Repository is configured in your project's ibexa.yaml."
+            );
+        }
+
+        return ['alias' => $repositoryAlias] + $this->repositories[$repositoryAlias];
+    }
+
+    public function getCurrentRepositoryAlias(): string
+    {
+        return $this->getRepositoryConfig()['alias'];
+    }
+
+    public function getDefaultRepositoryAlias(): ?string
+    {
+        $aliases = array_keys($this->repositories);
+
+        return array_shift($aliases);
+    }
+
+    public function getStorageConnectionName(): string
+    {
+        $repositoryConfig = $this->getRepositoryConfig();
+
+        return $repositoryConfig[self::REPOSITORY_STORAGE][self::REPOSITORY_CONNECTION] ?? self::DEFAULT_CONNECTION_NAME;
+    }
+}

--- a/src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
+++ b/src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
@@ -7,7 +7,7 @@
 
 namespace Ibexa\Core\Helper\FieldsGroups;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -15,15 +15,17 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class RepositoryConfigFieldsGroupsListFactory
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $configProvider;
+    private RepositoryConfigurationProviderInterface $configProvider;
 
-    public function __construct(RepositoryConfigurationProvider $configProvider)
+    public function __construct(RepositoryConfigurationProviderInterface $configProvider)
     {
         $this->configProvider = $configProvider;
     }
 
-    public function build(TranslatorInterface $translator)
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     */
+    public function build(TranslatorInterface $translator): FieldsGroupsList
     {
         $repositoryConfig = $this->configProvider->getRepositoryConfig();
 

--- a/src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
+++ b/src/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * Builds a SettingsFieldGroupsList.
  */
-final class RepositoryConfigFieldsGroupsListFactory
+final readonly class RepositoryConfigFieldsGroupsListFactory
 {
     private RepositoryConfigurationProviderInterface $configProvider;
 

--- a/tests/bundle/Core/ApiLoader/BaseRepositoryConfigurationProviderTestCase.php
+++ b/tests/bundle/Core/ApiLoader/BaseRepositoryConfigurationProviderTestCase.php
@@ -40,10 +40,10 @@ abstract class BaseRepositoryConfigurationProviderTestCase extends TestCase
         string $storageConnection = 'default_connection'
     ): array {
         return [
-                'storage' => [
-                    'engine' => $storageEngine,
-                    'connection' => $storageConnection,
-                ],
-            ] + self::MAIN_REPOSITORY_CONFIG;
+            'storage' => [
+                'engine' => $storageEngine,
+                'connection' => $storageConnection,
+            ],
+        ] + self::MAIN_REPOSITORY_CONFIG;
     }
 }

--- a/tests/bundle/Core/ApiLoader/BaseRepositoryConfigurationProviderTestCase.php
+++ b/tests/bundle/Core/ApiLoader/BaseRepositoryConfigurationProviderTestCase.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Core\ApiLoader;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @phpstan-import-type TRepositoryListItemConfiguration from \Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
+ */
+abstract class BaseRepositoryConfigurationProviderTestCase extends TestCase
+{
+    protected const string MAIN_REPOSITORY_ALIAS = 'main';
+    protected const array MAIN_REPOSITORY_CONFIG = [
+        'storage' => ['engine' => 'foo', 'connection' => 'some_connection'],
+        'search' => ['engine' => 'foo_search', 'connection' => 'some_connection'],
+        'fields_groups' => ['default' => 'meta', 'list' => ['content', 'meta']],
+        'options' => [],
+    ];
+    protected const array REPOSITORIES_CONFIG = [
+        self::MAIN_REPOSITORY_ALIAS => self::MAIN_REPOSITORY_CONFIG,
+        'another' => [
+            'storage' => ['engine' => 'bar', 'connection' => 'bar_connection'],
+            'search' => ['engine' => 'bar_search', 'connection' => 'bar_search_connection'],
+            'fields_groups' => ['default' => 'content', 'list' => ['meta', 'content']],
+            'options' => [],
+        ],
+    ];
+
+    /**
+     * @phpstan-return TRepositoryListItemConfiguration
+     */
+    protected function buildNormalizedSingleRepositoryConfig(
+        string $storageEngine,
+        string $storageConnection = 'default_connection'
+    ): array {
+        return [
+                'storage' => [
+                    'engine' => $storageEngine,
+                    'connection' => $storageConnection,
+                ],
+            ] + self::MAIN_REPOSITORY_CONFIG;
+    }
+}

--- a/tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
+++ b/tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
@@ -104,10 +104,16 @@ final class StorageConnectionFactoryTest extends BaseRepositoryConfigurationProv
         $factory = $this->buildStorageConnectionFactory(
             $repositoryConfigurationProviderMock,
             'my_doctrine_connection',
-            []
+            [
+                'default' => 'doctrine.dbal.default_connection',
+                'foo' => 'doctrine.dbal.foo_connection',
+            ]
         );
 
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid Doctrine connection \'my_doctrine_connection\' for Repository \'foo\'. Valid connections are: default, foo'
+        );
         $factory->getConnection();
     }
 
@@ -135,6 +141,7 @@ final class StorageConnectionFactoryTest extends BaseRepositoryConfigurationProv
             ->with($connectionName)
             ->willReturn(isset($doctrineConnections[$connectionName]))
         ;
+        $serviceLocatorMock->method('getProvidedServices')->willReturn($doctrineConnections);
         if (isset($doctrineConnections[$connectionName])) {
             $serviceLocatorMock->method('get')->with($connectionName)->willReturn($this->createMock(Connection::class));
         } else {
@@ -143,8 +150,7 @@ final class StorageConnectionFactoryTest extends BaseRepositoryConfigurationProv
 
         return new StorageConnectionFactory(
             $repositoryConfigurationProvider,
-            $serviceLocatorMock,
-            $doctrineConnections
+            $serviceLocatorMock
         );
     }
 }

--- a/tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
+++ b/tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
@@ -7,27 +7,24 @@
 
 namespace Ibexa\Tests\Bundle\Core\ApiLoader;
 
+use Doctrine\DBAL\Connection;
 use Ibexa\Bundle\Core\ApiLoader\Exception\InvalidRepositoryException;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
-use PHPUnit\Framework\TestCase;
+use Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class StorageConnectionFactoryTest extends TestCase
+class StorageConnectionFactoryTest extends BaseRepositoryConfigurationProviderTestCase
 {
     /**
      * @dataProvider getConnectionProvider
      */
-    public function testGetConnection($repositoryAlias, $doctrineConnection)
+    public function testGetConnection(string $repositoryAlias, string $doctrineConnection): void
     {
         $repositories = [
-            $repositoryAlias => [
-                'storage' => [
-                    'engine' => 'legacy',
-                    'connection' => $doctrineConnection,
-                ],
-            ],
+            $repositoryAlias => $this->buildNormalizedSingleRepositoryConfig('legacy', $doctrineConnection),
         ];
 
         $configResolver = $this->getConfigResolverMock();
@@ -35,31 +32,31 @@ class StorageConnectionFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getParameter')
             ->with('repository')
-            ->will(self::returnValue($repositoryAlias));
+            ->willReturn($repositoryAlias);
 
         $container = $this->getContainerMock();
         $container
             ->expects(self::once())
             ->method('has')
             ->with("doctrine.dbal.{$doctrineConnection}_connection")
-            ->will(self::returnValue(true));
+            ->willReturn(true);
         $container
             ->expects(self::once())
             ->method('get')
             ->with("doctrine.dbal.{$doctrineConnection}_connection")
-            ->will(self::returnValue($this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock()));
+            ->willReturn($this->createMock(Connection::class));
 
         $repositoryConfigurationProvider = new RepositoryConfigurationProvider($configResolver, $repositories);
         $factory = new StorageConnectionFactory($repositoryConfigurationProvider);
         $factory->setContainer($container);
         $connection = $factory->getConnection();
-        self::assertInstanceOf(
-            'Doctrine\DBAL\Connection',
-            $connection
-        );
+        self::assertInstanceOf(Connection::class, $connection);
     }
 
-    public function getConnectionProvider()
+    /**
+     * @return list<array{string, string}>
+     */
+    public function getConnectionProvider(): array
     {
         return [
             ['my_repository', 'my_doctrine_connection'],
@@ -68,17 +65,10 @@ class StorageConnectionFactoryTest extends TestCase
         ];
     }
 
-    public function testGetConnectionInvalidRepository()
+    public function testGetConnectionInvalidRepository(): void
     {
-        $this->expectException(InvalidRepositoryException::class);
-
         $repositories = [
-            'foo' => [
-                'storage' => [
-                    'engine' => 'legacy',
-                    'connection' => 'my_doctrine_connection',
-                ],
-            ],
+            'foo' => $this->buildNormalizedSingleRepositoryConfig('legacy', 'my_doctrine_connection'),
         ];
 
         $configResolver = $this->getConfigResolverMock();
@@ -86,19 +76,19 @@ class StorageConnectionFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getParameter')
             ->with('repository')
-            ->will(self::returnValue('inexistent_repository'));
+            ->willReturn('nonexistent_repository');
 
         $repositoryConfigurationProvider = new RepositoryConfigurationProvider($configResolver, $repositories);
         $factory = new StorageConnectionFactory($repositoryConfigurationProvider);
         $factory->setContainer($this->getContainerMock());
+
+        $this->expectException(InvalidRepositoryException::class);
         $factory->getConnection();
     }
 
-    public function testGetConnectionInvalidConnection()
+    public function testGetConnectionInvalidConnection(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $repositoryConfigurationProviderMock = $this->createMock(RepositoryConfigurationProvider::class);
+        $repositoryConfigurationProviderMock = $this->createMock(RepositoryConfigurationProviderInterface::class);
         $repositoryConfig = [
             'alias' => 'foo',
             'storage' => [
@@ -109,30 +99,32 @@ class StorageConnectionFactoryTest extends TestCase
         $repositoryConfigurationProviderMock
             ->expects(self::once())
             ->method('getRepositoryConfig')
-            ->will(self::returnValue($repositoryConfig));
+            ->willReturn($repositoryConfig);
 
         $container = $this->getContainerMock();
         $container
             ->expects(self::once())
             ->method('has')
             ->with('doctrine.dbal.my_doctrine_connection_connection')
-            ->will(self::returnValue(false));
+            ->willReturn(false);
         $container
             ->expects(self::once())
             ->method('getParameter')
             ->with('doctrine.connections')
-            ->will(self::returnValue([]));
+            ->willReturn([]);
         $factory = new StorageConnectionFactory($repositoryConfigurationProviderMock);
         $factory->setContainer($container);
+
+        $this->expectException(\InvalidArgumentException::class);
         $factory->getConnection();
     }
 
-    protected function getConfigResolverMock()
+    protected function getConfigResolverMock(): ConfigResolverInterface & MockObject
     {
         return $this->createMock(ConfigResolverInterface::class);
     }
 
-    protected function getContainerMock()
+    protected function getContainerMock(): ContainerInterface & MockObject
     {
         return $this->createMock(ContainerInterface::class);
     }

--- a/tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
+++ b/tests/bundle/Core/ApiLoader/StorageEngineFactoryTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class StorageEngineFactoryTest extends BaseRepositoryConfigurationProviderTestCase
+final class StorageEngineFactoryTest extends BaseRepositoryConfigurationProviderTestCase
 {
     public function testRegisterStorageEngine(): void
     {

--- a/tests/bundle/Core/DependencyInjection/Compiler/EntityManagerFactoryServiceLocatorPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/EntityManagerFactoryServiceLocatorPassTest.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Compiler;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\EntityManagerFactoryServiceLocatorPass;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,7 +25,7 @@ class EntityManagerFactoryServiceLocatorPassTest extends AbstractCompilerPassTes
         $this->setDefinition(
             'ibexa.doctrine.orm.entity_manager_factory',
             new Definition(null, [
-                '$repositoryConfigurationProvider' => new Reference(RepositoryConfigurationProvider::class),
+                '$repositoryConfigurationProvider' => new Reference(RepositoryConfigurationProviderInterface::class),
                 '$defaultConnection' => '%doctrine.default_connection%',
                 '$entityManagers' => '%doctrine.entity_managers%',
             ])

--- a/tests/bundle/Core/DependencyInjection/Compiler/StorageConnectionFactoryPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/StorageConnectionFactoryPassTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Compiler;
+
+use Ibexa\Bundle\Core\ApiLoader\StorageConnectionFactory;
+use Ibexa\Bundle\Core\DependencyInjection\Compiler\StorageConnectionFactoryPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @covers \Ibexa\Bundle\Core\DependencyInjection\Compiler\StorageConnectionFactoryPass
+ */
+final class StorageConnectionFactoryPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $doctrineConnections = ['default' => 'doctrine.dbal.default_connection'];
+
+        $this->container->setParameter('doctrine.connections', $doctrineConnections);
+        $this->setDefinition(
+            StorageConnectionFactory::class,
+            new Definition(
+                StorageConnectionFactory::class,
+                [
+                    '$doctrineConnections' => $doctrineConnections,
+                    '$serviceLocator' => null,
+                ]
+            )
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new StorageConnectionFactoryPass());
+    }
+
+    public function testProcess(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithServiceLocatorArgument(
+            StorageConnectionFactory::class,
+            '$serviceLocator',
+            [
+                'default' => new Reference('doctrine.dbal.default_connection'),
+            ]
+        );
+    }
+}

--- a/tests/bundle/Core/Entity/EntityManagerFactoryTest.php
+++ b/tests/bundle/Core/Entity/EntityManagerFactoryTest.php
@@ -9,9 +9,10 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Bundle\Core\Entity;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
 use Ibexa\Bundle\Core\Entity\EntityManagerFactory;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
@@ -25,8 +26,7 @@ class EntityManagerFactoryTest extends TestCase
         'ibexa_invalid' => self::INVALID_ENTITY_MANAGER,
     ];
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider */
-    private $repositoryConfigurationProvider;
+    private RepositoryConfigurationProviderInterface & MockObject $repositoryConfigurationProvider;
 
     /** @var \Doctrine\ORM\EntityManagerInterface */
     private $entityManager;
@@ -132,12 +132,9 @@ class EntityManagerFactoryTest extends TestCase
         $entityManagerFactory->getEntityManager();
     }
 
-    /**
-     * @return \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getRepositoryConfigurationProvider(): RepositoryConfigurationProvider
+    protected function getRepositoryConfigurationProvider(): RepositoryConfigurationProviderInterface & MockObject
     {
-        return $this->createMock(RepositoryConfigurationProvider::class);
+        return $this->createMock(RepositoryConfigurationProviderInterface::class);
     }
 
     /**

--- a/tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
+++ b/tests/lib/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
@@ -7,18 +7,19 @@
 
 namespace Ibexa\Tests\Core\Helper\FieldsGroups;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
 {
-    private $repositoryConfigMock;
+    private RepositoryConfigurationProviderInterface & MockObject $repositoryConfigMock;
 
-    private $translatorMock;
+    private TranslatorInterface & MockObject $translatorMock;
 
-    public function testBuild()
+    public function testBuild(): void
     {
         $this->getRepositoryConfigMock()
             ->expects(self::once())
@@ -26,9 +27,8 @@ class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
             ->willReturn(['fields_groups' => ['list' => ['group_a', 'group_b'], 'default' => 'group_a']]);
 
         $this->getTranslatorMock()
-            ->expects(self::any())
             ->method('trans')
-            ->will(self::returnArgument(0));
+            ->willReturnArgument(0);
 
         $factory = new RepositoryConfigFieldsGroupsListFactory($this->getRepositoryConfigMock());
         $list = $factory->build($this->getTranslatorMock());
@@ -37,22 +37,16 @@ class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
         self::assertEquals('group_a', $list->getDefaultGroup());
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider
-     */
-    protected function getRepositoryConfigMock()
+    protected function getRepositoryConfigMock(): RepositoryConfigurationProviderInterface & MockObject
     {
         if (!isset($this->repositoryConfigMock)) {
-            $this->repositoryConfigMock = $this->createMock(RepositoryConfigurationProvider::class);
+            $this->repositoryConfigMock = $this->createMock(RepositoryConfigurationProviderInterface::class);
         }
 
         return $this->repositoryConfigMock;
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Symfony\Contracts\Translation\TranslatorInterface
-     */
-    protected function getTranslatorMock()
+    protected function getTranslatorMock(): TranslatorInterface & MockObject
     {
         if (!isset($this->translatorMock)) {
             $this->translatorMock = $this->createMock(TranslatorInterface::class);


### PR DESCRIPTION
| :ticket: Issue | IBX-8399 on the way to IBX-8400 and IBX-8138 |
|----------------|-----------|

 
#### Related PRs: 
- ibexa/core#384

#### Description:

##### TL:DR;

Effectively moved `RepositoryConfigurationProvider` from Bundle to Repository layer (for now actually deprecated the old class, but aiming to back-port deprecation to 4.6 and remove it in 5.0 as a follow-up).

##### Background

We need to refactor DI configuration defining `RepositoryFactory` (see related PR) so we can fix long outstanding ambiguity issues listed in the JIRA ticket. For now it will help with Symfony 5 Rectors refactoring. The changes done to `./src/bundle/Core/ApiLoader/RepositoryFactory.php` are related to that refactoring (`RepositoryConfigurationProvider` injection instead of `$this->container->get()` call) and probably can be applied in a simpler manner to resolve the target issue IBX-8138, however I feel like it's the highest time to do that cleanup - it's a low hanging fruit.

But before we can do that, **we need to move `RepositoryConfigurationProvider` from the Bundle to the Repository layer as it's the most inner layer**. I've done that in this PR and while at it I've introduced `RepositoryConfigurationProviderInterface` contracts.

I've deprecated Core Bundle `RepositoryConfigurationProvider` in favor of the Core Repository layer one (`\Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider`). Ideally I'd like to back-port that deprecation to 4.6, but as a follow-up due to time constraints.

Additionally I've made `Ibexa\Bundle\Core\ApiLoader\Exception\*` Exceptions final and implementing Repository `InvalidArgumentException` instead of the core PHP one.

I've also cleaned up some minor parts of code touched around repository configuration provider injection refactoring.

##### Changelog:

- **Changed Core Bundle ApiLoader Exception to be Repository Exceptions**
- **Extracted an interface from RepositoryConfigurationProvider**
- **Fixed strict type of CleanupVersionsCommand::$connection property**
- **[Tests] Aligned tests with  RepositoryConfigurationProvider changes**
- **[PHPStan] Aligned baseline with the changes**

#### For QA:

Regressions done via ibexa/commerce#872 should be enough.

#### Documentation:

- Deprecation of Core Bundle RepositoryConfigurationProvider in favor of the Core Repository layer one.
- Core Bundle ApiLoader Exceptions follow now Repository Exceptions contract

