### PR TITLE
IBX-8378: [Tests] Fixed setting image field as searchable for tests

### DIFF
--- a/tests/integration/Core/Repository/SearchServiceImageTest.php
+++ b/tests/integration/Core/Repository/SearchServiceImageTest.php
@@ -365,6 +365,11 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
         );
     }
 
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
     private function setFieldTypeAsSearchable(
         ContentTypeDraft $contentTypeDraft,
         FieldDefinition $fieldDefinition
@@ -379,5 +384,6 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
             $fieldDefinition,
             $fieldDefinitionUpdateStruct
         );
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8378 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/solr/pull/71

#### Description:

This PR fixes changing image field type to be searchable. Content type needs to be published after changes. It worked by accident due to IBX-8378 bug. See Solr failures for ref.: https://github.com/ibexa/solr/actions/runs/9858608824/job/27257334657?pr=71
