### PR TITLE
Extracted redundant TextLine and ISBN SearchField into a common base

### DIFF
--- a/src/lib/FieldType/BaseSingleTextLineSearchField.php
+++ b/src/lib/FieldType/BaseSingleTextLineSearchField.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\FieldType;
+
+use Ibexa\Contracts\Core\FieldType\Indexable;
+use Ibexa\Contracts\Core\Persistence\Content\Field;
+use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
+use Ibexa\Contracts\Core\Search;
+
+abstract class BaseSingleTextLineSearchField implements Indexable
+{
+    /**
+     * @return \Ibexa\Contracts\Core\Search\Field[]
+     */
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition): array
+    {
+        return [
+            new Search\Field(
+                'value',
+                $field->value->data,
+                new Search\FieldType\StringField()
+            ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, \Ibexa\Contracts\Core\Search\FieldType>
+     */
+    public function getIndexDefinition(): array
+    {
+        return [
+            'value' => new Search\FieldType\StringField(),
+        ];
+    }
+
+    public function getDefaultMatchField(): string
+    {
+        return 'value';
+    }
+
+    public function getDefaultSortField(): string
+    {
+        return $this->getDefaultMatchField();
+    }
+}

--- a/src/lib/FieldType/ISBN/SearchField.php
+++ b/src/lib/FieldType/ISBN/SearchField.php
@@ -4,67 +4,15 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\ISBN;
 
-use Ibexa\Contracts\Core\FieldType\Indexable;
-use Ibexa\Contracts\Core\Persistence\Content\Field;
-use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
-use Ibexa\Contracts\Core\Search;
+use Ibexa\Core\FieldType\BaseSingleTextLineSearchField;
 
 /**
  * Indexable definition for ISBN field type.
  */
-class SearchField implements Indexable
+class SearchField extends BaseSingleTextLineSearchField
 {
-    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
-    {
-        return [
-            new Search\Field(
-                'value',
-                $field->value->data,
-                new Search\FieldType\StringField()
-            ),
-            new Search\Field(
-                'fulltext',
-                $field->value->data,
-                new Search\FieldType\FullTextField()
-            ),
-        ];
-    }
-
-    public function getIndexDefinition()
-    {
-        return [
-            'value' => new Search\FieldType\StringField(),
-        ];
-    }
-
-    /**
-     * Get name of the default field to be used for matching.
-     *
-     * As field types can index multiple fields (see MapLocation field type's
-     * implementation of this interface), this method is used to define default
-     * field for matching. Default field is typically used by Field criterion.
-     *
-     * @return string
-     */
-    public function getDefaultMatchField()
-    {
-        return 'value';
-    }
-
-    /**
-     * Get name of the default field to be used for sorting.
-     *
-     * As field types can index multiple fields (see MapLocation field type's
-     * implementation of this interface), this method is used to define default
-     * field for sorting. Default field is typically used by Field sort clause.
-     *
-     * @return string
-     */
-    public function getDefaultSortField()
-    {
-        return $this->getDefaultMatchField();
-    }
 }

--- a/src/lib/FieldType/TextLine/SearchField.php
+++ b/src/lib/FieldType/TextLine/SearchField.php
@@ -4,67 +4,15 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\TextLine;
 
-use Ibexa\Contracts\Core\FieldType\Indexable;
-use Ibexa\Contracts\Core\Persistence\Content\Field;
-use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
-use Ibexa\Contracts\Core\Search;
+use Ibexa\Core\FieldType\BaseSingleTextLineSearchField;
 
 /**
  * Indexable definition for TextLine field type.
  */
-class SearchField implements Indexable
+class SearchField extends BaseSingleTextLineSearchField
 {
-    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
-    {
-        return [
-            new Search\Field(
-                'value',
-                $field->value->data,
-                new Search\FieldType\StringField()
-            ),
-            new Search\Field(
-                'fulltext',
-                $field->value->data,
-                new Search\FieldType\FullTextField()
-            ),
-        ];
-    }
-
-    public function getIndexDefinition()
-    {
-        return [
-            'value' => new Search\FieldType\StringField(),
-        ];
-    }
-
-    /**
-     * Get name of the default field to be used for matching.
-     *
-     * As field types can index multiple fields (see MapLocation field type's
-     * implementation of this interface), this method is used to define default
-     * field for matching. Default field is typically used by Field criterion.
-     *
-     * @return string
-     */
-    public function getDefaultMatchField()
-    {
-        return 'value';
-    }
-
-    /**
-     * Get name of the default field to be used for sorting.
-     *
-     * As field types can index multiple fields (see MapLocation field type's
-     * implementation of this interface), this method is used to define default
-     * field for sorting. Default field is typically used by Field sort clause.
-     *
-     * @return string
-     */
-    public function getDefaultSortField()
-    {
-        return $this->getDefaultMatchField();
-    }
 }


### PR DESCRIPTION
| :ticket: Issue | Related to IBX-8138 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/385

#### Description:

This PR addresses code redundancy between ISBN and TextLine SearchField types. Code for these classes was identical. The reason for that is that both TextLine and ISBN are single text lines, indexed identically.

#### For QA:

Regression build should be enough (https://github.com/ibexa/commerce/pull/1008).


