### PR TITLE
Improved strictness of URLChecker HTTPHandler and URL Value Object

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3911,21 +3911,6 @@ parameters:
 			path: src/bundle/Core/URLChecker/Handler/AbstractURLHandler.php
 
 		-
-			message: "#^Access to protected property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\URL\\\\URL\\:\\:\\$url\\.$#"
-			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\URLChecker\\\\Handler\\\\HTTPHandler\\:\\:createCurlHandlerForUrl\\(\\) has parameter \\$handlers with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\URLChecker\\\\Handler\\\\HTTPHandler\\:\\:createCurlHandlerForUrl\\(\\) should return resource but returns CurlHandle\\.$#"
-			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Core\\\\URLChecker\\\\Handler\\\\HTTPHandler\\:\\:doValidate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
@@ -3948,11 +3933,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$handle of function curl_getinfo expects CurlHandle, resource given\\.$#"
 			count: 1
-			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
-
-		-
-			message: "#^Parameter \\#2 \\$handle of function curl_multi_add_handle expects CurlHandle, resource given\\.$#"
-			count: 2
 			path: src/bundle/Core/URLChecker/Handler/HTTPHandler.php
 
 		-

--- a/src/bundle/Core/URLChecker/Handler/HTTPHandler.php
+++ b/src/bundle/Core/URLChecker/Handler/HTTPHandler.php
@@ -118,7 +118,7 @@ class HTTPHandler extends AbstractConfigResolverBasedURLHandler
         $handler = curl_init();
 
         curl_setopt_array($handler, [
-            CURLOPT_URL => $url->url,
+            CURLOPT_URL => $url->getUrl(),
             CURLOPT_RETURNTRANSFER => false,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_CONNECTTIMEOUT => $connectionTimeout,
@@ -137,7 +137,7 @@ class HTTPHandler extends AbstractConfigResolverBasedURLHandler
         $handlers[(int)$handler] = $url;
 
         if (false === $handler) {
-            throw new LogicException('Failed to create Curl handler for url', 1);
+            throw new LogicException("Failed to create Curl handler for '{$url->getUrl()}' URL", 1);
         }
 
         return $handler;

--- a/src/bundle/Core/URLChecker/Handler/HTTPHandler.php
+++ b/src/bundle/Core/URLChecker/Handler/HTTPHandler.php
@@ -7,7 +7,9 @@
 
 namespace Ibexa\Bundle\Core\URLChecker\Handler;
 
+use CurlHandle;
 use Ibexa\Contracts\Core\Repository\Values\URL\URL;
+use LogicException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class HTTPHandler extends AbstractConfigResolverBasedURLHandler
@@ -108,14 +110,9 @@ class HTTPHandler extends AbstractConfigResolverBasedURLHandler
     /**
      * Initialize and return a cURL session for given URL.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\URL\URL $url
-     * @param array $handlers
-     * @param int $connectionTimeout
-     * @param int $timeout
-     *
-     * @return resource
+     * @param array<int, \Ibexa\Contracts\Core\Repository\Values\URL\URL> $handlers
      */
-    private function createCurlHandlerForUrl(URL $url, array &$handlers, int $connectionTimeout, int $timeout)
+    private function createCurlHandlerForUrl(URL $url, array &$handlers, int $connectionTimeout, int $timeout): CurlHandle
     {
         $options = $this->getOptions();
         $handler = curl_init();
@@ -138,6 +135,10 @@ class HTTPHandler extends AbstractConfigResolverBasedURLHandler
         }
 
         $handlers[(int)$handler] = $url;
+
+        if (false === $handler) {
+            throw new LogicException('Failed to create Curl handler for url', 1);
+        }
 
         return $handler;
     }

--- a/src/contracts/Repository/Values/URL/URL.php
+++ b/src/contracts/Repository/Values/URL/URL.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Values\URL;
 
+use DateTimeInterface;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 class URL extends ValueObject
@@ -53,4 +54,34 @@ class URL extends ValueObject
      * @var \DateTimeInterface
      */
     protected $modified;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function isValid(): bool
+    {
+        return $this->isValid;
+    }
+
+    public function getLastChecked(): ?DateTimeInterface
+    {
+        return $this->lastChecked;
+    }
+
+    public function getCreated(): ?DateTimeInterface
+    {
+        return $this->created;
+    }
+
+    public function getModified(): ?DateTimeInterface
+    {
+        return $this->modified;
+    }
 }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:
I've noticed that PHPStan after its release fails for HTTPHandler class which is a part of URLChecker feature introduced in 2017.

Instead of updating baseline's message, I've resolved the issue at hand, that is safe to resolve. This class requires further improvements, however they would require QA involvement, so out of scope of fixing CI right now.

Given the LogicException introduced there needs more verbose information, I've added strict types to `URL` value object. Using there `$url->url` would add more to technical debt as there are no `@property-read`s on that VO. Accessing properties via magic getter is deprecated.

I've tried also to declare strict types for that VO's properties, however that exploded in many different directions, so it's safer to process such change as a follow-up, when there's more time.