### PR TITLE
Extracted common base for TextBlock and TextLine field types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10126,41 +10126,6 @@ parameters:
 			path: src/lib/FieldType/TextBlock/SearchField.php
 
 		-
-			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\:\\:\\$text\\.$#"
-			count: 2
-			path: src/lib/FieldType/TextBlock/Type.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\TextBlock\\\\Type\\:\\:checkValueStructure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/FieldType/TextBlock/Type.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$value with type mixed is not subtype of native type Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\.$#"
-			count: 1
-			path: src/lib/FieldType/TextBlock/Type.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/lib/FieldType/TextBlock/Type.php
-
-		-
-			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\:\\:\\$text\\.$#"
-			count: 2
-			path: src/lib/FieldType/TextLine/Type.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\TextLine\\\\Type\\:\\:checkValueStructure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/FieldType/TextLine/Type.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$value with type mixed is not subtype of native type Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\.$#"
-			count: 1
-			path: src/lib/FieldType/TextLine/Type.php
-
-		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value\\:\\:\\$time\\.$#"
 			count: 1
 			path: src/lib/FieldType/Time/Type.php
@@ -33296,16 +33261,6 @@ parameters:
 			path: tests/integration/Core/Repository/FieldType/TextBlockIntegrationTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextBlock\\\\Value constructor expects string, int given\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/TextBlockIntegrationTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextBlock\\\\Value constructor expects string, null given\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/TextBlockIntegrationTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\TextLineIntegrationTest\\:\\:assertCopiedFieldDataLoadedCorrectly\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
@@ -33377,16 +33332,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Integration\\\\Core\\\\Repository\\\\FieldType\\\\TextLineIntegrationTest\\:\\:providerForTestIsNotEmptyValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextLine\\\\Value constructor expects string, int given\\.$#"
-			count: 1
-			path: tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextLine\\\\Value constructor expects string, null given\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
 
@@ -43814,126 +43759,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\StringLengthValidatorTest\\:\\:testValidateWrongValues\\(\\) has parameter \\$values with no type specified\\.$#"
 			count: 1
 			path: tests/lib/FieldType/StringLengthValidatorTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:getSettingsSchemaExpectation\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:getValidatorConfigurationSchemaExpectation\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:provideDataForGetName\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:provideInValidFieldSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:provideInputForFromHash\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:provideInputForToHash\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:provideInvalidInputForAcceptValue\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:provideValidFieldSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextBlockTest\\:\\:provideValidInputForAcceptValue\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextBlock\\\\Value constructor expects string, int given\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextBlock\\\\Value constructor expects string, null given\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextBlockTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:getSettingsSchemaExpectation\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:getValidatorConfigurationSchemaExpectation\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideDataForGetName\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideInputForFromHash\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideInputForToHash\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideInvalidDataForValidate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideInvalidInputForAcceptValue\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideInvalidValidatorConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideValidDataForValidate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideValidInputForAcceptValue\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TextLineTest\\:\\:provideValidValidatorConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextLine\\\\Value constructor expects string, int given\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$text of class Ibexa\\\\Core\\\\FieldType\\\\TextLine\\\\Value constructor expects string, null given\\.$#"
-			count: 1
-			path: tests/lib/FieldType/TextLineTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\FieldType\\\\TimeTest\\:\\:getSettingsSchemaExpectation\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/src/lib/FieldType/BaseTextType.php
+++ b/src/lib/FieldType/BaseTextType.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\FieldType;
+
+use Ibexa\Contracts\Core\FieldType\Value as FieldTypeValueInterface;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
+use Ibexa\Core\FieldType\Value as BaseValue;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
+
+/**
+ * @internal
+ *
+ * Base implementation for TextLine\Type and TextBlock\Type which extends TextLine\Type.
+ */
+abstract class BaseTextType extends FieldType implements TranslationContainerInterface
+{
+    public function isSearchable(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param \Ibexa\Core\FieldType\TextLine\Value $value
+     */
+    public function getName(
+        FieldTypeValueInterface $value,
+        FieldDefinition $fieldDefinition,
+        string $languageCode
+    ): string {
+        return (string)$value->text;
+    }
+
+    /**
+     * @param \Ibexa\Core\FieldType\TextLine\Value $value
+     */
+    public function isEmptyValue(FieldTypeValueInterface $value): bool
+    {
+        return $value->text === null || trim($value->text) === '';
+    }
+
+    /**
+     * @param \Ibexa\Core\FieldType\TextLine\Value $value
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected structure.
+     */
+    protected function checkValueStructure(BaseValue $value): void
+    {
+        if (!is_string($value->text)) {
+            throw new InvalidArgumentType(
+                '$value->text',
+                'string',
+                $value->text
+            );
+        }
+    }
+
+    protected function buildUnknownValidatorError(string $parameterName, string $validatorIdentifier): ValidationError
+    {
+        return new ValidationError(
+            "Validator '$parameterName' is unknown",
+            null,
+            [
+                $parameterName => $validatorIdentifier,
+            ]
+        );
+    }
+
+    /**
+     * @param \Ibexa\Core\FieldType\TextLine\Value $value
+     */
+    public function toHash(FieldTypeValueInterface $value): ?string
+    {
+        if ($this->isEmptyValue($value)) {
+            return null;
+        }
+
+        return $value->text;
+    }
+}

--- a/src/lib/FieldType/TextBlock/Type.php
+++ b/src/lib/FieldType/TextBlock/Type.php
@@ -126,9 +126,6 @@ class Type extends BaseTextType
         return $validationErrors;
     }
 
-    /**
-     * @return list<\JMS\TranslationBundle\Model\Message>
-     */
     public static function getTranslationMessages(): array
     {
         return [

--- a/src/lib/FieldType/TextBlock/Type.php
+++ b/src/lib/FieldType/TextBlock/Type.php
@@ -7,21 +7,18 @@
 
 namespace Ibexa\Core\FieldType\TextBlock;
 
-use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
-use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
-use Ibexa\Core\FieldType\FieldType;
+use Ibexa\Core\FieldType\BaseTextType;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * The TextBlock field type.
  *
  * Represents a larger body of text, such as text areas.
  */
-class Type extends FieldType implements TranslationContainerInterface
+class Type extends BaseTextType
 {
     protected $settingsSchema = [
         'textRows' => [
@@ -32,50 +29,17 @@ class Type extends FieldType implements TranslationContainerInterface
 
     protected $validatorConfigurationSchema = [];
 
-    /**
-     * Returns the field type identifier for this field type.
-     *
-     * @return string
-     */
     public function getFieldTypeIdentifier()
     {
         return 'eztext';
     }
 
-    /**
-     * @param \Ibexa\Core\FieldType\TextBlock\Value|\Ibexa\Contracts\Core\FieldType\Value $value
-     */
-    public function getName(SPIValue $value, FieldDefinition $fieldDefinition, string $languageCode): string
-    {
-        return (string)$value->text;
-    }
-
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\TextBlock\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
 
     /**
-     * Returns if the given $value is considered empty by the field type.
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    public function isEmptyValue(SPIValue $value)
-    {
-        return $value->text === null || trim($value->text) === '';
-    }
-
-    /**
-     * Inspects given $inputValue and potentially converts it into a dedicated value object.
-     *
      * @param string|\Ibexa\Core\FieldType\TextBlock\Value $inputValue
      *
      * @return \Ibexa\Core\FieldType\TextBlock\Value The potentially converted and structurally plausible value.
@@ -89,21 +53,10 @@ class Type extends FieldType implements TranslationContainerInterface
         return $inputValue;
     }
 
-    /**
-     * Throws an exception if value structure is not of expected format.
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected structure.
-     *
-     * @param \Ibexa\Core\FieldType\TextBlock\Value $value
-     */
-    protected function checkValueStructure(BaseValue $value)
+    protected static function checkValueType(mixed $value): void
     {
-        if (!is_string($value->text)) {
-            throw new InvalidArgumentType(
-                '$value->text',
-                'string',
-                $value->text
-            );
+        if (!$value instanceof Value) {
+            throw new InvalidArgumentType('$value', Value::class, $value);
         }
     }
 
@@ -112,24 +65,21 @@ class Type extends FieldType implements TranslationContainerInterface
      *
      * @param \Ibexa\Core\FieldType\TextBlock\Value $value
      *
-     * @return string
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(BaseValue $value): string
     {
-        return $this->transformationProcessor->transformByGroup(
-            mb_substr(strtok(trim($value->text), "\r\n"), 0, 255),
-            'lowercase'
-        );
+        $tokens = strtok(trim($value->text), "\r\n");
+
+        return $tokens !== false
+            ? $this->transformationProcessor->transformByGroup(mb_substr($tokens, 0, 255), 'lowercase')
+            : '';
     }
 
     /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\TextBlock\Value $value
+     * @param string $hash
      */
-    public function fromHash($hash)
+    public function fromHash($hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -139,57 +89,27 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
-     * @param \Ibexa\Core\FieldType\TextBlock\Value $value
-     *
-     * @return mixed
-     */
-    public function toHash(SPIValue $value)
-    {
-        if ($this->isEmptyValue($value)) {
-            return null;
-        }
-
-        return $value->text;
-    }
-
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
-    public function isSearchable()
-    {
-        return true;
-    }
-
-    /**
      * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
      *
      * @param mixed $fieldSettings
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings($fieldSettings): array
     {
         $validationErrors = [];
 
         foreach ($fieldSettings as $name => $value) {
             if (isset($this->settingsSchema[$name])) {
-                switch ($name) {
-                    case 'textRows':
-                        if (!is_int($value)) {
-                            $validationErrors[] = new ValidationError(
-                                "Setting '%setting%' value must be of integer type",
-                                null,
-                                [
-                                    '%setting%' => $name,
-                                ],
-                                "[$name]"
-                            );
-                        }
-                        break;
+                if ($name === 'textRows' && !is_int($value)) {
+                    $validationErrors[] = new ValidationError(
+                        "Setting '%setting%' value must be of integer type",
+                        null,
+                        [
+                            '%setting%' => $name,
+                        ],
+                        "[$name]"
+                    );
                 }
             } else {
                 $validationErrors[] = new ValidationError(
@@ -206,6 +126,9 @@ class Type extends FieldType implements TranslationContainerInterface
         return $validationErrors;
     }
 
+    /**
+     * @return list<\JMS\TranslationBundle\Model\Message>
+     */
     public static function getTranslationMessages(): array
     {
         return [

--- a/src/lib/FieldType/TextLine/Type.php
+++ b/src/lib/FieldType/TextLine/Type.php
@@ -7,22 +7,20 @@
 
 namespace Ibexa\Core\FieldType\TextLine;
 
+use Ibexa\Contracts\Core\Exception\InvalidArgumentType;
 use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
-use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
-use Ibexa\Core\FieldType\FieldType;
-use Ibexa\Core\FieldType\ValidationError;
+use Ibexa\Core\FieldType\BaseTextType;
 use Ibexa\Core\FieldType\Validator\StringLengthValidator;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * The TextLine field type.
  *
  * This field type represents a simple string.
  */
-class Type extends FieldType implements TranslationContainerInterface
+class Type extends BaseTextType
 {
     protected $validatorConfigurationSchema = [
         'StringLengthValidator' => [
@@ -40,27 +38,21 @@ class Type extends FieldType implements TranslationContainerInterface
     /**
      * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
      *
-     * @param mixed $validatorConfiguration
+     * @param array<string, mixed> $validatorConfiguration
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validateValidatorConfiguration($validatorConfiguration)
+    public function validateValidatorConfiguration($validatorConfiguration): array
     {
         $validationErrors = [];
-        $validator = new StringLengthValidator();
+        $validators = ['StringLengthValidator' => new StringLengthValidator()];
 
         foreach ($validatorConfiguration as $validatorIdentifier => $constraints) {
-            if ($validatorIdentifier !== 'StringLengthValidator') {
-                $validationErrors[] = new ValidationError(
-                    "Validator '%validator%' is unknown",
-                    null,
-                    [
-                        '%validator%' => $validatorIdentifier,
-                    ]
-                );
+            if (!isset($validators[$validatorIdentifier])) {
+                $validationErrors[] = $this->buildUnknownValidatorError('%validator%', $validatorIdentifier);
                 continue;
             }
-            $validationErrors += $validator->validateConstraints($constraints);
+            $validationErrors += $validators[$validatorIdentifier]->validateConstraints($constraints);
         }
 
         return $validationErrors;
@@ -69,14 +61,14 @@ class Type extends FieldType implements TranslationContainerInterface
     /**
      * Validates a field based on the validators in the field definition.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
      * @param \Ibexa\Core\FieldType\TextLine\Value $fieldValue The field value for which an action is performed
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\PropertyNotFoundException
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue): array
     {
         $validationErrors = [];
 
@@ -85,85 +77,27 @@ class Type extends FieldType implements TranslationContainerInterface
         }
 
         $validatorConfiguration = $fieldDefinition->getValidatorConfiguration();
-        $constraints = isset($validatorConfiguration['StringLengthValidator'])
-            ? $validatorConfiguration['StringLengthValidator']
-            : [];
+        $constraints = $validatorConfiguration['StringLengthValidator'] ?? [];
+        $validator = new StringLengthValidator();
+        $validator->initializeWithConstraints($constraints);
 
-        if (isset($constraints['maxStringLength']) &&
-            $constraints['maxStringLength'] !== false &&
-            $constraints['maxStringLength'] !== 0 &&
-            mb_strlen($fieldValue->text) > $constraints['maxStringLength']) {
-            $validationErrors[] = new ValidationError(
-                'The string can not exceed %size% character.',
-                'The string can not exceed %size% characters.',
-                [
-                    '%size%' => $constraints['maxStringLength'],
-                ],
-                'text'
-            );
-        }
-
-        if (isset($constraints['minStringLength']) &&
-            $constraints['minStringLength'] !== false &&
-            $constraints['minStringLength'] !== 0 &&
-            mb_strlen($fieldValue->text) < $constraints['minStringLength']) {
-            $validationErrors[] = new ValidationError(
-                'The string cannot be shorter than %size% character.',
-                'The string cannot be shorter than %size% characters.',
-                [
-                    '%size%' => $constraints['minStringLength'],
-                ],
-                'text'
-            );
-        }
-
-        return $validationErrors;
+        return false === $validator->validate($fieldValue, $fieldDefinition) ? $validator->getMessage() : [];
     }
 
-    /**
-     * Returns the field type identifier for this field type.
-     *
-     * @return string
-     */
     public function getFieldTypeIdentifier()
     {
         return 'ezstring';
     }
 
     /**
-     * @param \Ibexa\Core\FieldType\TextLine\Value|\Ibexa\Contracts\Core\FieldType\Value $value
-     */
-    public function getName(SPIValue $value, FieldDefinition $fieldDefinition, string $languageCode): string
-    {
-        return (string)$value->text;
-    }
-
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
      * @return \Ibexa\Core\FieldType\TextLine\Value
      */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
 
     /**
-     * Returns if the given $value is considered empty by the field type.
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    public function isEmptyValue(SPIValue $value)
-    {
-        return $value->text === null || trim($value->text) === '';
-    }
-
-    /**
-     * Inspects given $inputValue and potentially converts it into a dedicated value object.
-     *
      * @param string|\Ibexa\Core\FieldType\TextLine\Value $inputValue
      *
      * @return \Ibexa\Core\FieldType\TextLine\Value The potentially converted and structurally plausible value.
@@ -177,21 +111,10 @@ class Type extends FieldType implements TranslationContainerInterface
         return $inputValue;
     }
 
-    /**
-     * Throws an exception if value structure is not of expected format.
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected structure.
-     *
-     * @param \Ibexa\Core\FieldType\TextLine\Value $value
-     */
-    protected function checkValueStructure(BaseValue $value)
+    protected static function checkValueType(mixed $value): void
     {
-        if (!is_string($value->text)) {
-            throw new InvalidArgumentType(
-                '$value->text',
-                'string',
-                $value->text
-            );
+        if (!$value instanceof Value) {
+            throw new InvalidArgumentType('$value', Value::class, $value);
         }
     }
 
@@ -199,22 +122,16 @@ class Type extends FieldType implements TranslationContainerInterface
      * Returns information for FieldValue->$sortKey relevant to the field type.
      *
      * @param \Ibexa\Core\FieldType\TextLine\Value $value
-     *
-     * @return string
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(BaseValue $value): string
     {
         return $this->transformationProcessor->transformByGroup((string)$value, 'lowercase');
     }
 
     /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\TextLine\Value $value
+     * @param string $hash
      */
-    public function fromHash($hash)
+    public function fromHash($hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -224,31 +141,8 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
-     * @param \Ibexa\Core\FieldType\TextLine\Value $value
-     *
-     * @return mixed
+     * @return list<\JMS\TranslationBundle\Model\Message>
      */
-    public function toHash(SPIValue $value)
-    {
-        if ($this->isEmptyValue($value)) {
-            return null;
-        }
-
-        return $value->text;
-    }
-
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
-    public function isSearchable()
-    {
-        return true;
-    }
-
     public static function getTranslationMessages(): array
     {
         return [

--- a/src/lib/FieldType/TextLine/Value.php
+++ b/src/lib/FieldType/TextLine/Value.php
@@ -16,23 +16,18 @@ class Value extends BaseValue
 {
     /**
      * Text content.
-     *
-     * @var string
      */
-    public $text;
+    public string $text;
 
-    /**
-     * Construct a new Value object and initialize it $text.
-     *
-     * @param string $text
-     */
-    public function __construct($text = '')
+    public function __construct(?string $text = '')
     {
-        $this->text = $text;
+        parent::__construct();
+
+        $this->text = (string)$text;
     }
 
     public function __toString()
     {
-        return (string)$this->text;
+        return $this->text;
     }
 }

--- a/src/lib/FieldType/Validator/StringLengthValidator.php
+++ b/src/lib/FieldType/Validator/StringLengthValidator.php
@@ -20,6 +20,8 @@ use Ibexa\Core\FieldType\Value as BaseValue;
  */
 class StringLengthValidator extends Validator
 {
+    private const string PARAMETER_NAME = '%parameter%';
+
     protected $constraints = [
         'maxStringLength' => false,
         'minStringLength' => false,
@@ -45,10 +47,10 @@ class StringLengthValidator extends Validator
                 case 'maxStringLength':
                     if ($value !== false && !is_int($value) && !(null === $value)) {
                         $validationErrors[] = new ValidationError(
-                            "Validator parameter '%parameter%' value must be of integer type",
+                            sprintf('Validator parameter \'%s\' value must be of integer type', self::PARAMETER_NAME),
                             null,
                             [
-                                '%parameter%' => $name,
+                                self::PARAMETER_NAME => $name,
                             ]
                         );
                     } elseif ($value < 0) {
@@ -56,7 +58,7 @@ class StringLengthValidator extends Validator
                             "Validator parameter '%parameter%' value can't be negative",
                             null,
                             [
-                                '%parameter%' => $name,
+                                self::PARAMETER_NAME => $name,
                             ]
                         );
                     }
@@ -66,7 +68,7 @@ class StringLengthValidator extends Validator
                         "Validator parameter '%parameter%' is unknown",
                         null,
                         [
-                            '%parameter%' => $name,
+                            self::PARAMETER_NAME => $name,
                         ]
                     );
             }
@@ -92,9 +94,8 @@ class StringLengthValidator extends Validator
      */
     protected function validateConstraintsOrder($constraints)
     {
-        return !isset($constraints['minStringLength']) ||
-            !isset($constraints['maxStringLength']) ||
-            ($constraints['minStringLength'] <= $constraints['maxStringLength']);
+        return !isset($constraints['minStringLength'], $constraints['maxStringLength'])
+            || ($constraints['minStringLength'] <= $constraints['maxStringLength']);
     }
 
     /**
@@ -110,27 +111,33 @@ class StringLengthValidator extends Validator
     {
         $isValid = true;
 
-        if ($this->constraints['maxStringLength'] !== false &&
-            $this->constraints['maxStringLength'] !== 0 &&
-            mb_strlen($value->text) > $this->constraints['maxStringLength']) {
+        // BC: these constraints can be not set, null, or false
+        $minStringLength = $this->constraints['minStringLength'] ?? false;
+        $maxStringLength = $this->constraints['maxStringLength'] ?? false;
+
+        if ($maxStringLength !== false &&
+            $maxStringLength !== 0 &&
+            mb_strlen($value->text) > $maxStringLength) {
             $this->errors[] = new ValidationError(
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
                 [
-                    '%size%' => $this->constraints['maxStringLength'],
-                ]
+                    '%size%' => $maxStringLength,
+                ],
+                'text'
             );
             $isValid = false;
         }
-        if ($this->constraints['minStringLength'] !== false &&
-            $this->constraints['minStringLength'] !== 0 &&
-            mb_strlen($value->text) < $this->constraints['minStringLength']) {
+        if ($minStringLength !== false &&
+            $minStringLength !== 0 &&
+            mb_strlen($value->text) < $minStringLength) {
             $this->errors[] = new ValidationError(
                 'The string cannot be shorter than %size% character.',
                 'The string cannot be shorter than %size% characters.',
                 [
-                    '%size%' => $this->constraints['minStringLength'],
-                ]
+                    '%size%' => $minStringLength,
+                ],
+                'text'
             );
             $isValid = false;
         }

--- a/tests/integration/Core/Repository/FieldType/TextBlockIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/TextBlockIntegrationTest.php
@@ -281,7 +281,6 @@ class TextBlockIntegrationTest extends SearchBaseIntegrationTest
             [
                 $this->getValidCreationFieldData(),
             ],
-            [new TextBlockValue(0)],
             [new TextBlockValue('0')],
         ];
     }

--- a/tests/integration/Core/Repository/FieldType/TextBlockIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/TextBlockIntegrationTest.php
@@ -7,8 +7,8 @@
 
 namespace Ibexa\Tests\Integration\Core\Repository\FieldType;
 
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
-use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\TextBlock\Value as TextBlockValue;
 
 /**
@@ -149,7 +149,7 @@ class TextBlockIntegrationTest extends SearchBaseIntegrationTest
         return [
             [
                 new \stdClass(),
-                InvalidArgumentType::class,
+                InvalidArgumentException::class,
             ],
         ];
     }

--- a/tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
@@ -299,7 +299,6 @@ class TextLineIntegrationTest extends SearchBaseIntegrationTest
             [
                 $this->getValidCreationFieldData(),
             ],
-            [new TextLineValue(0)],
             [new TextLineValue('0')],
         ];
     }

--- a/tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/TextLineIntegrationTest.php
@@ -8,8 +8,8 @@
 namespace Ibexa\Tests\Integration\Core\Repository\FieldType;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
-use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\TextLine\Value as TextLineValue;
 
 /**
@@ -161,11 +161,11 @@ class TextLineIntegrationTest extends SearchBaseIntegrationTest
         return [
             [
                 new \stdClass(),
-                InvalidArgumentType::class,
+                InvalidArgumentException::class,
             ],
             [
                 42,
-                InvalidArgumentType::class,
+                InvalidArgumentException::class,
             ],
             [
                 new TextLineValue(str_repeat('.', 64)),

--- a/tests/lib/FieldType/TextBlockTest.php
+++ b/tests/lib/FieldType/TextBlockTest.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Tests\Core\FieldType;
 
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Ibexa\Core\FieldType\FieldType;
 use Ibexa\Core\FieldType\TextBlock\Type as TextBlockType;
 use Ibexa\Core\FieldType\TextBlock\Value as TextBlockValue;
 
@@ -15,20 +16,11 @@ use Ibexa\Core\FieldType\TextBlock\Value as TextBlockValue;
  * @group fieldType
  * @group eztext
  */
-class TextBlockTest extends FieldTypeTest
+final class TextBlockTest extends FieldTypeTest
 {
-    /**
-     * Returns the field type under test.
-     *
-     * This method is used by all test cases to retrieve the field type under
-     * test. Just create the FieldType instance using mocks from the provided
-     * get*Mock() methods and/or custom get*Mock() implementations. You MUST
-     * NOT take care for test case wide caching of the field type, just return
-     * a new instance from this method!
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\FieldType
-     */
-    protected function createFieldTypeUnderTest()
+    private const string SAMPLE_TEXT_LINE_VALUE = ' sindelfingen ';
+
+    protected function createFieldTypeUnderTest(): FieldType
     {
         $fieldType = new TextBlockType();
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
@@ -37,21 +29,17 @@ class TextBlockTest extends FieldTypeTest
     }
 
     /**
-     * Returns the validator configuration schema expected from the field type.
-     *
-     * @return array
+     * @return array{}
      */
-    protected function getValidatorConfigurationSchemaExpectation()
+    protected function getValidatorConfigurationSchemaExpectation(): array
     {
         return [];
     }
 
     /**
-     * Returns the settings schema expected from the field type.
-     *
-     * @return array
+     * @return array<string, mixed>
      */
-    protected function getSettingsSchemaExpectation()
+    protected function getSettingsSchemaExpectation(): array
     {
         return [
             'textRows' => [
@@ -61,17 +49,15 @@ class TextBlockTest extends FieldTypeTest
         ];
     }
 
-    /**
-     * Returns the empty value expected from the field type.
-     *
-     * @return \Ibexa\Core\FieldType\TextLine\Value
-     */
-    protected function getEmptyValueExpectation()
+    protected function getEmptyValueExpectation(): TextBlockValue
     {
         return new TextBlockValue();
     }
 
-    public function provideInvalidInputForAcceptValue()
+    /**
+     * @return list<array{mixed, class-string}>
+     */
+    public function provideInvalidInputForAcceptValue(): array
     {
         return [
             [
@@ -82,35 +68,9 @@ class TextBlockTest extends FieldTypeTest
     }
 
     /**
-     * Data provider for valid input to acceptValue().
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to acceptValue(), 2. The expected return value from acceptValue().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          __FILE__,
-     *          new BinaryFileValue( array(
-     *              'path' => __FILE__,
-     *              'fileName' => basename( __FILE__ ),
-     *              'fileSize' => filesize( __FILE__ ),
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'text/plain',
-     *          ) )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{mixed, \Ibexa\Core\FieldType\TextLine\Value}>
      */
-    public function provideValidInputForAcceptValue()
+    public function provideValidInputForAcceptValue(): array
     {
         return [
             [
@@ -122,12 +82,12 @@ class TextBlockTest extends FieldTypeTest
                 new TextBlockValue(),
             ],
             [
-                'sindelfingen',
-                new TextBlockValue('sindelfingen'),
+                self::SAMPLE_TEXT_LINE_VALUE,
+                new TextBlockValue(self::SAMPLE_TEXT_LINE_VALUE),
             ],
             [
-                new TextBlockValue('sindelfingen'),
-                new TextBlockValue('sindelfingen'),
+                new TextBlockValue(self::SAMPLE_TEXT_LINE_VALUE),
+                new TextBlockValue(self::SAMPLE_TEXT_LINE_VALUE),
             ],
             [
                 new TextBlockValue(''),
@@ -141,41 +101,9 @@ class TextBlockTest extends FieldTypeTest
     }
 
     /**
-     * Provide input for the toHash() method.
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to toHash(), 2. The expected return value from toHash().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          new BinaryFileValue( array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ) ),
-     *          array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{\Ibexa\Core\FieldType\TextLine\Value, mixed}>
      */
-    public function provideInputForToHash()
+    public function provideInputForToHash(): array
     {
         return [
             [
@@ -183,48 +111,16 @@ class TextBlockTest extends FieldTypeTest
                 null,
             ],
             [
-                new TextBlockValue('sindelfingen'),
-                'sindelfingen',
+                new TextBlockValue(self::SAMPLE_TEXT_LINE_VALUE),
+                self::SAMPLE_TEXT_LINE_VALUE,
             ],
         ];
     }
 
     /**
-     * Provide input to fromHash() method.
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to fromHash(), 2. The expected return value from fromHash().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ),
-     *          new BinaryFileValue( array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ) )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{mixed, \Ibexa\Core\FieldType\TextLine\Value}>
      */
-    public function provideInputForFromHash()
+    public function provideInputForFromHash(): array
     {
         return [
             [
@@ -232,35 +128,16 @@ class TextBlockTest extends FieldTypeTest
                 new TextBlockValue(),
             ],
             [
-                'sindelfingen',
-                new TextBlockValue('sindelfingen'),
+                self::SAMPLE_TEXT_LINE_VALUE,
+                new TextBlockValue(self::SAMPLE_TEXT_LINE_VALUE),
             ],
         ];
     }
 
     /**
-     * Provide data sets with field settings which are considered valid by the
-     * {@link validateFieldSettings()} method.
-     *
-     * Returns an array of data provider sets with a single argument: A valid
-     * set of field settings.
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          array(),
-     *      ),
-     *      array(
-     *          array( 'rows' => 2 )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<list<array<string, mixed>>>
      */
-    public function provideValidFieldSettings()
+    public function provideValidFieldSettings(): array
     {
         return [
             [
@@ -275,29 +152,9 @@ class TextBlockTest extends FieldTypeTest
     }
 
     /**
-     * Provide data sets with field settings which are considered invalid by the
-     * {@link validateFieldSettings()} method. The method must return a
-     * non-empty array of validation error when receiving such field settings.
-     *
-     * Returns an array of data provider sets with a single argument: A valid
-     * set of field settings.
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          true,
-     *      ),
-     *      array(
-     *          array( 'nonExistentKey' => 2 )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<list<array<string, mixed>>>
      */
-    public function provideInValidFieldSettings()
+    public function provideInValidFieldSettings(): array
     {
         return [
             [
@@ -319,6 +176,9 @@ class TextBlockTest extends FieldTypeTest
         return 'eztext';
     }
 
+    /**
+     * @return list<array{\Ibexa\Core\FieldType\TextLine\Value, string, array<mixed>, string}>
+     */
     public function provideDataForGetName(): array
     {
         return [

--- a/tests/lib/FieldType/TextBlockTest.php
+++ b/tests/lib/FieldType/TextBlockTest.php
@@ -13,7 +13,7 @@ use Ibexa\Core\FieldType\TextBlock\Value as TextBlockValue;
 
 /**
  * @group fieldType
- * @group ezselection
+ * @group eztext
  */
 class TextBlockTest extends FieldTypeTest
 {
@@ -76,10 +76,6 @@ class TextBlockTest extends FieldTypeTest
         return [
             [
                 23,
-                InvalidArgumentException::class,
-            ],
-            [
-                new TextBlockValue(23),
                 InvalidArgumentException::class,
             ],
         ];

--- a/tests/lib/FieldType/TextLineTest.php
+++ b/tests/lib/FieldType/TextLineTest.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Tests\Core\FieldType;
 
 use Ibexa\Contracts\Core\Exception\InvalidArgumentType;
+use Ibexa\Core\FieldType\FieldType;
 use Ibexa\Core\FieldType\TextLine\Type as TextLineType;
 use Ibexa\Core\FieldType\TextLine\Value as TextLineValue;
 use Ibexa\Core\FieldType\ValidationError;
@@ -16,20 +17,14 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezstring
  */
-class TextLineTest extends FieldTypeTest
+final class TextLineTest extends FieldTypeTest
 {
-    /**
-     * Returns the field type under test.
-     *
-     * This method is used by all test cases to retrieve the field type under
-     * test. Just create the FieldType instance using mocks from the provided
-     * get*Mock() methods and/or custom get*Mock() implementations. You MUST
-     * NOT take care for test case wide caching of the field type, just return
-     * a new instance from this method!
-     *
-     * @return \Ibexa\Core\FieldType\FieldType
-     */
-    protected function createFieldTypeUnderTest()
+    private const string STRING_TOO_SHORT_EXPECTED_SINGULAR_MESSAGE = 'The string cannot be shorter than %size% character.';
+    private const string STRING_TOO_SHORT_EXPECTED_PLURAL_MESSAGE = 'The string cannot be shorter than %size% characters.';
+    private const string SIZE_PARAM_NAME = '%size%';
+    private const string SAMPLE_TEXT_LINE_VALUE = ' sindelfingen ';
+
+    protected function createFieldTypeUnderTest(): FieldType
     {
         $fieldType = new TextLineType();
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
@@ -38,11 +33,9 @@ class TextLineTest extends FieldTypeTest
     }
 
     /**
-     * Returns the validator configuration schema expected from the field type.
-     *
-     * @return array
+     * @return array<string, array<string, array{type: string, default: mixed}>>
      */
-    protected function getValidatorConfigurationSchemaExpectation()
+    protected function getValidatorConfigurationSchemaExpectation(): array
     {
         return [
             'StringLengthValidator' => [
@@ -59,26 +52,22 @@ class TextLineTest extends FieldTypeTest
     }
 
     /**
-     * Returns the settings schema expected from the field type.
-     *
-     * @return array
+     * @return array<string, mixed>
      */
-    protected function getSettingsSchemaExpectation()
+    protected function getSettingsSchemaExpectation(): array
     {
         return [];
     }
 
-    /**
-     * Returns the empty value expected from the field type.
-     *
-     * @return \Ibexa\Core\FieldType\TextLine\Value
-     */
-    protected function getEmptyValueExpectation()
+    protected function getEmptyValueExpectation(): TextLineValue
     {
         return new TextLineValue();
     }
 
-    public function provideInvalidInputForAcceptValue()
+    /**
+     * @return list<array{mixed, class-string}>
+     */
+    public function provideInvalidInputForAcceptValue(): array
     {
         return [
             [
@@ -89,35 +78,9 @@ class TextLineTest extends FieldTypeTest
     }
 
     /**
-     * Data provider for valid input to acceptValue().
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to acceptValue(), 2. The expected return value from acceptValue().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          __FILE__,
-     *          new BinaryFileValue( array(
-     *              'path' => __FILE__,
-     *              'fileName' => basename( __FILE__ ),
-     *              'fileSize' => filesize( __FILE__ ),
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'text/plain',
-     *          ) )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{mixed, \Ibexa\Core\FieldType\TextLine\Value}>
      */
-    public function provideValidInputForAcceptValue()
+    public function provideValidInputForAcceptValue(): array
     {
         return [
             [
@@ -133,12 +96,12 @@ class TextLineTest extends FieldTypeTest
                 new TextLineValue(),
             ],
             [
-                ' sindelfingen ',
-                new TextLineValue(' sindelfingen '),
+                self::SAMPLE_TEXT_LINE_VALUE,
+                new TextLineValue(self::SAMPLE_TEXT_LINE_VALUE),
             ],
             [
-                new TextLineValue(' sindelfingen '),
-                new TextLineValue(' sindelfingen '),
+                new TextLineValue(self::SAMPLE_TEXT_LINE_VALUE),
+                new TextLineValue(self::SAMPLE_TEXT_LINE_VALUE),
             ],
             [
                 // 11+ numbers - EZP-21771
@@ -161,41 +124,9 @@ class TextLineTest extends FieldTypeTest
     }
 
     /**
-     * Provide input for the toHash() method.
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to toHash(), 2. The expected return value from toHash().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          new BinaryFileValue( array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ) ),
-     *          array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{\Ibexa\Core\FieldType\TextLine\Value, mixed}>
      */
-    public function provideInputForToHash()
+    public function provideInputForToHash(): array
     {
         return [
             [
@@ -207,48 +138,16 @@ class TextLineTest extends FieldTypeTest
                 null,
             ],
             [
-                new TextLineValue('sindelfingen'),
-                'sindelfingen',
+                new TextLineValue(self::SAMPLE_TEXT_LINE_VALUE),
+                self::SAMPLE_TEXT_LINE_VALUE,
             ],
         ];
     }
 
     /**
-     * Provide input to fromHash() method.
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to fromHash(), 2. The expected return value from fromHash().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ),
-     *          new BinaryFileValue( array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ) )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{mixed, \Ibexa\Core\FieldType\TextLine\Value}>
      */
-    public function provideInputForFromHash()
+    public function provideInputForFromHash(): array
     {
         return [
             [
@@ -260,41 +159,16 @@ class TextLineTest extends FieldTypeTest
                 new TextLineValue(),
             ],
             [
-                'sindelfingen',
-                new TextLineValue('sindelfingen'),
+                self::SAMPLE_TEXT_LINE_VALUE,
+                new TextLineValue(self::SAMPLE_TEXT_LINE_VALUE),
             ],
         ];
     }
 
     /**
-     * Provide data sets with validator configurations which are considered
-     * valid by the {@link validateValidatorConfiguration()} method.
-     *
-     * Returns an array of data provider sets with a single argument: A valid
-     * set of validator configurations.
-     *
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          array(),
-     *      ),
-     *      array(
-     *          array(
-     *              'StringLengthValidator' => array(
-     *                  'minStringLength' => 0,
-     *                  'maxStringLength' => 23,
-     *              )
-     *          )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{array<string, mixed>}>
      */
-    public function provideValidValidatorConfiguration()
+    public function provideValidValidatorConfiguration(): array
     {
         return [
             [
@@ -340,48 +214,9 @@ class TextLineTest extends FieldTypeTest
     }
 
     /**
-     * Provide data sets with validator configurations which are considered
-     * invalid by the {@link validateValidatorConfiguration()} method. The
-     * method must return a non-empty array of valiation errors when receiving
-     * one of the provided values.
-     *
-     * Returns an array of data provider sets with a single argument: A valid
-     * set of validator configurations.
-     *
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          array(
-     *              'NonExistentValidator' => array(),
-     *          ),
-     *      ),
-     *      array(
-     *          array(
-     *              // Typos
-     *              'InTEgervALUeVALIdator' => array(
-     *                  'iinStringLength' => 0,
-     *                  'maxStringLength' => 23,
-     *              )
-     *          )
-     *      ),
-     *      array(
-     *          array(
-     *              'StringLengthValidator' => array(
-     *                  // Incorrect value types
-     *                  'minStringLength' => true,
-     *                  'maxStringLength' => false,
-     *              )
-     *          )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{array<string, mixed>}>
      */
-    public function provideInvalidValidatorConfiguration()
+    public function provideInvalidValidatorConfiguration(): array
     {
         return [
             [
@@ -440,6 +275,9 @@ class TextLineTest extends FieldTypeTest
         return 'ezstring';
     }
 
+    /**
+     * @return list<array{\Ibexa\Core\FieldType\TextLine\Value, string, array<mixed>, string}>
+     */
     public function provideDataForGetName(): array
     {
         return [
@@ -449,51 +287,9 @@ class TextLineTest extends FieldTypeTest
     }
 
     /**
-     * Provides data sets with validator configuration and/or field settings and
-     * field value which are considered valid by the {@link validate()} method.
-     *
-     * ATTENTION: This is a default implementation, which must be overwritten if
-     * a FieldType supports validation!
-     *
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          array(
-     *              "validatorConfiguration" => array(
-     *                  "StringLengthValidator" => array(
-     *                      "minStringLength" => 2,
-     *                      "maxStringLength" => 10,
-     *                  ),
-     *              ),
-     *          ),
-     *          new TextLineValue( "lalalala" ),
-     *      ),
-     *      array(
-     *          array(
-     *              "fieldSettings" => array(
-     *                  'isMultiple' => true
-     *              ),
-     *          ),
-     *          new CountryValue(
-     *              array(
-     *                  "BE" => array(
-     *                      "Name" => "Belgium",
-     *                      "Alpha2" => "BE",
-     *                      "Alpha3" => "BEL",
-     *                      "IDC" => 32,
-     *                  ),
-     *              ),
-     *          ),
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{array<string, mixed>, \Ibexa\Core\FieldType\TextLine\Value}>
      */
-    public function provideValidDataForValidate()
+    public function provideValidDataForValidate(): array
     {
         return [
             [
@@ -531,70 +327,9 @@ class TextLineTest extends FieldTypeTest
     }
 
     /**
-     * Provides data sets with validator configuration and/or field settings,
-     * field value and corresponding validation errors returned by
-     * the {@link validate()} method.
-     *
-     * ATTENTION: This is a default implementation, which must be overwritten
-     * if a FieldType supports validation!
-     *
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          array(
-     *              "validatorConfiguration" => array(
-     *                  "IntegerValueValidator" => array(
-     *                      "minIntegerValue" => 5,
-     *                      "maxIntegerValue" => 10
-     *                  ),
-     *              ),
-     *          ),
-     *          new IntegerValue( 3 ),
-     *          array(
-     *              new ValidationError(
-     *                  "The value can not be lower than %size%.",
-     *                  null,
-     *                  array(
-     *                      "size" => 5
-     *                  ),
-     *              ),
-     *          ),
-     *      ),
-     *      array(
-     *          array(
-     *              "fieldSettings" => array(
-     *                  "isMultiple" => false
-     *              ),
-     *          ),
-     *          new CountryValue(
-     *              "BE" => array(
-     *                  "Name" => "Belgium",
-     *                  "Alpha2" => "BE",
-     *                  "Alpha3" => "BEL",
-     *                  "IDC" => 32,
-     *              ),
-     *              "FR" => array(
-     *                  "Name" => "France",
-     *                  "Alpha2" => "FR",
-     *                  "Alpha3" => "FRA",
-     *                  "IDC" => 33,
-     *              ),
-     *          )
-     *      ),
-     *      array(
-     *          new ValidationError(
-     *              "Field definition does not allow multiple countries to be selected."
-     *          ),
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
+     * @return list<array{array<string, mixed>, \Ibexa\Core\FieldType\TextLine\Value, list<\Ibexa\Core\FieldType\ValidationError>}>
      */
-    public function provideInvalidDataForValidate()
+    public function provideInvalidDataForValidate(): array
     {
         return [
             [
@@ -609,10 +344,10 @@ class TextLineTest extends FieldTypeTest
                 new TextLineValue('aaa'),
                 [
                     new ValidationError(
-                        'The string cannot be shorter than %size% character.',
-                        'The string cannot be shorter than %size% characters.',
+                        self::STRING_TOO_SHORT_EXPECTED_SINGULAR_MESSAGE,
+                        self::STRING_TOO_SHORT_EXPECTED_PLURAL_MESSAGE,
                         [
-                            '%size%' => 5,
+                            self::SIZE_PARAM_NAME => 5,
                         ],
                         'text'
                     ),
@@ -633,7 +368,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not exceed %size% character.',
                         'The string can not exceed %size% characters.',
                         [
-                            '%size%' => 10,
+                            self::SIZE_PARAM_NAME => 10,
                         ],
                         'text'
                     ),
@@ -654,15 +389,15 @@ class TextLineTest extends FieldTypeTest
                         'The string can not exceed %size% character.',
                         'The string can not exceed %size% characters.',
                         [
-                            '%size%' => 5,
+                            self::SIZE_PARAM_NAME => 5,
                         ],
                         'text'
                     ),
                     new ValidationError(
-                        'The string cannot be shorter than %size% character.',
-                        'The string cannot be shorter than %size% characters.',
+                        self::STRING_TOO_SHORT_EXPECTED_SINGULAR_MESSAGE,
+                        self::STRING_TOO_SHORT_EXPECTED_PLURAL_MESSAGE,
                         [
-                            '%size%' => 10,
+                            self::SIZE_PARAM_NAME => 10,
                         ],
                         'text'
                     ),
@@ -680,10 +415,10 @@ class TextLineTest extends FieldTypeTest
                 new TextLineValue('ABC♔'),
                 [
                     new ValidationError(
-                        'The string cannot be shorter than %size% character.',
-                        'The string cannot be shorter than %size% characters.',
+                        self::STRING_TOO_SHORT_EXPECTED_SINGULAR_MESSAGE,
+                        self::STRING_TOO_SHORT_EXPECTED_PLURAL_MESSAGE,
                         [
-                            '%size%' => 5,
+                            self::SIZE_PARAM_NAME => 5,
                         ],
                         'text'
                     ),

--- a/tests/lib/FieldType/TextLineTest.php
+++ b/tests/lib/FieldType/TextLineTest.php
@@ -7,7 +7,7 @@
 
 namespace Ibexa\Tests\Core\FieldType;
 
-use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Ibexa\Contracts\Core\Exception\InvalidArgumentType;
 use Ibexa\Core\FieldType\TextLine\Type as TextLineType;
 use Ibexa\Core\FieldType\TextLine\Value as TextLineValue;
 use Ibexa\Core\FieldType\ValidationError;
@@ -83,11 +83,7 @@ class TextLineTest extends FieldTypeTest
         return [
             [
                 23,
-                InvalidArgumentException::class,
-            ],
-            [
-                new TextLineValue(23),
-                InvalidArgumentException::class,
+                InvalidArgumentType::class,
             ],
         ];
     }


### PR DESCRIPTION
| :ticket: Issue | Related to IBX-8138 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/385

#### Description:

This PR addresses one of the many code redundancy issues found by SonarCloud while working on #385.

```php
class \Ibexa\Core\FieldType\TextBlock\Value extends \Ibexa\Core\FieldType\TextLine\Value { }
```

:point_up: because of that we can have a common base type-hinting just on TextValue contravariant base type.

- **Extracted common base for TextBlock and TextLine field types**
- **[Tests] Aligned tests with TextBlock and TextLine changes**
- **[Tests] Reduced complexity of TextBlock and TextLine test classes**
- **[Tests] Aligned TextLine and TextBlock integration tests with the changes**
- **[PHPStan] Aligned baseline with the changes**


#### For QA:

Regression build should be enough (https://github.com/ibexa/commerce/pull/1006).
