### PR TITLE
[Tests] Truncated SQLite last insert ID to real DB integer value

### DIFF
--- a/src/lib/Persistence/Legacy/SharedGateway/DatabasePlatform/SqliteGateway.php
+++ b/src/lib/Persistence/Legacy/SharedGateway/DatabasePlatform/SqliteGateway.php
@@ -18,6 +18,8 @@ final class SqliteGateway implements Gateway
      */
     private const FATAL_ERROR_CODE = 7;
 
+    private const DB_INT_MAX = 2147483647;
+
     /** @var array<string, int> */
     private $lastInsertedIds = [];
 
@@ -27,7 +29,7 @@ final class SqliteGateway implements Gateway
         string $sequenceName
     ): ?int {
         $lastId = $this->lastInsertedIds[$sequenceName] ?? 0;
-        $nextId = (int)hrtime(true);
+        $nextId = (int)hrtime(true) % self::DB_INT_MAX;
 
         // $lastId === $nextId shouldn't happen using high-resolution time, but better safe than sorry
         return $this->lastInsertedIds[$sequenceName] = $lastId === $nextId ? $nextId + 1 : $nextId;


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Related PRs: 
- ibexa/product-catalog#1180

#### TL;DR;

I've truncated the value of SQLite virtual sequence numbers up to `2147483647` max, given the risk of that change is minimal as it applies to SQLite-based test setup only. We don't support SQLite on production envs.


#### Description:

Some time ago we've changed the way virtual sequence number for SQLite gateway used for test purposes only is computed. We've changed it from a `SELECT MAX` expression to `hrtime` to simulate better a serial sequence.

There's one issue with that, visible for a few weeks now on 4.6+ product-catalog CI. The number generated by `hrtime` is too large. While for SQLite `INT` type it's okay (`< 9223372036854775807`), for other databases `INT is a number smaller than `2147483647`, contrary to `BIGINT`. For the most identity keys with serial / auto-incremented sequence we use `INT` (content language table is an exception).

Therefore the change.

##### Roads not taken

The issue actually surfaces in product-catalog for GraphQL queries as:
```
{"errors":[{"debugMessage":"Expected a value of type \u0022Int\u0022 but received: 136228248691669" ...
```
We define almost all database IDs as `Int`, which for GraphQL is within range of -2147483647 to 2147483647. I tried to use `ID` type for that, but it's cast to int, making all schema validation fail, as we expect integers there.

Alternatively we could introduce our own DbID or IbxID, however production-wise this doesn't make sense, as production is running on PostgreSQL and MySQL which `INT` type is of that smaller range.

##### TODO
- [ ] Check against tests of other packages relying on that