### PR TITLE
IBX-8811: Rebranded SiteAccess session prefix

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2141,11 +2141,6 @@ parameters:
 			path: src/bundle/Core/EventListener/SessionInitByPostListener.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListener\\:\\:onSiteAccessMatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Core/EventListener/SessionSetDynamicNameListener.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\EventListener\\\\SiteAccessListener\\:\\:generateViewParametersArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/bundle/Core/EventListener/SiteAccessListener.php
@@ -24446,46 +24441,6 @@ parameters:
 			path: tests/bundle/Core/EventListener/RoutingListenerTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionInitByPostListenerTest\\:\\:testGetSubscribedEvents\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionInitByPostListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionInitByPostListenerTest\\:\\:testOnSiteAccessMatchNewSessionName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionInitByPostListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionInitByPostListenerTest\\:\\:testOnSiteAccessMatchNoSessionService\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionInitByPostListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionInitByPostListenerTest\\:\\:testOnSiteAccessMatchRequestNoSessionName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionInitByPostListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionInitByPostListenerTest\\:\\:testOnSiteAccessMatchSubRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionInitByPostListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:onSiteAccessMatchProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testGetSubscribedEvents\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testOnSiteAccessMatch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testOnSiteAccessMatch\\(\\) has parameter \\$configuredSessionStorageOptions with no type specified\\.$#"
 			count: 1
 			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
@@ -24493,36 +24448,6 @@ parameters:
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testOnSiteAccessMatch\\(\\) has parameter \\$expectedSessionStorageOptions with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testOnSiteAccessMatchNoConfiguredSessionName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testOnSiteAccessMatchNoSession\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testOnSiteAccessMatchNonNativeSessionStorage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:testOnSiteAccessMatchSubRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$configResolver of class Ibexa\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListener constructor expects Ibexa\\\\Contracts\\\\Core\\\\SiteAccess\\\\ConfigResolverInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
-			count: 6
-			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$sessionStorageFactory of class Ibexa\\\\Bundle\\\\Core\\\\EventListener\\\\SessionSetDynamicNameListener constructor expects Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\Storage\\\\SessionStorageFactoryInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
-			count: 5
 			path: tests/bundle/Core/EventListener/SessionSetDynamicNameListenerTest.php
 
 		-
@@ -44704,16 +44629,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\Limitation\\\\SubtreeLimitationTypeTest\\:\\:testValueSchema\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/Limitation/SubtreeLimitationTypeTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Component\\\\Serializer\\\\SimplifiedRequestNormalizerTest\\:\\:testNormalize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Component\\\\Serializer\\\\SimplifiedRequestNormalizerTest\\:\\:testSupportsNormalization\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizerTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\Component\\\\Serializer\\\\Stubs\\\\CompoundStub\\:\\:__construct\\(\\) has parameter \\$subMatchers with no value type specified in iterable type array\\.$#"

--- a/src/bundle/Core/DependencyInjection/Configuration/Parser/Common.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/Parser/Common.php
@@ -89,7 +89,7 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
                 ->children()
                     ->scalarNode('name')
                         ->info('The session name. If you want a session name per siteaccess, use "{siteaccess_hash}" token. Will override default session name from framework.session.name')
-                        ->example('eZSESSID{siteaccess_hash}')
+                        ->example('IBX_SESSION_ID{siteaccess_hash}')
                     ->end()
                     ->scalarNode('cookie_lifetime')->end()
                     ->scalarNode('cookie_path')->end()

--- a/src/bundle/Core/EventListener/SessionSetDynamicNameListener.php
+++ b/src/bundle/Core/EventListener/SessionSetDynamicNameListener.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\EventListener;
 
@@ -21,27 +22,16 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * Allows to set a dynamic session name based on the siteaccess name.
  */
-class SessionSetDynamicNameListener implements EventSubscriberInterface
+final readonly class SessionSetDynamicNameListener implements EventSubscriberInterface
 {
-    public const MARKER = '{siteaccess_hash}';
+    public const string MARKER = '{siteaccess_hash}';
 
-    /**
-     * Prefix for session name.
-     */
-    public const SESSION_NAME_PREFIX = 'eZSESSID';
-
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
-
-    /** @var \Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface */
-    private $sessionStorageFactory;
+    public const string SESSION_NAME_PREFIX = 'IBX_SESSION_ID';
 
     public function __construct(
-        ConfigResolverInterface $configResolver,
-        SessionStorageFactoryInterface $sessionStorageFactory
+        private ConfigResolverInterface $configResolver,
+        private SessionStorageFactoryInterface $sessionStorageFactory
     ) {
-        $this->configResolver = $configResolver;
-        $this->sessionStorageFactory = $sessionStorageFactory;
     }
 
     public static function getSubscribedEvents(): array
@@ -51,7 +41,7 @@ class SessionSetDynamicNameListener implements EventSubscriberInterface
         ];
     }
 
-    public function onSiteAccessMatch(PostSiteAccessMatchEvent $event)
+    public function onSiteAccessMatch(PostSiteAccessMatchEvent $event): void
     {
         $request = $event->getRequest();
         $session = $request->hasSession() ? $request->getSession() : null;
@@ -69,26 +59,20 @@ class SessionSetDynamicNameListener implements EventSubscriberInterface
         }
 
         $sessionOptions = (array)$this->configResolver->getParameter('session');
-        $sessionName = isset($sessionOptions['name']) ? $sessionOptions['name'] : $session->getName();
+        $sessionName = $sessionOptions['name'] ?? $session->getName();
         $sessionOptions['name'] = $this->getSessionName($sessionName, $event->getSiteAccess());
         $sessionStorage->setOptions($sessionOptions);
     }
 
-    /**
-     * @param string $sessionName
-     * @param \Ibexa\Core\MVC\Symfony\SiteAccess $siteAccess
-     *
-     * @return string
-     */
-    private function getSessionName($sessionName, SiteAccess $siteAccess)
+    private function getSessionName(string $sessionName, SiteAccess $siteAccess): string
     {
         // Add session prefix if needed.
-        if (strpos($sessionName, static::SESSION_NAME_PREFIX) !== 0) {
-            $sessionName = static::SESSION_NAME_PREFIX . '_' . $sessionName;
+        if (!str_starts_with($sessionName, self::SESSION_NAME_PREFIX)) {
+            $sessionName = self::SESSION_NAME_PREFIX . '_' . $sessionName;
         }
 
         // Check if uniqueness marker is present. If so, session name will be unique for current siteaccess.
-        if (strpos($sessionName, self::MARKER) !== false) {
+        if (str_contains($sessionName, self::MARKER)) {
             $sessionName = str_replace(self::MARKER, md5($siteAccess->name), $sessionName);
         }
 

--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -83,7 +83,7 @@ parameters:
     # Common settings
     ibexa.repositories: {}
     ibexa.site_access.config.default.repository: ~
-    ibexa.session_name.default: "eZSESSID{siteaccess_hash}"
+    ibexa.session_name.default: "IBX_SESSION_ID{siteaccess_hash}"
     ibexa.site_access.config.default.session_name: '%ibexa.session_name.default%'    # Using "{siteaccess_hash}" in session name makes it unique per siteaccess
     ibexa.site_access.config.default.session: { name: '%ibexa.session_name.default%' } # Session options that will override options from framework
     ibexa.site_access.config.default.url_alias_router: true                       # Use UrlAliasRouter by default

--- a/tests/bundle/Core/EventListener/SessionInitByPostListenerTest.php
+++ b/tests/bundle/Core/EventListener/SessionInitByPostListenerTest.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\Core\EventListener;
 
@@ -18,10 +19,9 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class SessionInitByPostListenerTest extends TestCase
+final class SessionInitByPostListenerTest extends TestCase
 {
-    /** @var \Ibexa\Bundle\Core\EventListener\SessionInitByPostListener */
-    private $listener;
+    private SessionInitByPostListener $listener;
 
     protected function setUp(): void
     {
@@ -29,7 +29,7 @@ class SessionInitByPostListenerTest extends TestCase
         $this->listener = new SessionInitByPostListener();
     }
 
-    public function testGetSubscribedEvents()
+    public function testGetSubscribedEvents(): void
     {
         self::assertSame(
             [
@@ -39,7 +39,7 @@ class SessionInitByPostListenerTest extends TestCase
         );
     }
 
-    public function testOnSiteAccessMatchNoSessionService()
+    public function testOnSiteAccessMatchNoSessionService(): void
     {
         $request = new Request();
         $request->setSession(new Session(new MockArraySessionStorage()));
@@ -49,7 +49,7 @@ class SessionInitByPostListenerTest extends TestCase
         self::assertNull($listener->onSiteAccessMatch($event));
     }
 
-    public function testOnSiteAccessMatchSubRequest()
+    public function testOnSiteAccessMatchSubRequest(): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -63,9 +63,9 @@ class SessionInitByPostListenerTest extends TestCase
         $this->listener->onSiteAccessMatch($event);
     }
 
-    public function testOnSiteAccessMatchRequestNoSessionName()
+    public function testOnSiteAccessMatchRequestNoSessionName(): void
     {
-        $sessionName = 'eZSESSID';
+        $sessionName = 'IBX_SESSION_ID';
 
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -90,9 +90,9 @@ class SessionInitByPostListenerTest extends TestCase
         $this->listener->onSiteAccessMatch($event);
     }
 
-    public function testOnSiteAccessMatchNewSessionName()
+    public function testOnSiteAccessMatchNewSessionName(): void
     {
-        $sessionName = 'eZSESSID';
+        $sessionName = 'IBX_SESSION_ID';
         $sessionId = 'foobar123';
         $session = $this->createMock(SessionInterface::class);
 

--- a/tests/lib/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizerTest.php
+++ b/tests/lib/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizerTest.php
@@ -14,7 +14,7 @@ use stdClass;
 
 final class SimplifiedRequestNormalizerTest extends TestCase
 {
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $request = new SimplifiedRequest([
             'scheme' => 'http',
@@ -27,7 +27,7 @@ final class SimplifiedRequestNormalizerTest extends TestCase
                 'Accept-Encoding' => 'gzip, deflate, br',
                 'Accept-Language' => 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
                 'User-Agent' => 'Mozilla/5.0',
-                'Cookie' => 'eZSESSID21232f297a57a5a743894a0e4a801fc3=mgbs2p6lv936hb5hmdd2cvq6bq',
+                'Cookie' => 'IBX_SESSION_ID21232f297a57a5a743894a0e4a801fc3=mgbs2p6lv936hb5hmdd2cvq6bq',
                 'Connection' => 'keep-alive',
             ],
             'languages' => ['pl-PL', 'en-US'],
@@ -46,7 +46,7 @@ final class SimplifiedRequestNormalizerTest extends TestCase
         ], $normalizer->normalize($request));
     }
 
-    public function testSupportsNormalization()
+    public function testSupportsNormalization(): void
     {
         $normalizer = new SimplifiedRequestNormalizer();
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8811 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
While checking if session sharing between SiteAccesses works (it does 😄) in the new security ecosystem I decided to improve code quality a little and rebrand `eZSESSID` to `IBX_SESSION_ID` as it is one of the leftovers that we have after the rebranding process. Remarks related to the naming are welcome.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
