### PR TITLE
[Tests] Fixed breaking changes introduced by twig/twig v3.11.0

### DIFF
--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/filters/ez_data_attributes_serialize.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/filters/ez_data_attributes_serialize.test
@@ -1,7 +1,7 @@
 --TEST--
 "ez_data_attributes_serialize" filter
 --DEPRECATION--
-Twig Filter "ez_data_attributes_serialize" is deprecated since version 4.0. Use "ibexa_data_attributes_serialize" instead in index.twig at line 2.
+Since  4.0: Twig Filter "ez_data_attributes_serialize" is deprecated. Use "ibexa_data_attributes_serialize" instead in index.twig at line 2.
 --TEMPLATE--
 <a href="/article" {{ data_attributes|ez_data_attributes_serialize }}>Article</a>
 --DATA--

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/filters/ez_data_attributes_serialize.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/filters/ez_data_attributes_serialize.test
@@ -13,27 +13,3 @@ return [
 ];
 --EXPECT--
 <a href="/article" data-my-attr1="value1" data-my-attr2="value2,value3">Article</a>
---DATA--
-return [
-    'data_attributes' => [
-        'attr' => 'foo" style="background: red',
-    ]
-];
---EXPECT--
-<a href="/article" data-attr="foo&quot; style=&quot;background: red">Article</a>
---DATA--
-return [
-    'data_attributes' => [
-        'attr' => true,
-    ]
-];
---EXPECT--
-<a href="/article" data-attr="true">Article</a>
---DATA--
-return [
-    'data_attributes' => [
-        'attr' => ['key1' => 'value1', 'key2' => 'value2'],
-    ]
-];
---EXPECT--
-<a href="/article" data-attr="{&quot;key1&quot;:&quot;value1&quot;,&quot;key2&quot;:&quot;value2&quot;}">Article</a>

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/functions/ez_file_size/ez_file_size.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/functions/ez_file_size/ez_file_size.test
@@ -1,18 +1,18 @@
 --TEST--
 "twig" filter
 --DEPRECATION--
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 2.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 3.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 4.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 5.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 6.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 7.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 8.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 9.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 10.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 11.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 12.
-Twig Filter "ez_file_size" is deprecated since version 4.0. Use "ibexa_file_size" instead in index.twig at line 13.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 2.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 3.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 4.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 5.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 6.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 7.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 8.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 9.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 10.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 11.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 12.
+Since  4.0: Twig Filter "ez_file_size" is deprecated. Use "ibexa_file_size" instead in index.twig at line 13.
 --TEMPLATE--
 {{ 10|ez_file_size( 2 ) }}
 {{ 1024|ez_file_size( 0 ) }}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/functions/ez_file_size/ez_file_size.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/functions/ez_file_size/ez_file_size.test
@@ -42,37 +42,3 @@ return array()
 789.7897897898 PB wrong local so we take the default one which is en-GB here
 789.79 EB wrong local so we take the default one which is en-GB here
 789789789.7898 EB wrong local so we take the default one which is en-GB here
---DATA--
-return array()
---CONFIG--
-$this->locale = "fre-FR"; return array();
---EXPECT--
-10 B French version
-1 kB French version
-5 kB French version
-12 kB French version
-152 kB French version
-26,15126 MB French version
-123,1231 MB French version
-456,5 GB French version
-789,78979 TB French version
-789,7897897898 PB French version
-789,79 EB French version
-789789789,7898 EB French version
---DATA--
-return array()
---CONFIG--
-$this->locale = "eng-GB"; return array();
---EXPECT--
-10 B English version
-1 kB English version
-5 kB English version
-12 kB English version
-152 kB English version
-26.15126 MB English version
-123.1231 MB English version
-456.5 GB English version
-789.78979 TB English version
-789.7897897898 PB English version
-789.79 EB English version
-789789789.7898 EB English version

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_path.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_path.test
@@ -1,24 +1,24 @@
 --TEST--
 "ez_path" function
 --DEPRECATION--
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 2.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 3.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 4.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 5.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 6.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 7.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 8.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 9.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 10.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 11.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 12.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 13.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 14.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 15.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 16.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 17.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 18.
-Twig Function "ez_path" is deprecated since version 4.0. Use "ibexa_path" instead in index.twig at line 19.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 2.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 3.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 4.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 5.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 6.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 7.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 8.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 9.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 10.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 11.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 12.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 13.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 14.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 15.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 16.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 17.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 18.
+Since  4.0: Twig Function "ez_path" is deprecated. Use "ibexa_path" instead in index.twig at line 19.
 --TEMPLATE--
 {{ ez_path(location) }}
 {{ ez_path(location, {}, true) }}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_route.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_route.test
@@ -1,9 +1,9 @@
 --TEST--
 "twig" filter
 --DEPRECATION--
-Twig Function "ez_route" is deprecated since version 4.0. Use "ibexa_route" instead in index.twig at line 2.
-Twig Function "ez_route" is deprecated since version 4.0. Use "ibexa_route" instead in index.twig at line 3.
-Twig Function "ez_route" is deprecated since version 4.0. Use "ibexa_route" instead in index.twig at line 4.
+Since  4.0: Twig Function "ez_route" is deprecated. Use "ibexa_route" instead in index.twig at line 2.
+Since  4.0: Twig Function "ez_route" is deprecated. Use "ibexa_route" instead in index.twig at line 3.
+Since  4.0: Twig Function "ez_route" is deprecated. Use "ibexa_route" instead in index.twig at line 4.
 --TEMPLATE--
 {% set route_ref1 = ez_route( "foo_route" ) %}
 {% set route_ref2 = ez_route( "bar_route", {"some": "thing"} ) %}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_url.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/routing_functions/ez_url.test
@@ -1,24 +1,24 @@
 --TEST--
 "ez_url" function
 --DEPRECATION--
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 2.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 3.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 4.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 5.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 6.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 7.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 8.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 9.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 10.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 11.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 12.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 13.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 14.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 15.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 16.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 17.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 18.
-Twig Function "ez_url" is deprecated since version 4.0. Use "ibexa_url" instead in index.twig at line 19.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 2.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 3.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 4.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 5.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 6.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 7.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 8.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 9.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 10.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 11.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 12.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 13.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 14.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 15.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 16.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 17.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 18.
+Since  4.0: Twig Function "ez_url" is deprecated. Use "ibexa_url" instead in index.twig at line 19.
 --TEMPLATE--
 {{ ez_url(location) }}
 {{ ez_url(location, {}, true) }}


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Related PRs: 
- blocks https://github.com/ibexa/core/pull/413

#### Description:

The latest Twig release ([`twig/twig:v3.11.0`](https://github.com/twigphp/Twig/releases/tag/v3.11.0)) [changed deprecation message format](https://github.com/twigphp/Twig/pull/4183/files#diff-ad87623d49894167ed5e4ecd1814164bdbe5c4c250e6b2ad9da415edd22e8e85R783). As we deprecated our own filters and functions, it crashed our Twig integration tests.

Moreover I see some sort of template caching has been introduced, making deprecation being thrown only once, per 1st template loading. I had to remove other snippets from a template file as they didn't produce any message. While overall more caching is better, I think Twig's integration test shouldn't behave this way. There's nothing I can do about it right now.

Update: The removed test cases are also covered fully by the test cases testing the actual filters and functions (not their deprecated counterparts). E.g: https://github.com/ibexa/core/blob/e766878c07435ee29997e9d4e704fd8235c9cce6/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/filters/ibexa_data_attributes_serialize.test