### PR TITLE
Extracted abstract for redundant Host & URI text matchers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12426,36 +12426,6 @@ parameters:
 			path: src/lib/MVC/Symfony/SiteAccess/Matcher/HostElement.php
 
 		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\HostText\\:\\:__construct\\(\\) has parameter \\$siteAccessesConfiguration with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\HostText\\:\\:setRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\HostText\\:\\:\\$prefix has no type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\HostText\\:\\:\\$siteAccessesConfiguration is never read, only written\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\HostText\\:\\:\\$siteAccessesConfiguration type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\HostText\\:\\:\\$suffix has no type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\Map\\:\\:__construct\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/SiteAccess/Matcher/Map.php
@@ -12619,31 +12589,6 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/SiteAccess/Matcher/URIElement.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\URIText\\:\\:__construct\\(\\) has parameter \\$siteAccessesConfiguration with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\URIText\\:\\:analyseURI\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\URIText\\:\\:setRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\URIText\\:\\:\\$siteAccessesConfiguration is never read, only written\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
-
-		-
-			message: "#^Property Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\URIText\\:\\:\\$siteAccessesConfiguration type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
 
 		-
 			message: "#^Call to an undefined method object\\:\\:setRequest\\(\\)\\.$#"

--- a/src/lib/MVC/Symfony/SiteAccess/Matcher/AffixBasedTextMatcher.php
+++ b/src/lib/MVC/Symfony/SiteAccess/Matcher/AffixBasedTextMatcher.php
@@ -15,14 +15,11 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
  *
  * @phpstan-type TSiteAccessConfigurationArray array{prefix?: string, suffix?: string}
  */
-abstract class PrefixSuffixBasedTextMatcher extends Regex implements VersatileMatcher
+abstract class AffixBasedTextMatcher extends Regex implements VersatileMatcher
 {
-    protected string $prefix;
+    protected readonly string $prefix;
 
-    protected string $suffix;
-
-    /** @phpstan-var TSiteAccessConfigurationArray */
-    protected array $siteAccessesConfiguration;
+    protected readonly string $suffix;
 
     abstract protected function buildRegex(): string;
 
@@ -31,10 +28,8 @@ abstract class PrefixSuffixBasedTextMatcher extends Regex implements VersatileMa
     /**
      * @phpstan-param TSiteAccessConfigurationArray $siteAccessesConfiguration
      */
-    public function __construct(array $siteAccessesConfiguration)
+    public function __construct(private readonly array $siteAccessesConfiguration)
     {
-        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
-
         $this->prefix = $this->siteAccessesConfiguration['prefix'] ?? '';
         $this->suffix = $this->siteAccessesConfiguration['suffix'] ?? '';
 

--- a/src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
+++ b/src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
@@ -10,46 +10,24 @@ namespace Ibexa\Core\MVC\Symfony\SiteAccess\Matcher;
 use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use Ibexa\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
 
-class HostText extends Regex implements VersatileMatcher
+class HostText extends PrefixSuffixBasedTextMatcher
 {
-    private $prefix;
-
-    private $suffix;
-
-    /**
-     * The property needed to allow correct deserialization with Symfony serializer.
-     *
-     * @var array
-     */
-    private $siteAccessesConfiguration;
-
-    /**
-     * Constructor.
-     *
-     * @param array $siteAccessesConfiguration SiteAccesses configuration.
-     */
-    public function __construct(array $siteAccessesConfiguration)
+    protected function buildRegex(): string
     {
-        $this->prefix = isset($siteAccessesConfiguration['prefix']) ? $siteAccessesConfiguration['prefix'] : '';
-        $this->suffix = isset($siteAccessesConfiguration['suffix']) ? $siteAccessesConfiguration['suffix'] : '';
-        parent::__construct(
-            '^' . preg_quote($this->prefix, '@') . "(\w+)" . preg_quote($this->suffix, '@') . '$',
-            1
-        );
-        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
+        return '^' . preg_quote($this->prefix, '@') . "(\w+)" . preg_quote($this->suffix, '@') . '$';
     }
 
-    public function getName()
+    protected function getMatchedItemNumber(): int
+    {
+        return 1;
+    }
+
+    public function getName(): string
     {
         return 'host:text';
     }
 
-    /**
-     * Injects the request object to match against.
-     *
-     * @param \Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest $request
-     */
-    public function setRequest(SimplifiedRequest $request)
+    public function setRequest(SimplifiedRequest $request): void
     {
         if (!$this->element) {
             $this->setMatchElement($request->host);
@@ -58,14 +36,14 @@ class HostText extends Regex implements VersatileMatcher
         parent::setRequest($request);
     }
 
-    public function reverseMatch($siteAccessName)
+    public function reverseMatch($siteAccessName): ?VersatileMatcher
     {
         $this->request->setHost($this->prefix . $siteAccessName . $this->suffix);
 
         return $this;
     }
 
-    public function getRequest()
+    public function getRequest(): SimplifiedRequest
     {
         return $this->request;
     }

--- a/src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
+++ b/src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
@@ -10,7 +10,7 @@ namespace Ibexa\Core\MVC\Symfony\SiteAccess\Matcher;
 use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use Ibexa\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
 
-class HostText extends PrefixSuffixBasedTextMatcher
+class HostText extends AffixBasedTextMatcher
 {
     protected function buildRegex(): string
     {

--- a/src/lib/MVC/Symfony/SiteAccess/Matcher/PrefixSuffixBasedTextMatcher.php
+++ b/src/lib/MVC/Symfony/SiteAccess/Matcher/PrefixSuffixBasedTextMatcher.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\SiteAccess\Matcher;
+
+use Ibexa\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
+
+/**
+ * @internal
+ *
+ * @phpstan-type TSiteAccessConfigurationArray array{prefix?: string, suffix?: string}
+ */
+abstract class PrefixSuffixBasedTextMatcher extends Regex implements VersatileMatcher
+{
+    protected string $prefix;
+
+    protected string $suffix;
+
+    /** @phpstan-var TSiteAccessConfigurationArray */
+    protected array $siteAccessesConfiguration;
+
+    abstract protected function buildRegex(): string;
+
+    abstract protected function getMatchedItemNumber(): int;
+
+    /**
+     * @phpstan-param TSiteAccessConfigurationArray $siteAccessesConfiguration
+     */
+    public function __construct(array $siteAccessesConfiguration)
+    {
+        $this->siteAccessesConfiguration = $siteAccessesConfiguration;
+
+        $this->prefix = $this->siteAccessesConfiguration['prefix'] ?? '';
+        $this->suffix = $this->siteAccessesConfiguration['suffix'] ?? '';
+
+        parent::__construct($this->buildRegex(), $this->getMatchedItemNumber());
+    }
+}

--- a/src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
+++ b/src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
@@ -11,7 +11,7 @@ use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use Ibexa\Core\MVC\Symfony\SiteAccess\URILexer;
 use Ibexa\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
 
-class URIText extends PrefixSuffixBasedTextMatcher implements URILexer
+class URIText extends AffixBasedTextMatcher implements URILexer
 {
     protected function buildRegex(): string
     {


### PR DESCRIPTION
| :ticket: Issue | Related to IBX-8138 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/385

#### Description:

This PR addresses code redundancy between `URIText` and `HostText` Matchers. Big portion of the code was identical. Found by SonarCloud for #385.

#### For QA:

Regression build should be enough (ibexa/commerce#1009).


