### PR TITLE
Add missing variable name in var tag in PermissionResolver

### DIFF
--- a/src/lib/Repository/Permission/PermissionResolver.php
+++ b/src/lib/Repository/Permission/PermissionResolver.php
@@ -206,7 +206,7 @@ class PermissionResolver implements PermissionResolverInterface
              * These are already filtered by hasAccess and given hasAccess did not return boolean
              * there must be some, so only return true if one of them says yes.
              *
-             * @var \Ibexa\Contracts\Core\Repository\Values\User\Policy
+             * @var \Ibexa\Contracts\Core\Repository\Values\User\Policy $policy
              */
             foreach ($permissionSet['policies'] as $policy) {
                 $limitations = $policy->getLimitations();


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Without the variable name, PhpStorm will not apply the `@var` annotation to the loop variable.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
