### PR TITLE
[PHPDoc] Fixed LocationService::loadLocationChildren doc

### DIFF
--- a/src/contracts/Ibexa.php
+++ b/src/contracts/Ibexa.php
@@ -13,5 +13,5 @@ final class Ibexa
     /**
      * Ibexa DXP Version.
      */
-    public const VERSION = '4.6.7';
+    public const VERSION = '4.6.8';
 }

--- a/src/contracts/Repository/LocationService.php
+++ b/src/contracts/Repository/LocationService.php
@@ -98,15 +98,12 @@ interface LocationService
      * Loads children which are readable by the current user of a location object sorted by sortField and sortOrder.
      *
      * Use this method with caution. It performs heavy queries on the database.
-     * Consider using {@see \eZ\Publish\API\Repository\SearchService::findLocations()} with
-     * {@see \eZ\Publish\Core\QueryType\BuiltIn\ChildrenQueryType} as an alternative.
+     * Consider using {@see \Ibexa\Contracts\Core\Repository\SearchService::findLocations()} with
+     * {@see \Ibexa\Core\QueryType\BuiltIn\ChildrenQueryType} as an alternative.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Location $location
      * @param int $offset the start offset for paging
      * @param int $limit the number of locations returned
      * @param string[]|null $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\LocationList
      */
     public function loadLocationChildren(Location $location, int $offset = 0, int $limit = 25, ?array $prioritizedLanguages = null): LocationList;
 


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|


#### Description:

Seems we've missed the references to legacy namespace in PHPDoc of `\Ibexa\Contracts\Core\Repository\LocationService::loadLocationChildren` during the merge up.