### PR TITLE
IBX-8356: Deprecated `Ibexa\Core\MVC\Symfony\Security\Authentication\AuthenticatorInterface` to be replaced with Symfony-based authorization in 5.0

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19591,7 +19591,7 @@ parameters:
 			path: src/lib/Persistence/Utf8Converter.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\Persistence\\\\Utf8Converter\\:\\:toUnicodeCodepoint\\(\\) should return int but returns int\\<0, max\\>\\|false\\.$#"
+			message: "#^Method Ibexa\\\\Core\\\\Persistence\\\\Utf8Converter\\:\\:toUnicodeCodepoint\\(\\) should return int but returns int\\<0, 2147483647\\>\\|false\\.$#"
 			count: 1
 			path: src/lib/Persistence/Utf8Converter.php
 

--- a/src/lib/MVC/Symfony/Security/Authentication/AuthenticatorInterface.php
+++ b/src/lib/MVC/Symfony/Security/Authentication/AuthenticatorInterface.php
@@ -11,6 +11,8 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * This interface is to be implemented by authenticator classes.
  * Authenticators are meant to be used to run authentication programmatically, i.e. outside the firewall context.
+ *
+ * @deprecated 4.6.7 this class is deprecated. Symfony Security has received major changes in 5.3, therefore Ibexa DXP relies on authenticator system from now on. Will be removed in 5.0.
  */
 interface AuthenticatorInterface
 {


### PR DESCRIPTION
| :ticket: Issue | IBX-8356 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/375

#### Description:
Since we are about to drop `AuthenticatorInterface` due to Symfony security changes, I marked it as deprecated in 4.6.

PHPStan baseline was regenerated on this occasion, unrelated to the proposed changes.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
