### PR TITLE
IBX-8426: Fixed duplicate relations

### DIFF
--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2009,13 +2009,13 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
-     * Loads all outgoing relations for the given version without checking the permissions on $versionInfo.
+     * Loads all outgoing relations for the given version without checking the permissions.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation[]
      */
-    protected function internalLoadRelations(APIVersionInfo $versionInfo, bool $checkDestinationPermission = true): array
+    protected function internalLoadRelations(APIVersionInfo $versionInfo): array
     {
         $contentInfo = $versionInfo->getContentInfo();
         $spiRelations = $this->persistenceHandler->contentHandler()->loadRelations(
@@ -2027,7 +2027,7 @@ class ContentService implements ContentServiceInterface
         $relations = [];
         foreach ($spiRelations as $spiRelation) {
             $destinationContentInfo = $this->internalLoadContentInfoById($spiRelation->destinationContentId);
-            if ($checkDestinationPermission && !$this->permissionResolver->canUser('content', 'read', $destinationContentInfo)) {
+            if (!$this->permissionResolver->canUser('content', 'read', $destinationContentInfo)) {
                 continue;
             }
 

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -1421,7 +1421,7 @@ class ContentService implements ContentServiceInterface
                 )->id,
             ]
         );
-        $existingRelations = $this->internalLoadRelations($versionInfo, false);
+        $existingRelations = $this->repository->sudo(fn (): array => $this->internalLoadRelations($versionInfo));
 
         $this->repository->beginTransaction();
         try {

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -1421,7 +1421,7 @@ class ContentService implements ContentServiceInterface
                 )->id,
             ]
         );
-        $existingRelations = $this->internalLoadRelations($versionInfo);
+        $existingRelations = $this->internalLoadRelations($versionInfo, false);
 
         $this->repository->beginTransaction();
         try {
@@ -2009,13 +2009,13 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
-     * Loads all outgoing relations for the given version without checking the permissions.
+     * Loads all outgoing relations for the given version without checking the permissions on $versionInfo.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation[]
      */
-    protected function internalLoadRelations(APIVersionInfo $versionInfo): array
+    protected function internalLoadRelations(APIVersionInfo $versionInfo, bool $checkDestinationPermission = true): array
     {
         $contentInfo = $versionInfo->getContentInfo();
         $spiRelations = $this->persistenceHandler->contentHandler()->loadRelations(
@@ -2027,7 +2027,7 @@ class ContentService implements ContentServiceInterface
         $relations = [];
         foreach ($spiRelations as $spiRelation) {
             $destinationContentInfo = $this->internalLoadContentInfoById($spiRelation->destinationContentId);
-            if (!$this->permissionResolver->canUser('content', 'read', $destinationContentInfo)) {
+            if ($checkDestinationPermission && !$this->permissionResolver->canUser('content', 'read', $destinationContentInfo)) {
                 continue;
             }
 

--- a/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
+++ b/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
@@ -48,7 +48,10 @@ final class UpdateContentTest extends RepositoryTestCase
         // Read relations & check if count($relations) is unchanged
         self::setAdministratorUser();
         $relations = $contentService->loadRelations($folder->getVersionInfo());
-        self::assertCount(1, (array)$relations);
+        if ($relations instanceof \Traversable) {
+            $relations = iterator_to_array($relations);
+        }
+        self::assertCount(1, $relations);
     }
 
     /**

--- a/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
+++ b/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
@@ -70,12 +70,13 @@ final class UpdateContentTest extends BaseTest
 
         // 5. Create User that has no access to content in $privateSection
         $editorRole = $repository->getRoleService()->loadRole(3);
+        // remove existing role assignments
         foreach ($repository->getRoleService()->getRoleAssignments($editorRole) as $role) {
-            if ($role->getRoleLimitation()->limitationValues == ['/1/2/']) {
-                $repository->getRoleService()->removeRoleAssignment($role);
-            }
+            $repository->getRoleService()->removeRoleAssignment($role);
         }
+
         $editorUserGroup = $userService->loadUserGroup(13);
+        // grant access to standard section
         $repository->getRoleService()->assignRoleToUserGroup(
             $editorRole,
             $editorUserGroup,
@@ -93,6 +94,6 @@ final class UpdateContentTest extends BaseTest
         // 7. Read relations & check if count($relations) is unchanged
         $permissionResolver->setCurrentUserReference($userService->loadUser($administratorUserId));
         $relations = $contentService->loadRelations($folder->getVersionInfo());
-        self::assertEquals(1, count($relations));
+        self::assertEquals(1, count((array)$relations));
     }
 }

--- a/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
+++ b/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\ContentService;
+
+use Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation;
+use Ibexa\Tests\Integration\Core\Repository\BaseTest;
+
+/**
+ * @covers \Ibexa\Contracts\Core\Repository\ContentService
+ */
+final class UpdateContentTest extends BaseTest
+{
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     */
+    public function testUpdateContentHavingPrivateRelation(): void
+    {
+        $administratorUserId = $this->generateId('user', 14);
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        $sectionService = $repository->getSectionService();
+        $contentService = $repository->getContentService();
+        $userService = $repository->getUserService();
+        $permissionResolver = $repository->getPermissionResolver();
+
+        /* BEGIN: Use Case */
+        // 1. Add relation field to 'folder' ContentType
+        $folderType = $contentTypeService->loadContentTypeByIdentifier('folder');
+        $folderTypeDraft = $contentTypeService->createContentTypeDraft($folderType);
+
+        $titleFieldCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('relations', 'ezobjectrelationlist');
+        $titleFieldCreateStruct->names = ['eng-GB' => 'Relations'];
+        $titleFieldCreateStruct->descriptions = ['eng-GB' => 'Relations'];
+        $titleFieldCreateStruct->fieldGroup = 'content';
+        $titleFieldCreateStruct->position = 10;
+        $titleFieldCreateStruct->isTranslatable = false;
+        $titleFieldCreateStruct->isRequired = false;
+        $titleFieldCreateStruct->isSearchable = false;
+        $contentTypeService->addFieldDefinition($folderTypeDraft, $titleFieldCreateStruct);
+        $contentTypeService->publishContentTypeDraft($folderTypeDraft);
+
+        // 2. Add Section 'private'
+        $sectionCreateStruct = $sectionService->newSectionCreateStruct();
+        $sectionCreateStruct->identifier = 'private';
+        $sectionCreateStruct->name = 'Private Section';
+        $privateSection = $sectionService->createSection($sectionCreateStruct);
+
+        // 3. Add 'Private Folder'
+        $folderPrivate = $this->createFolder(['eng-GB' => 'Private Folder'], 2);
+        $sectionService->assignSection($folderPrivate->getContentInfo(), $privateSection);
+
+        // 4. Add folder with relation to 'Private Folder'
+        $folder = $this->createFolder(['eng-GB' => 'Folder with private relation'], 2);
+        $folderDraft = $contentService->createContentDraft($folder->getContentInfo());
+        $folderUpdateStruct = $contentService->newContentUpdateStruct();
+        $relationListTarget = [$folderPrivate->id];
+        $folderUpdateStruct->setField('relations', $relationListTarget);
+        $folder = $contentService->updateContent($folderDraft->getVersionInfo(), $folderUpdateStruct);
+        $contentService->publishVersion($folder->getVersionInfo());
+
+        // 5. Create User that has no access to content in $privateSection
+        $editorRole = $repository->getRoleService()->loadRole(3);
+        foreach ($repository->getRoleService()->getRoleAssignments($editorRole) as $role) {
+            if ($role->getRoleLimitation()->limitationValues == ['/1/2/']) {
+                $repository->getRoleService()->removeRoleAssignment($role);
+            }
+        }
+        $editorUserGroup = $userService->loadUserGroup(13);
+        $repository->getRoleService()->assignRoleToUserGroup(
+            $editorRole,
+            $editorUserGroup,
+            new SectionLimitation(['limitationValues' => [1]])
+        );
+        $editor = $this->createUser('test.editor', 'Editor', 'Test');
+
+        // 6. Create & publish new $folder version as $editor
+        $permissionResolver->setCurrentUserReference($editor);
+        $folderDraft = $contentService->createContentDraft($folder->getContentInfo());
+        $folderUpdateStruct = $contentService->newContentUpdateStruct();
+        $folder = $contentService->updateContent($folderDraft->getVersionInfo(), $folderUpdateStruct);
+        $contentService->publishVersion($folder->getVersionInfo());
+
+        // 7. Read relations & check if count($relations) is unchanged
+        $permissionResolver->setCurrentUserReference($userService->loadUser($administratorUserId));
+        $relations = $contentService->loadRelations($folder->getVersionInfo());
+        self::assertEquals(1, count($relations));
+    }
+}

--- a/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
+++ b/tests/integration/Core/Repository/ContentService/UpdateContentTest.php
@@ -31,22 +31,16 @@ final class UpdateContentTest extends BaseTest
         $sectionService = $repository->getSectionService();
         $contentService = $repository->getContentService();
         $userService = $repository->getUserService();
+        $roleService = $repository->getRoleService();
         $permissionResolver = $repository->getPermissionResolver();
 
-        /* BEGIN: Use Case */
         // 1. Add relation field to 'folder' ContentType
         $folderType = $contentTypeService->loadContentTypeByIdentifier('folder');
         $folderTypeDraft = $contentTypeService->createContentTypeDraft($folderType);
 
-        $titleFieldCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('relations', 'ezobjectrelationlist');
-        $titleFieldCreateStruct->names = ['eng-GB' => 'Relations'];
-        $titleFieldCreateStruct->descriptions = ['eng-GB' => 'Relations'];
-        $titleFieldCreateStruct->fieldGroup = 'content';
-        $titleFieldCreateStruct->position = 10;
-        $titleFieldCreateStruct->isTranslatable = false;
-        $titleFieldCreateStruct->isRequired = false;
-        $titleFieldCreateStruct->isSearchable = false;
-        $contentTypeService->addFieldDefinition($folderTypeDraft, $titleFieldCreateStruct);
+        $relationsFieldCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('relations', 'ezobjectrelationlist');
+        $relationsFieldCreateStruct->names = ['eng-GB' => 'Relations'];
+        $contentTypeService->addFieldDefinition($folderTypeDraft, $relationsFieldCreateStruct);
         $contentTypeService->publishContentTypeDraft($folderTypeDraft);
 
         // 2. Add Section 'private'
@@ -69,15 +63,15 @@ final class UpdateContentTest extends BaseTest
         $contentService->publishVersion($folder->getVersionInfo());
 
         // 5. Create User that has no access to content in $privateSection
-        $editorRole = $repository->getRoleService()->loadRole(3);
+        $editorRole = $roleService->loadRole(3);
         // remove existing role assignments
-        foreach ($repository->getRoleService()->getRoleAssignments($editorRole) as $role) {
-            $repository->getRoleService()->removeRoleAssignment($role);
+        foreach ($roleService->getRoleAssignments($editorRole) as $role) {
+            $roleService->removeRoleAssignment($role);
         }
 
         $editorUserGroup = $userService->loadUserGroup(13);
         // grant access to standard section
-        $repository->getRoleService()->assignRoleToUserGroup(
+        $roleService->assignRoleToUserGroup(
             $editorRole,
             $editorUserGroup,
             new SectionLimitation(['limitationValues' => [1]])

--- a/tests/integration/Core/RepositoryTestCase.php
+++ b/tests/integration/Core/RepositoryTestCase.php
@@ -51,7 +51,7 @@ abstract class RepositoryTestCase extends IbexaKernelTestCase
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      */
-    protected function createUser(string $login, string $firstName, string $lastName, UserGroup $userGroup = null): User
+    final protected function createUser(string $login, string $firstName, string $lastName, UserGroup $userGroup = null): User
     {
         $userService = self::getUserService();
 

--- a/tests/lib/Repository/Service/Mock/ContentTest.php
+++ b/tests/lib/Repository/Service/Mock/ContentTest.php
@@ -3317,7 +3317,7 @@ class ContentTest extends BaseServiceMockTest
             ->expects($this->once())
             ->method('getCurrentUserReference')
             ->willReturn(new UserReference(169));
-        $mockedService = $this->getPartlyMockedContentService(['internalLoadContentById', 'internalLoadRelations'], $permissionResolverMock);
+        $mockedService = $this->getPartlyMockedContentService(['internalLoadContentById'], $permissionResolverMock);
         $permissionResolverMock = $this->getPermissionResolverMock();
         /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandlerMock */
         $contentHandlerMock = $this->getPersistenceMock()->contentHandler();
@@ -3470,10 +3470,7 @@ class ContentTest extends BaseServiceMockTest
             )->will($this->returnValue([]));
 
         $existingRelations = ['RELATIONS!!!'];
-        $mockedService
-            ->method('internalLoadRelations')
-            ->with($content->versionInfo)
-            ->will($this->returnValue($existingRelations));
+        $repositoryMock->method('sudo')->willReturn($existingRelations);
         $relationProcessorMock->expects($this->any())
             ->method('processFieldRelations')
             ->with(


### PR DESCRIPTION
| :ticket: Issue | IBX-8426 |
|----------------|-----------|

#### Description:

~PR adds a "permission switch" to `internalLoadRelations()`.~

maintainer update: changed to use sudo as all of them are needed for the update process, see review notes.

Background:
When a user changes Content with related Content without having read permission to the related Content, existing relations are duplicated in `ezcontentobject_link` table.

https://github.com/ibexa/core/blob/4.6/src/lib/Repository/ContentService.php#L1432
```
$this->relationProcessor->processFieldRelations(
          $inputRelations,
          $spiContent->versionInfo->contentInfo->id,
          $spiContent->versionInfo->versionNo,
          $contentType,
          $existingRelations
      );
```
- `processFieldRelations() ` adds all relations from `$inputRelations` that do **not** alreaday exist in  `$existingRelations`.
-  `$existingRelations` are load from `internalLoadRelations()` - skipping non-readable Content
```
 protected function internalLoadRelations(APIVersionInfo $versionInfo): array
 {
        ..
        /** @var $relations \Ibexa\Contracts\Core\Repository\Values\Content\Relation[] */
        $relations = [];
        foreach ($spiRelations as $spiRelation) {
            $destinationContentInfo = $this->internalLoadContentInfoById($spiRelation->destinationContentId);
            if (!$this->permissionResolver->canUser('content', 'read', $destinationContentInfo)) {
                continue;
            }
         }
        ..
}
```


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
