### PR TITLE
IBX-8400: Fixed redundancy in RepositoryFactory implementations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,16 +11,6 @@ parameters:
 			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$repositoryClass with no type specified\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:buildRepository\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Repository but returns object\\.$#"
-			count: 1
-			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
-
-		-
 			message: "#^Property Ibexa\\\\Bundle\\\\Core\\\\ApiLoader\\\\RepositoryFactory\\:\\:\\$policyMap type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -7784,26 +7774,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Contracts\\\\Core\\\\Variation\\\\VariationPurger\\:\\:purge\\(\\) has parameter \\$aliasNames with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Variation/VariationPurger.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$policyMap with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:__construct\\(\\) has parameter \\$repositoryClass with no type specified\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:buildRepository\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Repository but returns object\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\RepositoryFactory\\:\\:\\$policyMap type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Base/Container/ApiLoader/RepositoryFactory.php
 
 		-
 			message: "#^Method Ibexa\\\\Core\\\\Base\\\\Container\\\\Compiler\\\\AbstractFieldTypeBasedPass\\:\\:getFieldTypeServiceIds\\(\\) return type has no value type specified in iterable type iterable\\.$#"
@@ -20766,11 +20736,6 @@ parameters:
 			path: src/lib/Repository/RoleService.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:__construct\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Repository/RoleService.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:buildRoleAssignmentsFromPersistence\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Repository/RoleService.php
@@ -20831,11 +20796,6 @@ parameters:
 			path: src/lib/Repository/RoleService.php
 
 		-
-			message: "#^Parameter \\#1 \\$identifier of method Ibexa\\\\Core\\\\Repository\\\\Permission\\\\LimitationService\\:\\:getLimitationType\\(\\) expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/lib/Repository/RoleService.php
-
-		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_diff expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/lib/Repository/RoleService.php
@@ -20848,11 +20808,6 @@ parameters:
 		-
 			message: "#^Parameter \\#3 \\$limitations of method Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:validatePolicy\\(\\) expects array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\Limitation\\>, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\Limitation\\> given\\.$#"
 			count: 3
-			path: src/lib/Repository/RoleService.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\Repository\\\\RoleService\\:\\:\\$settings type has no value type specified in iterable type array\\.$#"
-			count: 1
 			path: src/lib/Repository/RoleService.php
 
 		-

--- a/src/bundle/Core/ApiLoader/RepositoryFactory.php
+++ b/src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -31,7 +31,13 @@ use Ibexa\Core\Search\Common\BackgroundIndexer;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-class RepositoryFactory implements ContainerAwareInterface
+/**
+ * @internal
+ *
+ * @deprecated 5.0.0 The "\Ibexa\Bundle\Core\ApiLoader\RepositoryFactory" class is deprecated, will be removed in 6.0.
+ * Use {@see \Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory instead}.
+ */
+class RepositoryFactory
 {
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
     private $configResolver;

--- a/src/bundle/Core/ApiLoader/RepositoryFactory.php
+++ b/src/bundle/Core/ApiLoader/RepositoryFactory.php
@@ -25,22 +25,16 @@ use Ibexa\Core\Repository\Helper\RelationProcessor;
 use Ibexa\Core\Repository\Mapper;
 use Ibexa\Core\Repository\Permission\LimitationService;
 use Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
+use Ibexa\Core\Repository\Repository as CoreRepository;
 use Ibexa\Core\Repository\User\PasswordValidatorInterface;
 use Ibexa\Core\Search\Common\BackgroundIndexer;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 class RepositoryFactory implements ContainerAwareInterface
 {
-    use ContainerAwareTrait;
-
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
     private $configResolver;
-
-    /** @var string */
-    private $repositoryClass;
 
     /**
      * Map of system configured policies.
@@ -57,14 +51,12 @@ class RepositoryFactory implements ContainerAwareInterface
 
     public function __construct(
         ConfigResolverInterface $configResolver,
-        $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
         private readonly RepositoryConfigurationProviderInterface $repositoryConfigurationProvider,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
-        $this->repositoryClass = $repositoryClass;
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = $logger ?? new NullLogger();
@@ -100,7 +92,7 @@ class RepositoryFactory implements ContainerAwareInterface
     ): Repository {
         $config = $this->repositoryConfigurationProvider->getRepositoryConfig();
 
-        return new $this->repositoryClass(
+        return new CoreRepository(
             $persistenceHandler,
             $searchHandler,
             $backgroundIndexer,

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -17,8 +17,6 @@ services:
             $languageResolver: '@Ibexa\Contracts\Core\Repository\LanguageResolver'
             $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
             $logger: "@?logger"
-        calls:
-            - [setContainer, ["@service_container"]]
 
     Ibexa\Bundle\Core\ApiLoader\StorageEngineFactory:
         arguments:

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -11,6 +11,10 @@ parameters:
 services:
     # API
     Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
+        deprecated:
+            package: 'ibexa/core'
+            version: '5.0'
+            message: 'Since ibexa/core 5.0: The "%service_id%" service is deprecated and will be removed in 6.0. Use Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory instead'
         arguments:
             $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
             $policyMap: '%ibexa.api.role.policy_map%'

--- a/src/bundle/Core/Resources/config/papi.yml
+++ b/src/bundle/Core/Resources/config/papi.yml
@@ -12,12 +12,11 @@ services:
     # API
     Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
         arguments:
-            - '@ibexa.config.resolver'
-            - Ibexa\Core\Repository\Repository
-            - '%ibexa.api.role.policy_map%'
-            - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
-            - '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
-            - "@?logger"
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $policyMap: '%ibexa.api.role.policy_map%'
+            $languageResolver: '@Ibexa\Contracts\Core\Repository\LanguageResolver'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
+            $logger: "@?logger"
         calls:
             - [setContainer, ["@service_container"]]
 

--- a/src/bundle/Core/Resources/config/storage_engines.yml
+++ b/src/bundle/Core/Resources/config/storage_engines.yml
@@ -1,12 +1,4 @@
 services:
-    Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface:
-        alias: Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider
-
-    Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider:
-        arguments:
-            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
-            $repositories: '%ibexa.repositories%'
-
     Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider:
         deprecated:
             package: 'ibexa/core'

--- a/src/contracts/Repository/RoleService.php
+++ b/src/contracts/Repository/RoleService.php
@@ -23,6 +23,8 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 
 /**
  * This service provides methods for managing Roles and Policies.
+ *
+ * @phpstan-type TPolicyMap array<string, array<string, array<string, boolean|null>>>
  */
 interface RoleService
 {

--- a/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
@@ -25,17 +25,15 @@ use Ibexa\Core\Repository\Helper\RelationProcessor;
 use Ibexa\Core\Repository\Mapper;
 use Ibexa\Core\Repository\Permission\LimitationService;
 use Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
+use Ibexa\Core\Repository\Repository as CoreRepository;
 use Ibexa\Core\Repository\User\PasswordValidatorInterface;
 use Ibexa\Core\Search\Common\BackgroundIndexer;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class RepositoryFactory implements ContainerAwareInterface
+final class RepositoryFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
-
-    /** @var string */
-    private $repositoryClass;
 
     /**
      * Policies map.
@@ -48,11 +46,9 @@ class RepositoryFactory implements ContainerAwareInterface
     private $languageResolver;
 
     public function __construct(
-        $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver
     ) {
-        $this->repositoryClass = $repositoryClass;
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
     }
@@ -88,7 +84,7 @@ class RepositoryFactory implements ContainerAwareInterface
         NameSchemaServiceInterface $nameSchemaService,
         array $languages
     ): Repository {
-        return new $this->repositoryClass(
+        return new CoreRepository(
             $persistenceHandler,
             $searchHandler,
             $backgroundIndexer,

--- a/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
@@ -35,22 +35,23 @@ use Psr\Log\NullLogger;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type TPolicyMap from \Ibexa\Contracts\Core\Repository\RoleService
  */
 final class RepositoryFactory implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    /**
-     * Policies map.
-     *
-     * @var array
-     */
+    /** @phpstan-var TPolicyMap */
     private array $policyMap;
 
     private LanguageResolver $languageResolver;
 
     private RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
+    /**
+     * @phpstan-param TPolicyMap $policyMap
+     */
     public function __construct(
         array $policyMap,
         LanguageResolver $languageResolver,

--- a/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/src/lib/Base/Container/ApiLoader/RepositoryFactory.php
@@ -28,19 +28,15 @@ use Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use Ibexa\Core\Repository\Repository as CoreRepository;
 use Ibexa\Core\Repository\User\PasswordValidatorInterface;
 use Ibexa\Core\Search\Common\BackgroundIndexer;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-final class RepositoryFactory implements ContainerAwareInterface
+final class RepositoryFactory
 {
-    use ContainerAwareTrait;
-
     /**
      * Policies map.
      *
      * @var array
      */
-    protected $policyMap = [];
+    private $policyMap = [];
 
     /** @var \Ibexa\Contracts\Core\Repository\LanguageResolver */
     private $languageResolver;

--- a/src/lib/Repository/RoleService.php
+++ b/src/lib/Repository/RoleService.php
@@ -42,6 +42,8 @@ use Ibexa\Core\Repository\Values\User\RoleCreateStruct;
 
 /**
  * This service provides methods for managing Roles and Policies.
+ *
+ * @phpstan-import-type TPolicyMap from \Ibexa\Contracts\Core\Repository\RoleService
  */
 class RoleService implements RoleServiceInterface
 {
@@ -57,8 +59,8 @@ class RoleService implements RoleServiceInterface
     /** @var \Ibexa\Core\Repository\Mapper\RoleDomainMapper */
     protected $roleDomainMapper;
 
-    /** @var array */
-    protected $settings;
+    /** @phpstan-var array{policyMap: TPolicyMap}|array{} */
+    protected array $settings;
 
     /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
     private $permissionResolver;
@@ -66,11 +68,7 @@ class RoleService implements RoleServiceInterface
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Repository $repository
-     * @param \Ibexa\Contracts\Core\Persistence\User\Handler $userHandler
-     * @param \Ibexa\Core\Repository\Permission\LimitationService $limitationService
-     * @param \Ibexa\Core\Repository\Mapper\RoleDomainMapper $roleDomainMapper
-     * @param array $settings
+     * @phpstan-param array{policyMap: TPolicyMap}|array{} $settings
      */
     public function __construct(
         RepositoryInterface $repository,

--- a/src/lib/Resources/settings/repository/autowire.yml
+++ b/src/lib/Resources/settings/repository/autowire.yml
@@ -1,4 +1,6 @@
 services:
+    Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface: '@Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider'
+
     Ibexa\Contracts\Core\Repository\Repository: '@ibexa.api.repository'
 
     Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface: '@ibexa.config.resolver'

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -9,7 +9,6 @@ services:
     Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
         class: Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory
         arguments:
-            - Ibexa\Core\Repository\Repository
             - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
         calls:

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -13,33 +13,33 @@ services:
 
     Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory:
         arguments:
-            - '%ibexa.api.role.policy_map%'
-            - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
+            $policyMap: '%ibexa.api.role.policy_map%'
+            $languageResolver: '@Ibexa\Contracts\Core\Repository\LanguageResolver'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
 
     Ibexa\Core\Repository\Repository:
         factory: ['@Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory', buildRepository]
         arguments:
-            - '@ibexa.api.persistence_handler'
-            - '@ibexa.spi.search'
-            - '@Ibexa\Bundle\Core\EventListener\BackgroundIndexingTerminateListener'
-            - '@Ibexa\Core\Repository\Helper\RelationProcessor'
-            - '@Ibexa\Core\FieldType\FieldTypeRegistry'
-            - '@Ibexa\Core\Repository\User\PasswordHashService'
-            - '@Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
-            - '@Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactory'
-            - '@Ibexa\Core\Repository\Mapper\ContentDomainMapper'
-            - '@Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper'
-            - '@Ibexa\Core\Repository\Mapper\RoleDomainMapper'
-            - '@Ibexa\Core\Repository\Mapper\ContentMapper'
-            - '@Ibexa\Contracts\Core\Repository\Validator\ContentValidator'
-            - '@Ibexa\Core\Repository\Permission\LimitationService'
-            - '@Ibexa\Contracts\Core\Repository\PermissionService'
-            - '@Ibexa\Contracts\Core\Persistence\Filter\Content\Handler'
-            - '@Ibexa\Contracts\Core\Persistence\Filter\Location\Handler'
-            - '@Ibexa\Core\Repository\User\PasswordValidatorInterface'
-            - '@ibexa.config.resolver'
-            - '@Ibexa\Contracts\Core\Repository\NameSchema\NameSchemaServiceInterface'
-            - '%languages%'
+            $persistenceHandler: '@ibexa.api.persistence_handler'
+            $searchHandler: '@ibexa.spi.search'
+            $backgroundIndexer: '@Ibexa\Bundle\Core\EventListener\BackgroundIndexingTerminateListener'
+            $relationProcessor: '@Ibexa\Core\Repository\Helper\RelationProcessor'
+            $fieldTypeRegistry: '@Ibexa\Core\FieldType\FieldTypeRegistry'
+            $passwordHashService: '@Ibexa\Core\Repository\User\PasswordHashService'
+            $thumbnailStrategy: '@Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
+            $proxyDomainMapperFactory: '@Ibexa\Core\Repository\ProxyFactory\ProxyDomainMapperFactory'
+            $contentDomainMapper: '@Ibexa\Core\Repository\Mapper\ContentDomainMapper'
+            $contentTypeDomainMapper: '@Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper'
+            $roleDomainMapper: '@Ibexa\Core\Repository\Mapper\RoleDomainMapper'
+            $contentMapper: '@Ibexa\Core\Repository\Mapper\ContentMapper'
+            $contentValidator: '@Ibexa\Contracts\Core\Repository\Validator\ContentValidator'
+            $limitationService: '@Ibexa\Core\Repository\Permission\LimitationService'
+            $permissionService: '@Ibexa\Contracts\Core\Repository\PermissionService'
+            $contentFilteringHandler: '@Ibexa\Contracts\Core\Persistence\Filter\Content\Handler'
+            $locationFilteringHandler: '@Ibexa\Contracts\Core\Persistence\Filter\Location\Handler'
+            $passwordValidator: '@Ibexa\Core\Repository\User\PasswordValidatorInterface'
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $nameSchemaService: '@Ibexa\Contracts\Core\Repository\NameSchema\NameSchemaServiceInterface'
 
     Ibexa\Core\Repository\ContentService:
         class: Ibexa\Core\Repository\ContentService

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -6,14 +6,18 @@ parameters:
 
     # intentionally defined class parameter to be used by the Repository Factory
 services:
-    Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
-        class: Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory
+    Ibexa\Core\Base\Container\ApiLoader\RepositoryConfigurationProvider:
+        arguments:
+            $configResolver: '@Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface'
+            $repositories: '%ibexa.repositories%'
+
+    Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory:
         arguments:
             - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
 
     Ibexa\Core\Repository\Repository:
-        factory: ['@Ibexa\Bundle\Core\ApiLoader\RepositoryFactory', buildRepository]
+        factory: ['@Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory', buildRepository]
         arguments:
             - '@ibexa.api.persistence_handler'
             - '@ibexa.spi.search'

--- a/src/lib/Resources/settings/repository/inner.yml
+++ b/src/lib/Resources/settings/repository/inner.yml
@@ -11,8 +11,6 @@ services:
         arguments:
             - '%ibexa.api.role.policy_map%'
             - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
-        calls:
-            - [setContainer, ["@service_container"]]
 
     Ibexa\Core\Repository\Repository:
         factory: ['@Ibexa\Bundle\Core\ApiLoader\RepositoryFactory', buildRepository]

--- a/tests/integration/Core/Resources/settings/integration_legacy.yml
+++ b/tests/integration/Core/Resources/settings/integration_legacy.yml
@@ -14,6 +14,22 @@ parameters:
 
     ibexa.site_access.config.default.user_content_type_identifier: ['user']
 
+    ibexa.repositories:
+        default:
+            storage: ~
+            search:
+                engine: '%env(SEARCH_ENGINE)%'
+                connection: default
+            fields_groups:
+                list: [content, metadata]
+                default: content
+            options:
+                default_version_archive_limit: 5
+                remove_archived_versions_on_publish: true
+
+    ibexa.site_access.config.default.repository: default
+    ibexa.site_access.config.default.languages: '%languages%'
+
 services:
     Ibexa\Core\FieldType\ImageAsset\AssetMapper:
         arguments:


### PR DESCRIPTION
| :ticket: Issue | IBX-8400 on the way to IBX-3183 |
|----------------|-----------|


#### Related PRs: 
- ibexa/core#383

#### Description:

##### TL;DR;

Merged Core Bundle and Core Repository layer `RepositoryFactory` classes into one. Deprecated the Bundle one in favor of the Repository one.

##### Background

We have ambiguous and redundant RepositoryFactory DI definitions and implementations on Bundle and Repository levels respectively.

```yaml
 Ibexa\Bundle\Core\ApiLoader\RepositoryFactory:
        class: Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory
        arguments:
            - Ibexa\Core\Repository\Repository
            - '%ibexa.api.role.policy_map%'
            - '@Ibexa\Contracts\Core\Repository\LanguageResolver'
        calls:
            - [setContainer, ["@service_container"]]

    Ibexa\Core\Repository\Repository:
        factory: ['@Ibexa\Bundle\Core\ApiLoader\RepositoryFactory', buildRepository]
```

Basically ` Ibexa\Bundle\Core\ApiLoader\RepositoryFactory` for Repository layer is a named service with `Ibexa\Core\Base\Container\ApiLoader\RepositoryFactory` as its implementation. Then on Bundle level it's overridden by the actual class implementation.

This causes quite a headache for both rector and static analysis. Moreover to modify any of the Repository services, changes to both classes are needed, which is difficult due to PHPStorm not understanding which definition is being modified. So this also constitutes a maintenance hell. We've also had issues in the past where due to existence of multiple `RepositoryFactory` definitions (maybe not ATM as it's overridden) wrong instances of services were injected (e.g. uninitialized permission resolver).

I've decided to extract some common abstraction and using it merge Bundle logic with Repository logic and use in DI only the Core Repository `RepositoryFactory`. ATM the Bundle one is just deprecated, however as in case of #383, I hope to back-port that to 4.6 and drop it here.

Additionally I've dropped support for dynamic Core Repository class passed as `RepositoryFactory` service argument. This is also difficult to maintain and makes no sense (substitution principle-wise) as it requires for a constructor to have the same argument list. If a custom `Repository` class is needed, the entire `RepositoryFactory` should be properly decorated.

All the changes allowed me to drop Container-awareness from `RepositoryFactory` and use proper dependency injection for `RepositoryConfigurationProvider` (see #383).

The legacy integration test setup configuration has been modified to have the same effect after changes to the factory.

I've also added an array shape `TPolicyMap` for policy configuration injected into `RoleService` through `Repository` through `RepositoryFactory`

##### Changelog:

- **Dropped support for dynamic Core Repository class in RepositoryFactory**
- **Made RepositoryFactory not Container-aware**
- **Deprecated Core Bundle RepositoryFactory in favor of Repository's one**
- **[PHPStan] Aligned baseline with the changes**
- **Combined Bundle and core RepositoryFactory into one**
- **[Tests] Added needed RepositoryFactory configuration to test setup**
- **[PHPStan] Introduced role policy map array shape as TPolicyMap**
- **[PHPStan] Aligned baseline with the changes**

#### For QA:

Regressions done via ibexa/commerce#877 should be enough.

#### Documentation:

- Deprecated Core Bundle `RepositoryFactory` in favor of the Core Repository one
- Dropped support for dynamic Core Repository class FQCN RepositoryFactory argument

