### PR TITLE
IBX-8469: Fixed image filtering by file size float value 

### DIFF
--- a/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
@@ -15,18 +15,28 @@ final class FileSize extends AbstractImageRangeCriterion
         $minValue = 0,
         $maxValue = null
     ) {
-        if ($minValue > 0) {
-            $minValue *= 1024 * 1024;
-        }
-
         if ($maxValue > 0) {
-            $maxValue *= 1024 * 1024;
+            $maxValue = $this->convertToBytes($maxValue);
         }
 
         parent::__construct(
             $fieldDefIdentifier,
-            $minValue,
+            $this->convertToBytes($minValue),
             $maxValue
         );
+    }
+
+    /**
+     * @param numeric $value
+     */
+    private function convertToBytes($value): int
+    {
+        $value *= 1024 * 1024;
+
+        if (is_float($value)) {
+            $value = (int)$value;
+        }
+
+        return $value;
     }
 }

--- a/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
@@ -12,14 +12,11 @@ final class FileSize extends AbstractImageRangeCriterion
 {
     public function __construct(
         string $fieldDefIdentifier,
-        $minValue = 0,
+        $minValue = null,
         $maxValue = null
     ) {
         $minValue = $this->convertToBytes($minValue);
-
-        if ($maxValue > 0) {
-            $maxValue = $this->convertToBytes($maxValue);
-        }
+        $maxValue = $this->convertToBytes($maxValue);
 
         parent::__construct(
             $fieldDefIdentifier,
@@ -29,10 +26,17 @@ final class FileSize extends AbstractImageRangeCriterion
     }
 
     /**
-     * @param numeric $value
+     * @param numeric|null $value
      */
-    private function convertToBytes($value): int
+    private function convertToBytes($value): ?int
     {
+        if (
+            null === $value
+            || 0 === $value
+        ) {
+            return null;
+        }
+
         $value *= 1024 * 1024;
 
         return (int)$value;

--- a/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/Image/FileSize.php
@@ -15,13 +15,15 @@ final class FileSize extends AbstractImageRangeCriterion
         $minValue = 0,
         $maxValue = null
     ) {
+        $minValue = $this->convertToBytes($minValue);
+
         if ($maxValue > 0) {
             $maxValue = $this->convertToBytes($maxValue);
         }
 
         parent::__construct(
             $fieldDefIdentifier,
-            $this->convertToBytes($minValue),
+            $minValue,
             $maxValue
         );
     }
@@ -33,10 +35,6 @@ final class FileSize extends AbstractImageRangeCriterion
     {
         $value *= 1024 * 1024;
 
-        if (is_float($value)) {
-            $value = (int)$value;
-        }
-
-        return $value;
+        return (int)$value;
     }
 }

--- a/tests/integration/Core/Repository/SearchServiceImageTest.php
+++ b/tests/integration/Core/Repository/SearchServiceImageTest.php
@@ -94,6 +94,26 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
             $this->createFileSizeCriterion(0, 2),
         ];
 
+        yield 'FileSize - with numeric string values' => [
+            3,
+            $this->createFileSizeCriterion('0.0', '2.5'),
+        ];
+
+        yield 'FileSize - with numeric values from 0.0 to 2.5' => [
+            3,
+            $this->createFileSizeCriterion(0.0, 2.5),
+        ];
+
+        yield 'FileSize - with numeric values 0.0001 to 2.5' => [
+            3,
+            $this->createFileSizeCriterion(0.0001, 1),
+        ];
+
+        yield 'FileSize - with values less than 1' => [
+            3,
+            $this->createFileSizeCriterion('0.00001', 0.3),
+        ];
+
         yield 'Width' => [
             3,
             $this->createWidthCriterion(0, 100),
@@ -238,9 +258,13 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
         );
     }
 
+    /**
+     * @param numeric $min
+     * @param numeric|null $max
+     */
     private function createFileSizeCriterion(
-        int $min = 0,
-        ?int $max = null
+        $min = 0,
+        $max = null
     ): Query\Criterion\Image\FileSize {
         return new Query\Criterion\Image\FileSize(
             self::IMAGE_FIELD_DEF_IDENTIFIER,

--- a/tests/integration/Core/Repository/SearchServiceImageTest.php
+++ b/tests/integration/Core/Repository/SearchServiceImageTest.php
@@ -84,17 +84,12 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
             ),
         ];
 
-        yield 'FileSize - default values min 0 and max 1' => [
+        yield 'FileSize - with numeric values from 0 to 1' => [
             3,
             $this->createFileSizeCriterion(0, 1),
         ];
 
-        yield 'FileSize' => [
-            3,
-            $this->createFileSizeCriterion(0, 2),
-        ];
-
-        yield 'FileSize - with numeric string values' => [
+        yield 'FileSize - with numeric string values from 0.0 to 2.5' => [
             3,
             $this->createFileSizeCriterion('0.0', '2.5'),
         ];
@@ -104,24 +99,24 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
             $this->createFileSizeCriterion(0.0, 2.5),
         ];
 
-        yield 'FileSize - with numeric values 0.0001 to 2.5' => [
-            3,
-            $this->createFileSizeCriterion(0.0001, 1),
+        yield 'FileSize - with numeric values 0.0001 to 0.004' => [
+            2,
+            $this->createFileSizeCriterion(0.001, 0.004),
         ];
 
-        yield 'FileSize - with values less than 1' => [
-            3,
-            $this->createFileSizeCriterion('0.00001', 0.3),
+        yield 'FileSize - with values numeric string 0.0003 and numeric 0.3' => [
+            1,
+            $this->createFileSizeCriterion('0.003', 0.3),
         ];
 
         yield 'FileSize - min value' => [
-            3,
-            $this->createFileSizeCriterion('0.00001'),
+            2,
+            $this->createFileSizeCriterion('0.0002'),
         ];
 
         yield 'FileSize - max value' => [
-            3,
-            $this->createFileSizeCriterion(null, '1.2'),
+            1,
+            $this->createFileSizeCriterion(null, '0.0003'),
         ];
 
         yield 'Width' => [

--- a/tests/integration/Core/Repository/SearchServiceImageTest.php
+++ b/tests/integration/Core/Repository/SearchServiceImageTest.php
@@ -86,7 +86,7 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
 
         yield 'FileSize - default values min 0 and max 1' => [
             3,
-            $this->createFileSizeCriterion(),
+            $this->createFileSizeCriterion(0, 1),
         ];
 
         yield 'FileSize' => [
@@ -112,6 +112,16 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
         yield 'FileSize - with values less than 1' => [
             3,
             $this->createFileSizeCriterion('0.00001', 0.3),
+        ];
+
+        yield 'FileSize - min value' => [
+            3,
+            $this->createFileSizeCriterion('0.00001'),
+        ];
+
+        yield 'FileSize - max value' => [
+            3,
+            $this->createFileSizeCriterion(null, '1.2'),
         ];
 
         yield 'Width' => [
@@ -259,7 +269,7 @@ final class SearchServiceImageTest extends RepositorySearchTestCase
     }
 
     /**
-     * @param numeric $min
+     * @param numeric|null $min
      * @param numeric|null $max
      */
     private function createFileSizeCriterion(


### PR DESCRIPTION
| :ticket: Issue | [IBX-8469](https://issues.ibexa.co/browse/IBX-8469) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Float values in file size filter causes error when using solr search engine. This PR adds cast to int value converted to bytes and allows to use float values. 

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
