### PR TITLE
IBX-4000: Changed the method name creation for logCall in callable function

### DIFF
--- a/src/lib/Persistence/Cache/ObjectStateHandler.php
+++ b/src/lib/Persistence/Cache/ObjectStateHandler.php
@@ -51,7 +51,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             (int) $groupId,
             $this->cacheIdentifierGenerator->generateKey(self::STATE_GROUP_IDENTIFIER, [], true) . '-',
             function (int $groupId): Group {
-                $this->logger->logCall(__METHOD__, ['groupId' => (int) $groupId]);
+                $this->logger->logCall(__CLASS__ . '::loadGroup', ['groupId' => (int) $groupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadGroup($groupId);
             },
@@ -79,7 +79,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             $identifier,
             $this->cacheIdentifierGenerator->generateKey(self::STATE_GROUP_IDENTIFIER, [], true) . '-',
             function (string $identifier): Group {
-                $this->logger->logCall(__METHOD__, ['groupId' => $identifier]);
+                $this->logger->logCall(__CLASS__ . '::loadGroupByIdentifier', ['groupId' => $identifier]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadGroupByIdentifier($identifier);
             },
@@ -106,7 +106,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
         $stateGroups = $this->getListCacheValue(
             $this->cacheIdentifierGenerator->generateKey(self::STATE_GROUP_ALL_IDENTIFIER, [], true),
             function () use ($offset, $limit): array {
-                $this->logger->logCall(__METHOD__, ['offset' => (int) $offset, 'limit' => (int) $limit]);
+                $this->logger->logCall(__CLASS__ . '::loadAllGroups', ['offset' => (int) $offset, 'limit' => (int) $limit]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadAllGroups(0, -1);
             },
@@ -135,7 +135,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             $groupId,
             $this->cacheIdentifierGenerator->generateKey(self::STATE_LIST_BY_GROUP_IDENTIFIER, [], true) . '-',
             function (int $groupId): array {
-                $this->logger->logCall(__METHOD__, ['groupId' => (int) $groupId]);
+                $this->logger->logCall(__CLASS__ . '::loadObjectStates', ['groupId' => (int) $groupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadObjectStates($groupId);
             },
@@ -210,7 +210,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             (int) $stateId,
             $this->cacheIdentifierGenerator->generateKey(self::STATE_IDENTIFIER, [], true) . '-',
             function (int $stateId): ObjectState {
-                $this->logger->logCall(__METHOD__, ['stateId' => $stateId]);
+                $this->logger->logCall(__CLASS__ . '::load', ['stateId' => $stateId]);
 
                 return $this->persistenceHandler->objectStateHandler()->load($stateId);
             },
@@ -239,7 +239,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             $identifier,
             $this->cacheIdentifierGenerator->generateKey(self::STATE_ID_IDENTIFIER, [], true) . '-',
             function (string $identifier) use ($groupId): ObjectState {
-                $this->logger->logCall(__METHOD__, ['identifier' => $identifier, 'groupId' => (int) $groupId]);
+                $this->logger->logCall(__CLASS__ . '::loadByIdentifier', ['identifier' => $identifier, 'groupId' => (int) $groupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->loadByIdentifier($identifier, (int) $groupId);
             },
@@ -335,7 +335,7 @@ class ObjectStateHandler extends AbstractInMemoryPersistenceHandler implements O
             (int) $stateGroupId,
             $this->cacheIdentifierGenerator->generateKey(self::STATE_BY_GROUP_IDENTIFIER, [], true) . '-',
             function (int $stateGroupId) use ($contentId): ObjectState {
-                $this->logger->logCall(__METHOD__, ['contentId' => (int) $contentId, 'stateGroupId' => $stateGroupId]);
+                $this->logger->logCall(__CLASS__ . '::getContentState', ['contentId' => (int) $contentId, 'stateGroupId' => $stateGroupId]);
 
                 return $this->persistenceHandler->objectStateHandler()->getContentState((int) $contentId, $stateGroupId);
             },

--- a/tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+++ b/tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
@@ -219,7 +219,10 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
         $cacheItem = $this->getCacheItem($key, null);
         $handlerMethodName = $this->getHandlerMethodName();
 
-        $this->loggerMock->expects($this->once())->method('logCall');
+        $handler = $this->persistenceCacheHandler->$handlerMethodName();
+        $this->loggerMock->expects($this->once())
+                         ->method('logCall')
+                         ->with(get_class($handler) . '::' . $method, self::isType('array'));
 
         if ($tagGeneratingArguments) {
             $this->cacheIdentifierGeneratorMock
@@ -281,7 +284,6 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
             ->method('save')
             ->with($cacheItem);
 
-        $handler = $this->persistenceCacheHandler->$handlerMethodName();
         $return = call_user_func_array([$handler, $method], $arguments);
 
         $this->assertEquals($data, $return);

--- a/tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+++ b/tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
@@ -220,9 +220,10 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
         $handlerMethodName = $this->getHandlerMethodName();
 
         $handler = $this->persistenceCacheHandler->$handlerMethodName();
-        $this->loggerMock->expects($this->once())
-                         ->method('logCall')
-                         ->with(get_class($handler) . '::' . $method, self::isType('array'));
+        $this->loggerMock
+            ->expects(self::once())
+            ->method('logCall')
+            ->with(get_class($handler) . '::' . $method, self::isType('array'));
 
         if ($tagGeneratingArguments) {
             $this->cacheIdentifierGeneratorMock


### PR DESCRIPTION
| :ticket: Issue | IBX-4000 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/fieldtype-page/pull/136


#### Description:
 The problem is that the Ibexa\Bundle\Debug\Collector\PersistenceCacheCollector::getCalls function expects us to format the method as Namespace::Function. With callable functions, __METHOD__ returns Namespace\{closure} instead of the correct value. To prevent this, we must use __CLASS__ in these functions and add the method name manually, which will allow us to correctly save the call function to log.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
