### PR TITLE
Aligned PHPStan baseline and updated Symfony deprecations helper setting

### DIFF
--- a/phpstan-baseline-gte-8.0.neon
+++ b/phpstan-baseline-gte-8.0.neon
@@ -71,7 +71,7 @@ parameters:
 			path: src/bundle/Core/Imagine/IORepositoryResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\URLChecker\\\\Handler\\\\HTTPHandler\\:\\:createCurlHandlerForUrl\\(\\) should return resource but returns CurlHandle\\.$#"
+			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\URLChecker\\\\Handler\\\\HTTPHandler\\:\\:createCurlHandlerForUrl\\(\\) should return resource but returns \\(CurlHandle\\|false\\)\\.$#"
 			count: 1
 			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9676,11 +9676,6 @@ parameters:
 			path: src/lib/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
 
 		-
-			message: "#^Cannot call method fetchFirstColumn\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
-			count: 1
-			path: src/lib/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\FieldType\\\\Keyword\\\\KeywordStorage\\\\Gateway\\\\DoctrineStorage\\:\\:assignKeywords\\(\\) has parameter \\$keywordMap with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
@@ -10273,11 +10268,6 @@ parameters:
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
 			count: 3
-			path: src/lib/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
-
-		-
-			message: "#^Cannot call method fetchFirstColumn\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
-			count: 1
 			path: src/lib/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
 
 		-
@@ -16428,11 +16418,6 @@ parameters:
 		-
 			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
 			count: 12
-			path: src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
-
-		-
-			message: "#^Cannot call method fetchFirstColumn\\(\\) on Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\Result\\|int\\|string\\.$#"
-			count: 1
 			path: src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
 
 		-

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
   >
   <php>
     <ini name="error_reporting" value="-1" />
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=576&amp;verbose=0"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=631&amp;verbose=0"/>
   </php>
   <testsuites>
     <testsuite name="unit_core">


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

#### Description:

Maintainer update: besides PHPStan alignment after the release, we have increased number of deprecations, which fails test suite. That's probably due to the Symfony 5.4 release within the last 2 weeks. Given the volume, it's hard to say what's new without long analysis. For now increasing the number of allowed deprecations (`max[total]`) of Symfony deprecations helper.
