### PR TITLE
RFC: Injected previous exception into field validation exception

### DIFF
--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -340,11 +340,6 @@ interface ContentService
      * Publishes a content version and deletes archive versions if they overflow max archive versions.
      * Max archive versions are currently a configuration for default max limit, by default set to 5.
      *
-     * @todo Introduce null|int ContentType->versionArchiveLimit to be able to let admins override this per type.
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
      * @param string[] $translations List of language codes of translations which will be included
      *                               in a published version.
@@ -354,6 +349,13 @@ interface ContentService
      *                               overriding those in the current version.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
      */
     public function publishVersion(VersionInfo $versionInfo, array $translations = Language::ALL): Content;
 

--- a/src/lib/Base/Exceptions/ContentFieldValidationException.php
+++ b/src/lib/Base/Exceptions/ContentFieldValidationException.php
@@ -9,6 +9,7 @@ namespace Ibexa\Core\Base\Exceptions;
 use Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException as APIContentFieldValidationException;
 use Ibexa\Core\Base\Translatable;
 use Ibexa\Core\Base\TranslatableBase;
+use Throwable;
 
 /**
  * This Exception is thrown on create or update content one or more given fields are not valid.
@@ -42,11 +43,11 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *
      * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
      */
-    public function __construct(array $errors)
+    public function __construct(array $errors, ?Throwable $previous = null)
     {
         $this->errors = $errors;
         $this->setMessageTemplate('Content fields did not validate');
-        parent::__construct($this->getBaseTranslation());
+        parent::__construct($this->getBaseTranslation(), 0, $previous);
     }
 
     /**
@@ -54,15 +55,15 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *
      * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
      */
-    public static function createNewWithMultiline(array $errors, ?string $contentName = null): self
+    public static function createNewWithMultiline(array $errors, ?string $contentName = null, ?Throwable $previous = null): self
     {
-        $exception = new self($errors);
+        $exception = new self($errors, $previous);
         $exception->contentName = $contentName;
 
         $exception->setMessageTemplate('Content "%contentName%" fields did not validate: %errors%');
         $exception->setParameters([
             '%errors%' => $exception->generateValidationErrorsMessages(),
-            '%contentName%' => $exception->contentName !== null ? $exception->contentName : '',
+            '%contentName%' => $exception->contentName ?? '',
         ]);
         $exception->message = $exception->getBaseTranslation();
 

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -1449,22 +1449,6 @@ class ContentService implements ContentServiceInterface
         );
     }
 
-    /**
-     * Publishes a content version.
-     *
-     * Publishes a content version and deletes archive versions if they overflow max archive versions.
-     * Max archive versions are currently a configuration, but might be moved to be a param of ContentType in the future.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
-     * @param string[] $translations
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
-     */
     public function publishVersion(APIVersionInfo $versionInfo, array $translations = Language::ALL): APIContent
     {
         $content = $this->internalLoadContentById(
@@ -1721,13 +1705,16 @@ class ContentService implements ContentServiceInterface
      * Publishes a content version and deletes archive versions if they overflow max archive versions.
      * Max archive versions are currently a configuration, but might be moved to be a param of ContentType in the future.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
      * @param int|null $publicationDate If null existing date is kept if there is one, otherwise current time is used.
      * @param string[] $translations
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException if the version is not a draft
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
      */
     protected function internalPublishVersion(APIVersionInfo $versionInfo, $publicationDate = null, array $translations = Language::ALL)
     {

--- a/tests/lib/Base/Exception/ContentFieldValidationExceptionTest.php
+++ b/tests/lib/Base/Exception/ContentFieldValidationExceptionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Base\Exception;
+
+use Ibexa\Core\Base\Exceptions\ContentFieldValidationException;
+use Ibexa\Core\FieldType\ValidationError;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ibexa\Core\Base\Exceptions\ContentFieldValidationException
+ */
+final class ContentFieldValidationExceptionTest extends TestCase
+{
+    public function testGetFieldErrors(): ContentFieldValidationException
+    {
+        $errors = [
+            123 => [
+                'eng-GB' => [
+                    new ValidationError('error 1'), new ValidationError('error 2'),
+                ],
+                'pol-PL' => [
+                    new ValidationError('error 1'), new ValidationError('error 2'),
+                ],
+            ],
+            456 => [
+                'pol-PL' => [
+                    new ValidationError('error 3'), new ValidationError('error 4'),
+                ],
+                'eng-GB' => [
+                    new ValidationError('error 3'), new ValidationError('error 4'),
+                ],
+            ],
+        ];
+
+        $exception = new ContentFieldValidationException($errors);
+
+        self::assertSame($errors, $exception->getFieldErrors());
+
+        return $exception;
+    }
+
+    /**
+     * @depends testGetFieldErrors
+     */
+    public function testCreateNewWithMultiline(ContentFieldValidationException $exception): void
+    {
+        $newException = ContentFieldValidationException::createNewWithMultiline(
+            $exception->getFieldErrors(),
+            'My Content'
+        );
+
+        $expectedExceptionMessage = <<<MSG
+        Content "My Content" fields did not validate: 
+        - error 1
+        - error 2
+        - error 1
+        - error 2
+        - error 3
+        - error 4
+        - error 3
+        - error 4
+        MSG;
+
+        self::assertSame($expectedExceptionMessage, $newException->getMessage());
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

**Question after reading this:** Does this provide enough value?

#### Description:

> [!NOTE]
> The issue in ibexa/migrations, which I was trying to fix, actually no longer exists on 4.x - by accident - due to https://github.com/ibexa/migrations/pull/338. However I still believe this change presents some minor value.

##### Background

OOTB validation message returned by `ContentFieldValidationException::getMessage` states `"Content fields did not validate"`.
To avoid lack of verbosity here (user doesn't know where the error actually is) we have there static method `createNewWithMultiline`,
however it still needs to be called explicitly when handling the exception thrown from _some places_, [while in other places it has been wrapped already](https://github.com/ibexa/core/blob/v4.6.7/src/lib/Repository/ContentService.php#L1322). Leaving this as-is due to BC.

##### Fix 

This PR adds the possibility to include previous exception thrown when building new one using `ContentFieldValidationException::createNewWithMultiline`. Seems it is more correct to do:

```php
try {
 // ...
} catch (ContentFieldValidationException $e) {
  throw ContentFieldValidationException::createNewWithMultiline($e->getFieldErrors(), $contentName, $e);
}
```
however due to the mentioned migrations fix, provides little actual value - just improving here the exception API itself.

Ideally I would do:
```php
throw ContentFieldValidationException::createNewWithMultiline($e);
```
but that can't be done due to BC.

Additionally I've fixed broken PHPDoc for `ContentService::publishVersion`. Long time ago we've added the possibility to validate a content item during publishing instead of a create/update operation, but seems we've forgotten to document an exception that can be thrown.

#### For QA:

Not reproducible on 4.6 due to the mentioned migrations fix.

#### Documentation:
Rest API reference change for 4.6, not sure if extra doc action is needed here.

