### PR TITLE
[Tests] Migrated deprecated PHPUnit configuration

### DIFF
--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -1,37 +1,28 @@
-<?xml version = '1.0' encoding = 'utf-8'?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="bootstrap.php"
-         processIsolation="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         colors="true"
-         >
-    <php>
-        <env name="setupFactory" value="Ibexa\Tests\Solr\SetupFactory\LegacySetupFactory" />
-        <env name="backendVersion" value="5" />
-        <env name="fixtureDir" value="Solr" />
-        <env name="solrServer" value="http://localhost:8983/" />
-        <env name="CORES_SETUP" value="dedicated" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-        <ini name="error_reporting" value="-1" />
-        <env name="KERNEL_CLASS" value="Ibexa\Contracts\Solr\Test\IbexaSolrTestKernel"/>
-        <env name="SEARCH_ENGINE" value="solr"/>
-        <env name="DATABASE_URL" value="sqlite://:memory:" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-    </php>
-    <testsuites>
-        <!-- Search service is used all over the place, so we must run entire integration test suite -->
-        <testsuite name="integration_repository">
-            <directory>tests/integration/Core</directory>
-            <exclude>tests/integration/Core/Repository/Filtering</exclude>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">tests/integration</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="bootstrap.php" processIsolation="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" beStrictAboutTestsThatDoNotTestAnything="false" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">tests/integration</directory>
+    </include>
+  </coverage>
+  <php>
+    <env name="setupFactory" value="Ibexa\Tests\Solr\SetupFactory\LegacySetupFactory"/>
+    <env name="backendVersion" value="5"/>
+    <env name="fixtureDir" value="Solr"/>
+    <env name="solrServer" value="http://localhost:8983/"/>
+    <env name="CORES_SETUP" value="dedicated"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    <ini name="error_reporting" value="-1"/>
+    <env name="KERNEL_CLASS" value="Ibexa\Contracts\Solr\Test\IbexaSolrTestKernel"/>
+    <env name="SEARCH_ENGINE" value="solr"/>
+    <env name="DATABASE_URL" value="sqlite://:memory:"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+  </php>
+  <testsuites>
+    <!-- Search service is used all over the place, so we must run entire integration test suite -->
+    <testsuite name="integration_repository">
+      <directory>tests/integration/Core</directory>
+      <exclude>tests/integration/Core/Repository/Filtering</exclude>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -1,45 +1,36 @@
-<?xml version = '1.0' encoding = 'utf-8'?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="bootstrap.php"
-         processIsolation="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         colors="true"
-         >
-    <php>
-        <env name="setupFactory" value="\Ibexa\Contracts\Core\Test\Repository\SetupFactory\Legacy" />
-        <env name="backendVersion" value="5" />
-        <env name="fixtureDir" value="Legacy" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-        <ini name="error_reporting" value="-1" />
-        <env name="DATABASE_URL" value="sqlite://:memory:" />
-        <env name="KERNEL_CLASS" value="Ibexa\Contracts\Core\Test\IbexaTestKernel"/>
-        <env name="SEARCH_ENGINE" value="legacy"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-    </php>
-    <testsuites>
-        <testsuite name="integration_core">
-            <directory>tests/integration/Core</directory>
-        </testsuite>
-        <testsuite name="integration_debug">
-            <directory>tests/integration/Debug</directory>
-        </testsuite>
-        <testsuite name="integration_io">
-            <directory>tests/integration/IO</directory>
-        </testsuite>
-        <testsuite name="integration_legacy_search_engine">
-            <directory>tests/integration/LegacySearchEngine</directory>
-        </testsuite>
-        <testsuite name="integration_repository_installer">
-            <directory>tests/integration/RepositoryInstaller</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">tests/integration</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="bootstrap.php" processIsolation="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" beStrictAboutTestsThatDoNotTestAnything="false" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">tests/integration</directory>
+    </include>
+  </coverage>
+  <php>
+    <env name="setupFactory" value="\Ibexa\Contracts\Core\Test\Repository\SetupFactory\Legacy"/>
+    <env name="backendVersion" value="5"/>
+    <env name="fixtureDir" value="Legacy"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    <ini name="error_reporting" value="-1"/>
+    <env name="DATABASE_URL" value="sqlite://:memory:"/>
+    <env name="KERNEL_CLASS" value="Ibexa\Contracts\Core\Test\IbexaTestKernel"/>
+    <env name="SEARCH_ENGINE" value="legacy"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+  </php>
+  <testsuites>
+    <testsuite name="integration_core">
+      <directory>tests/integration/Core</directory>
+    </testsuite>
+    <testsuite name="integration_debug">
+      <directory>tests/integration/Debug</directory>
+    </testsuite>
+    <testsuite name="integration_io">
+      <directory>tests/integration/IO</directory>
+    </testsuite>
+    <testsuite name="integration_legacy_search_engine">
+      <directory>tests/integration/LegacySearchEngine</directory>
+    </testsuite>
+    <testsuite name="integration_repository_installer">
+      <directory>tests/integration/RepositoryInstaller</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:

On `main (5.0.x-dev)` we're getting PHPUnit configuration deprecation warning.

```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

Migrated PHPUnit configuration here to the new schema.