### PR TITLE
[Tests] Refactored various unit tests to make them DRY

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24606,16 +24606,6 @@ parameters:
 			path: tests/bundle/Core/EventListener/OriginalRequestListenerTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\RejectExplicitFrontControllerRequestsListenerTest\\:\\:prohibitedRequestDataProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\RejectExplicitFrontControllerRequestsListenerTest\\:\\:validRequestDataProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\RequestEventListenerTest\\:\\:testOnKernelRequestForward\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/bundle/Core/EventListener/RequestEventListenerTest.php
@@ -56671,72 +56661,7 @@ parameters:
 			path: tests/lib/Repository/Permission/PermissionCriterionResolverTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:getEventDispatcher\\(\\) should return PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface but returns Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:getRelationProcessorMock\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:getRepository\\(\\) has parameter \\$serviceSettings with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Parameter \\#1 \\$className of method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\) expects class\\-string\\<mixed\\>, string given\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchHandler of class Ibexa\\\\Core\\\\Repository\\\\Repository constructor expects Ibexa\\\\Contracts\\\\Core\\\\Search\\\\Handler, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$contentDomainMapperMock \\(Ibexa\\\\Core\\\\Repository\\\\Mapper\\\\ContentDomainMapper&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$contentTypeDomainMapperMock \\(Ibexa\\\\Core\\\\Repository\\\\Mapper\\\\ContentTypeDomainMapper&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$fieldTypeRegistryMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$fieldTypeServiceMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$permissionServiceMock \\(Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\PermissionService&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$persistenceMock \\(Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\Handler&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$repositoryMock \\(Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Repository&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\Base\\:\\:\\$thumbnailStrategyMock \\(Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Strategy\\\\ContentThumbnail\\\\ThumbnailStrategy&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/Base.php
-
-		-
-			message: "#^Unable to resolve the template type T in call to method PHPUnit\\\\Framework\\\\TestCase\\:\\:getMockBuilder\\(\\)$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/Base.php
 
@@ -57486,37 +57411,7 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/ContentTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:testLoadVersionInfo\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:testLoadVersionInfoById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:testLoadVersionInfoByIdAndVersionNumber\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:testLoadVersionInfoByIdNonPublishedVersion\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:testLoadVersionInfoByIdPublishedVersion\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:testLoadVersionInfoByIdThrowsNotFoundException\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:testLoadVersionInfoByIdThrowsUnauthorizedExceptionNonPublishedVersion\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/ContentTest.php
 
@@ -57736,11 +57631,6 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/ContentTest.php
 
 		-
-			message: "#^PHPDoc tag @var for property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:\\$nameSchemaServiceMock with type PHPUnit\\\\Framework\\\\MockObject\\\\MockObject is not subtype of native type Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\NameSchema\\\\NameSchemaServiceInterface\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$languageHandlerMock of method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:loadByLanguageCodeMock\\(\\) expects PHPUnit\\\\Framework\\\\MockObject\\\\MockObject, Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\Content\\\\Language\\\\Handler given\\.$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/ContentTest.php
@@ -57771,11 +57661,6 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/ContentTest.php
 
 		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\ContentTest\\:\\:\\$relationProcessorMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/ContentTest.php
-
-		-
 			message: "#^Call to an undefined method Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\User\\\\Handler\\:\\:expects\\(\\)\\.$#"
 			count: 11
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
@@ -57791,17 +57676,7 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionTest\\:\\:getPermissionResolverMock\\(\\) has parameter \\$methods with no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionTest\\:\\:getPermissionSetsMock\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionTest\\:\\:getUserReferenceMock\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
 
@@ -57986,11 +57861,6 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionTest\\:\\:testSetAndGetCurrentUserReference\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\$policy \\\\Ibexa\\\\Contracts\\\\Core\\\\Persistence\\\\User\\\\Policy\\)\\: Unexpected token \"\\$policy\", expected type at offset 9$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
@@ -58021,29 +57891,9 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
 
 		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionTest\\:\\:\\$permissionResolverMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionTest\\:\\:\\$repositoryMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionTest\\:\\:\\$userReferenceMock has no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
 			message: "#^Variable \\$limitationsPass might not be defined\\.$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionsCriterionHandlerTest\\:\\:getPermissionResolverMock\\(\\) has parameter \\$methods with no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionsCriterionHandlerTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionsCriterionHandlerTest\\:\\:mockServices\\(\\) has no return type specified\\.$#"
@@ -58147,11 +57997,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionsCriterionHandlerTest\\:\\:testGetPermissionsCriterionBooleanPermissionSets\\(\\) has parameter \\$permissionSets with no type specified\\.$#"
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionsCriterionHandlerTest.php
-
-		-
-			message: "#^Property Ibexa\\\\Tests\\\\Core\\\\Repository\\\\Service\\\\Mock\\\\PermissionsCriterionHandlerTest\\:\\:\\$permissionResolverMock has no type specified\\.$#"
 			count: 1
 			path: tests/lib/Repository/Service/Mock/PermissionsCriterionHandlerTest.php
 

--- a/tests/lib/Repository/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/tests/lib/Repository/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -8,13 +8,13 @@
 namespace Ibexa\Tests\Core\Repository\Service\Mock;
 
 use Ibexa\Contracts\Core\Limitation\Type;
-use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitation;
 use Ibexa\Core\Repository\PermissionsCriterionHandler;
 use Ibexa\Core\Repository\Values\User\Policy;
 use Ibexa\Core\Repository\Values\User\User;
 use Ibexa\Tests\Core\Repository\Service\Mock\Base as BaseServiceMockTest;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Mock test case for PermissionCriterionHandler.
@@ -280,12 +280,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
         $userMock = $this->createMock(User::class);
         $limitationTypeMock = $this->createMock(Type::class);
         $limitationServiceMock = $this->getLimitationServiceMock();
-        $permissionResolverMock = $this->getPermissionResolverMock(
-            [
-                'hasAccess',
-                'getCurrentUserReference',
-            ]
-        );
+        $permissionResolverMock = $this->getPermissionResolverMock();
 
         $limitationTypeMock
             ->expects(self::any())
@@ -326,7 +321,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
         $expectedCriterion
     ) {
         $this->mockServices($criterionMock, $limitationCount, $permissionSets);
-        $handler = $this->getPermissionsCriterionHandlerMock(null);
+        $handler = $this->getPermissionsCriterionHandlerMock();
 
         $permissionsCriterion = $handler->getPermissionsCriterion();
 
@@ -348,13 +343,13 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
      */
     public function testGetPermissionsCriterionBooleanPermissionSets($permissionSets)
     {
-        $permissionResolverMock = $this->getPermissionResolverMock(['hasAccess']);
+        $permissionResolverMock = $this->getPermissionResolverMock();
         $permissionResolverMock
             ->expects(self::once())
             ->method('hasAccess')
             ->with(self::equalTo('testModule'), self::equalTo('testFunction'))
-            ->will(self::returnValue($permissionSets));
-        $handler = $this->getPermissionsCriterionHandlerMock(null);
+            ->willReturn($permissionSets);
+        $handler = $this->getPermissionsCriterionHandlerMock();
 
         $permissionsCriterion = $handler->getPermissionsCriterion('testModule', 'testFunction');
 
@@ -364,15 +359,13 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
     /**
      * Returns the PermissionsCriterionHandler to test with $methods mocked.
      *
-     * @param string[]|null $methods
-     *
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Core\Repository\PermissionsCriterionHandler
+     * @param string[] $methods
      */
-    protected function getPermissionsCriterionHandlerMock($methods = [])
+    protected function getPermissionsCriterionHandlerMock(array $methods = []): MockObject & PermissionsCriterionHandler
     {
         return $this
             ->getMockBuilder(PermissionsCriterionHandler::class)
-            ->setMethods($methods)
+            ->onlyMethods($methods)
             ->setConstructorArgs(
                 [
                     $this->getPermissionResolverMock(),
@@ -380,20 +373,5 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                 ]
             )
             ->getMock();
-    }
-
-    protected $permissionResolverMock;
-
-    protected function getPermissionResolverMock($methods = [])
-    {
-        if ($this->permissionResolverMock === null) {
-            $this->permissionResolverMock = $this
-                ->getMockBuilder(PermissionResolver::class)
-                ->setMethods($methods)
-                ->disableOriginalConstructor()
-                ->getMockForAbstractClass();
-        }
-
-        return $this->permissionResolverMock;
     }
 }

--- a/tests/lib/Repository/Service/Mock/RelationProcessorTest.php
+++ b/tests/lib/Repository/Service/Mock/RelationProcessorTest.php
@@ -20,6 +20,7 @@ use Ibexa\Core\Repository\Helper\RelationProcessor;
 use Ibexa\Core\Repository\Values\Content\Relation as RelationValue;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Tests\Core\Repository\Service\Mock\Base as BaseServiceMockTest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -680,10 +681,7 @@ class RelationProcessorTest extends BaseServiceMockTest
             ->getMock();
     }
 
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getFieldTypeServiceMock()
+    protected function getFieldTypeServiceMock(): MockObject & FieldTypeService
     {
         return $this->createMock(FieldTypeService::class);
     }

--- a/tests/lib/Repository/Service/Mock/RoleTest.php
+++ b/tests/lib/Repository/Service/Mock/RoleTest.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Core\Persistence\User\Role as SPIRole;
 use Ibexa\Contracts\Core\Repository\Exceptions\BadStateException;
 use Ibexa\Contracts\Core\Repository\Exceptions\LimitationValidationException;
 use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
-use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Repository as APIRepository;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\RoleLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\PolicyCreateStruct;
@@ -30,6 +30,7 @@ use Ibexa\Core\Repository\Mapper\RoleDomainMapper;
 use Ibexa\Core\Repository\Permission\LimitationService;
 use Ibexa\Core\Repository\RoleService;
 use Ibexa\Tests\Core\Repository\Service\Mock\Base as BaseServiceMockTest;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @covers \Ibexa\Contracts\Core\Repository\RoleService
@@ -1083,14 +1084,10 @@ class RoleTest extends BaseServiceMockTest
         return $this->partlyMockedRoleService;
     }
 
-    /**
-     * @return \Ibexa\Contracts\Core\Repository\Repository|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getRepositoryMock(): Repository
+    protected function getRepositoryMock(): MockObject & APIRepository
     {
         $repositoryMock = parent::getRepositoryMock();
         $repositoryMock
-            ->expects(self::any())
             ->method('getPermissionResolver')
             ->willReturn($this->getPermissionResolverMock());
 

--- a/tests/lib/Search/Legacy/Content/HandlerContentSortTest.php
+++ b/tests/lib/Search/Legacy/Content/HandlerContentSortTest.php
@@ -7,14 +7,12 @@
 
 namespace Ibexa\Tests\Core\Search\Legacy\Content;
 
-use Ibexa\Contracts\Core\Persistence\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;
 use Ibexa\Core\Persistence\Legacy\Content\FieldHandler;
 use Ibexa\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
 use Ibexa\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
-use Ibexa\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use Ibexa\Core\Search\Legacy\Content;
 use Ibexa\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
 
@@ -88,47 +86,6 @@ class HandlerContentSortTest extends AbstractTestCase
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
-    }
-
-    /**
-     * Returns a content mapper mock.
-     *
-     * @return \Ibexa\Core\Persistence\Legacy\Content\Mapper
-     */
-    protected function getContentMapperMock()
-    {
-        $mapperMock = $this->getMockBuilder(ContentMapper::class)
-            ->setConstructorArgs(
-                [
-                    $this->getFieldRegistry(),
-                    $this->getLanguageHandler(),
-                    $this->getContentTypeHandler(),
-                    $this->getEventDispatcher(),
-                ]
-            )
-            ->setMethods(['extractContentInfoFromRows'])
-            ->getMock();
-        $mapperMock->expects(self::any())
-            ->method('extractContentInfoFromRows')
-            ->with(self::isType('array'))
-            ->will(
-                self::returnCallback(
-                    static function ($rows) {
-                        $contentInfoObjs = [];
-                        foreach ($rows as $row) {
-                            $contentId = (int)$row['id'];
-                            if (!isset($contentInfoObjs[$contentId])) {
-                                $contentInfoObjs[$contentId] = new ContentInfo();
-                                $contentInfoObjs[$contentId]->id = $contentId;
-                            }
-                        }
-
-                        return array_values($contentInfoObjs);
-                    }
-                )
-            );
-
-        return $mapperMock;
     }
 
     /**

--- a/tests/lib/Search/Legacy/Content/HandlerContentTest.php
+++ b/tests/lib/Search/Legacy/Content/HandlerContentTest.php
@@ -7,7 +7,6 @@
 
 namespace Ibexa\Tests\Core\Search\Legacy\Content;
 
-use Ibexa\Contracts\Core\Persistence\Content\ContentInfo;
 use Ibexa\Contracts\Core\Persistence\Content\Type;
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
@@ -17,7 +16,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;
 use Ibexa\Core\Persistence;
 use Ibexa\Core\Persistence\Legacy\Content\FieldHandler;
 use Ibexa\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
-use Ibexa\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use Ibexa\Core\Search\Legacy\Content;
 use Ibexa\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
 
@@ -187,47 +185,6 @@ class HandlerContentTest extends AbstractTestCase
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
-    }
-
-    /**
-     * Returns a content mapper mock.
-     *
-     * @return \Ibexa\Core\Persistence\Legacy\Content\Mapper
-     */
-    protected function getContentMapperMock()
-    {
-        $mapperMock = $this->getMockBuilder(ContentMapper::class)
-            ->setConstructorArgs(
-                [
-                    $this->getConverterRegistry(),
-                    $this->getLanguageHandler(),
-                    $this->getContentTypeHandler(),
-                    $this->getEventDispatcher(),
-                ]
-            )
-            ->setMethods(['extractContentInfoFromRows'])
-            ->getMock();
-        $mapperMock->expects(self::any())
-            ->method('extractContentInfoFromRows')
-            ->with(self::isType('array'))
-            ->will(
-                self::returnCallback(
-                    static function ($rows) {
-                        $contentInfoObjs = [];
-                        foreach ($rows as $row) {
-                            $contentId = (int)$row['id'];
-                            if (!isset($contentInfoObjs[$contentId])) {
-                                $contentInfoObjs[$contentId] = new ContentInfo();
-                                $contentInfoObjs[$contentId]->id = $contentId;
-                            }
-                        }
-
-                        return array_values($contentInfoObjs);
-                    }
-                )
-            );
-
-        return $mapperMock;
     }
 
     /**

--- a/tests/lib/Search/Legacy/Content/HandlerLocationSortTest.php
+++ b/tests/lib/Search/Legacy/Content/HandlerLocationSortTest.php
@@ -7,11 +7,9 @@
 
 namespace Ibexa\Tests\Core\Search\Legacy\Content;
 
-use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;
-use Ibexa\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 use Ibexa\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use Ibexa\Core\Search\Legacy\Content;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
@@ -103,40 +101,6 @@ class HandlerLocationSortTest extends AbstractTestCase
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
-    }
-
-    /**
-     * Returns a location mapper mock.
-     *
-     * @return \Ibexa\Core\Persistence\Legacy\Content\Location\Mapper
-     */
-    protected function getLocationMapperMock()
-    {
-        $mapperMock = $this->getMockBuilder(LocationMapper::class)
-            ->setMethods(['createLocationsFromRows'])
-            ->getMock();
-        $mapperMock
-            ->expects(self::any())
-            ->method('createLocationsFromRows')
-            ->with(self::isType('array'))
-            ->will(
-                self::returnCallback(
-                    static function ($rows) {
-                        $locations = [];
-                        foreach ($rows as $row) {
-                            $locationId = (int)$row['node_id'];
-                            if (!isset($locations[$locationId])) {
-                                $locations[$locationId] = new SPILocation();
-                                $locations[$locationId]->id = $locationId;
-                            }
-                        }
-
-                        return array_values($locations);
-                    }
-                )
-            );
-
-        return $mapperMock;
     }
 
     public function testNoSorting()

--- a/tests/lib/Search/Legacy/Content/HandlerLocationTest.php
+++ b/tests/lib/Search/Legacy/Content/HandlerLocationTest.php
@@ -7,13 +7,11 @@
 
 namespace Ibexa\Tests\Core\Search\Legacy\Content;
 
-use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;
 use Ibexa\Core\Persistence;
-use Ibexa\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 use Ibexa\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use Ibexa\Core\Search\Legacy\Content;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
@@ -164,40 +162,6 @@ class HandlerLocationTest extends AbstractTestCase
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
-    }
-
-    /**
-     * Returns a location mapper mock.
-     *
-     * @return \Ibexa\Core\Persistence\Legacy\Content\Location\Mapper
-     */
-    protected function getLocationMapperMock()
-    {
-        $mapperMock = $this->getMockBuilder(LocationMapper::class)
-            ->setMethods(['createLocationsFromRows'])
-            ->getMock();
-        $mapperMock
-            ->expects(self::any())
-            ->method('createLocationsFromRows')
-            ->with(self::isType('array'))
-            ->will(
-                self::returnCallback(
-                    static function ($rows) {
-                        $locations = [];
-                        foreach ($rows as $row) {
-                            $locationId = (int)$row['node_id'];
-                            if (!isset($locations[$locationId])) {
-                                $locations[$locationId] = new SPILocation();
-                                $locations[$locationId]->id = $locationId;
-                            }
-                        }
-
-                        return array_values($locations);
-                    }
-                )
-            );
-
-        return $mapperMock;
     }
 
     public function testFindWithoutOffsetLimit()


### PR DESCRIPTION
| :ticket: Issue | Related to IBX-8138 |
|----------------|-----------|

#### TODO
- [ ] Seems there's more code duplication detected.

#### Related PRs: 
- https://github.com/ibexa/core/pull/385

#### Description:


This PR addresses a several of the many code redundancy issues found by SonarCloud while working on #385.

Refactored few unit test clases, including Base Repository service mock tests to avoid code redundancy.

Changelog:

- **[Tests] Fixed code duplication in Content & Location handler tests**
- **[Tests] Refactored redundant code in RejectExplicitFrontControllerRequestsListenerTest**
- **[Tests] Improved quality of Base Repository service mock tests**
- **[Tests] Refactored ContentTest to drop redundancy**
- **[Tests] Refactored PermissionsCriterionHandlerTest to rely on base permission resolver**
- **[Tests] Aligned RelationProcessorTest with Base changes**
- **[Tests] Aligned RoleTest with Base changes**
- **[Tests] Aligned PermissionTest with Base changes**
- **[PHPStan] Aligned baseline with the changes**

#### For QA

No QA required, unit test changes only.
