### PR TITLE
IBX-8957: Fixed deserializing SiteAccess Matchers for ESI

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46186,6 +46186,16 @@ parameters:
 			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
 
 		-
+			message: "#^Parameter \\#1 \\$siteAccessRouter of class Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListener constructor expects Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Router, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
+			count: 1
+			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$eventDispatcher of class Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListener constructor expects Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
+			count: 1
+			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
+
+		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\FieldType\\\\ImageAsset\\\\ParameterProviderTest\\:\\:dataProviderForTestGetViewParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/lib/MVC/Symfony/FieldType/ImageAsset/ParameterProviderTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11316,11 +11316,6 @@ parameters:
 			path: src/lib/MVC/RepositoryAwareInterface.php
 
 		-
-			message: "#^Cannot access offset 'config' on array\\|ArrayObject\\<\\(int\\|string\\), mixed\\>\\|bool\\|float\\|int\\|string\\|null\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\Component\\\\Serializer\\\\SimplifiedRequestNormalizer\\:\\:supportsNormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizer.php
@@ -11554,31 +11549,6 @@ parameters:
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\LanguageSwitchListener\\:\\:onRouteReferenceGeneration\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/MVC/Symfony/EventListener/LanguageSwitchListener.php
-
-		-
-			message: "#^Call to an undefined method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\:\\:setSubMatchers\\(\\)\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
-
-		-
-			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListener\\:\\:deserializeMatcher\\(\\) has parameter \\$serializedSubMatchers with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
-
-		-
-			message: "#^Parameter \\#1 \\$serializedGroups of method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListener\\:\\:buildGroups\\(\\) expects array\\<array\\{name\\: string\\}\\>, array\\<Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccessGroup\\> given\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
-
-		-
-			message: "#^Parameter \\#2 \\$haystack of function in_array expects array, array\\<string, class\\-string\\>\\|false given\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
-
-		-
-			message: "#^Parameter \\#2 \\$matcherFQCN of method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListener\\:\\:deserializeMatcher\\(\\) expects string, Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher given\\.$#"
-			count: 1
-			path: src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
 
 		-
 			message: "#^Method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\ExpressionLanguage\\\\TwigVariableProviderExtension\\:\\:hasParameterProvider\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
@@ -25191,11 +25161,6 @@ parameters:
 			path: tests/bundle/Core/Fragment/DecoratedFragmentRendererTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$innerRenderer of class Ibexa\\\\Bundle\\\\Core\\\\Fragment\\\\DecoratedFragmentRenderer constructor expects Symfony\\\\Component\\\\HttpKernel\\\\Fragment\\\\FragmentRendererInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
-			count: 5
-			path: tests/bundle/Core/Fragment/DecoratedFragmentRendererTest.php
-
-		-
 			message: "#^Binary operation \"\\.\" between 'rendered_' and \\(Closure\\(array\\<string, mixed\\>\\)\\: string\\)\\|string results in an error\\.$#"
 			count: 1
 			path: tests/bundle/Core/Fragment/DirectFragmentRendererTest.php
@@ -25238,11 +25203,6 @@ parameters:
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Core\\\\Fragment\\\\InlineFragmentRendererTest\\:\\:testRendererControllerReference\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: tests/bundle/Core/Fragment/InlineFragmentRendererTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$innerRenderer of class Ibexa\\\\Bundle\\\\Core\\\\Fragment\\\\InlineFragmentRenderer constructor expects Symfony\\\\Component\\\\HttpKernel\\\\Fragment\\\\FragmentRendererInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
-			count: 2
 			path: tests/bundle/Core/Fragment/InlineFragmentRendererTest.php
 
 		-
@@ -46156,46 +46116,6 @@ parameters:
 			path: tests/lib/MVC/Symfony/EventListener/LanguageSwitchListenerTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListenerTest\\:\\:testGetSubscribedEvents\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListenerTest\\:\\:testOnKernelRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListenerTest\\:\\:testOnKernelRequestSerializedSA\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListenerTest\\:\\:testOnKernelRequestSerializedSAWithCompoundMatcher\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListenerTest\\:\\:testOnKernelRequestSiteAccessPresent\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListenerTest\\:\\:testOnKernelRequestUserHashWithOriginalRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$siteAccessRouter of class Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListener constructor expects Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Router, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$eventDispatcher of class Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\EventListener\\\\SiteAccessMatchListener constructor expects Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\FieldType\\\\ImageAsset\\\\ParameterProviderTest\\:\\:dataProviderForTestGetViewParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/lib/MVC/Symfony/FieldType/ImageAsset/ParameterProviderTest.php
@@ -47889,36 +47809,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$matcherBuilder of method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\Compound\\:\\:setMatcherBuilder\\(\\) expects Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\MatcherBuilderInterface, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
 			count: 6
 			path: tests/lib/MVC/Symfony/SiteAccess/Compound/CompoundOrTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\MatcherSerializationTest\\:\\:getMapHostMatcherTestCase\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/SiteAccess/MatcherSerializationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\MatcherSerializationTest\\:\\:getMapPortMatcherTestCase\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/SiteAccess/MatcherSerializationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\MatcherSerializationTest\\:\\:getMapURIMatcherTestCase\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/SiteAccess/MatcherSerializationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\MatcherSerializationTest\\:\\:matcherProvider\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/SiteAccess/MatcherSerializationTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\MatcherSerializationTest\\:\\:testDeserialize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/lib/MVC/Symfony/SiteAccess/MatcherSerializationTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$subMatchers of method Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\Compound\\:\\:setSubMatchers\\(\\) expects array\\<Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\>, array\\<string, array\\<string, array\\<string, string\\>\\>\\> given\\.$#"
-			count: 4
-			path: tests/lib/MVC/Symfony/SiteAccess/MatcherSerializationTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Provider\\\\ChainSiteAccessProviderTest\\:\\:getExistingSiteProvider\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/src/bundle/Core/DependencyInjection/Compiler/FragmentPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/FragmentPass.php
@@ -9,6 +9,7 @@ namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
 use Ibexa\Bundle\Core\Fragment\DecoratedFragmentRenderer;
 use Ibexa\Bundle\Core\Fragment\FragmentListenerFactory;
 use Ibexa\Bundle\Core\Fragment\InlineFragmentRenderer;
+use Ibexa\Bundle\Core\Fragment\SiteAccessSerializerInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -47,7 +48,7 @@ class FragmentPass implements CompilerPassInterface
             $container->setDefinition($renamedId, $definition);
 
             $decoratedDef = new ChildDefinition(DecoratedFragmentRenderer::class);
-            $decoratedDef->setArguments([new Reference($renamedId)]);
+            $decoratedDef->setArguments([new Reference($renamedId), new Reference(SiteAccessSerializerInterface::class)]);
             $decoratedDef->setPublic($public);
             $decoratedDef->setTags($tags);
             // Special treatment for inline fragment renderer, to fit ESI renderer constructor type hinting (forced to InlineFragmentRenderer)

--- a/src/bundle/Core/Fragment/DecoratedFragmentRenderer.php
+++ b/src/bundle/Core/Fragment/DecoratedFragmentRenderer.php
@@ -15,17 +15,20 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccessAware
 {
-    use SiteAccessSerializationTrait;
-
     /** @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface */
     private $innerRenderer;
 
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteAccess;
 
-    public function __construct(FragmentRendererInterface $innerRenderer)
-    {
+    private SiteAccessSerializerInterface $siteAccessSerializer;
+
+    public function __construct(
+        FragmentRendererInterface $innerRenderer,
+        SiteAccessSerializerInterface $siteAccessSerializer
+    ) {
         $this->innerRenderer = $innerRenderer;
+        $this->siteAccessSerializer = $siteAccessSerializer;
     }
 
     /**
@@ -61,10 +64,10 @@ class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccess
     public function render($uri, Request $request, array $options = [])
     {
         if ($uri instanceof ControllerReference && $request->attributes->has('siteaccess')) {
-            // Serialize the siteaccess to get it back after.
+            // Serialize a SiteAccess to get it back after.
             // @see \Ibexa\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
             $siteAccess = $request->attributes->get('siteaccess');
-            $this->serializeSiteAccess($siteAccess, $uri);
+            $this->siteAccessSerializer->serializeSiteAccessAsControllerAttributes($siteAccess, $uri);
         }
 
         return $this->innerRenderer->render($uri, $request, $options);

--- a/src/bundle/Core/Fragment/InlineFragmentRenderer.php
+++ b/src/bundle/Core/Fragment/InlineFragmentRenderer.php
@@ -16,17 +16,20 @@ use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
 class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
 {
-    use SiteAccessSerializationTrait;
-
     /** @var \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface */
     private $innerRenderer;
 
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteAccess;
 
-    public function __construct(FragmentRendererInterface $innerRenderer)
-    {
+    private SiteAccessSerializerInterface $siteAccessSerializer;
+
+    public function __construct(
+        FragmentRendererInterface $innerRenderer,
+        SiteAccessSerializerInterface $siteAccessSerializer
+    ) {
         $this->innerRenderer = $innerRenderer;
+        $this->siteAccessSerializer = $siteAccessSerializer;
     }
 
     public function setFragmentPath($path)
@@ -47,7 +50,7 @@ class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware
             if ($request->attributes->has('siteaccess')) {
                 /** @var \Ibexa\Core\MVC\Symfony\SiteAccess $siteAccess */
                 $siteAccess = $request->attributes->get('siteaccess');
-                $this->serializeSiteAccess($siteAccess, $uri);
+                $this->siteAccessSerializer->serializeSiteAccessAsControllerAttributes($siteAccess, $uri);
             }
             if ($request->attributes->has('semanticPathinfo')) {
                 $uri->attributes['semanticPathinfo'] = $request->attributes->get('semanticPathinfo');

--- a/src/bundle/Core/Fragment/SiteAccessSerializer.php
+++ b/src/bundle/Core/Fragment/SiteAccessSerializer.php
@@ -8,24 +8,31 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\Fragment;
 
-use Ibexa\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
- * @deprecated Deprecated since 4.6. Inject an instance of {@see \Ibexa\Bundle\Core\Fragment\SiteAccessSerializerInterface}
- *  instead.
+ * @internal
  */
-trait SiteAccessSerializationTrait
+final class SiteAccessSerializer implements SiteAccessSerializerInterface
 {
-    use SerializerTrait;
+    private SerializerInterface $serializer;
 
-    public function serializeSiteAccess(SiteAccess $siteAccess, ControllerReference $uri): void
+    public function __construct(SerializerInterface $serializer)
     {
-        // Serialize the siteaccess to get it back after. @see \Ibexa\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
-        $uri->attributes['serialized_siteaccess'] = json_encode($siteAccess);
-        $uri->attributes['serialized_siteaccess_matcher'] = $this->getSerializer()->serialize(
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    public function serializeSiteAccessAsControllerAttributes(SiteAccess $siteAccess, ControllerReference $controller): void
+    {
+        // Serialize the SiteAccess to get it back after. @see \Ibexa\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
+        $controller->attributes['serialized_siteaccess'] = json_encode($siteAccess, JSON_THROW_ON_ERROR);
+        $controller->attributes['serialized_siteaccess_matcher'] = $this->serializer->serialize(
             $siteAccess->matcher,
             'json',
             [AbstractNormalizer::IGNORED_ATTRIBUTES => ['request', 'container', 'matcherBuilder', 'connection']]
@@ -33,7 +40,7 @@ trait SiteAccessSerializationTrait
         if ($siteAccess->matcher instanceof SiteAccess\Matcher\CompoundInterface) {
             $subMatchers = $siteAccess->matcher->getSubMatchers();
             foreach ($subMatchers as $subMatcher) {
-                $uri->attributes['serialized_siteaccess_sub_matchers'][get_class($subMatcher)] = $this->getSerializer()->serialize(
+                $controller->attributes['serialized_siteaccess_sub_matchers'][get_class($subMatcher)] = $this->serializer->serialize(
                     $subMatcher,
                     'json',
                     [AbstractNormalizer::IGNORED_ATTRIBUTES => ['request', 'container', 'matcherBuilder', 'connection']]
@@ -42,5 +49,3 @@ trait SiteAccessSerializationTrait
         }
     }
 }
-
-class_alias(SiteAccessSerializationTrait::class, 'eZ\Bundle\EzPublishCoreBundle\Fragment\SiteAccessSerializationTrait');

--- a/src/bundle/Core/Fragment/SiteAccessSerializerInterface.php
+++ b/src/bundle/Core/Fragment/SiteAccessSerializerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Core\Fragment;
+
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ * @internal
+ */
+interface SiteAccessSerializerInterface
+{
+    public function serializeSiteAccessAsControllerAttributes(SiteAccess $siteAccess, ControllerReference $controller): void;
+}

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -14,12 +14,64 @@ services:
         calls:
             - [setContext, ["@router.request_context"]]
 
+    ibexa.core.mvc.serializer:
+        class: Symfony\Component\Serializer\Serializer
+        arguments:
+            $normalizers:
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\MatcherDenormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\HostElementNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\MapNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\URITextNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\HostTextNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexURINormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexHostNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\URIElementNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\SimplifiedRequestNormalizer'
+                - '@ibexa.core.mvc.serializer.normalizer.json_serializable_normalizer'
+                - '@ibexa.core.mvc.serializer.normalizer.property_normalizer'
+            $encoders:
+                - '@ibexa.core.mvc.serializer.json_encoder'
+
+    ibexa.core.mvc.serializer.json_encoder:
+        class: Symfony\Component\Serializer\Encoder\JsonEncoder
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\MatcherDenormalizer:
+        arguments:
+            $registry: '@Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface'
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\HostElementNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\MapNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\URITextNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\HostTextNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexURINormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexHostNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\URIElementNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\SimplifiedRequestNormalizer: ~
+
+    ibexa.core.mvc.serializer.normalizer.json_serializable_normalizer:
+        class: Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer
+
+    ibexa.core.mvc.serializer.normalizer.property_normalizer:
+        class: Symfony\Component\Serializer\Normalizer\PropertyNormalizer
+
     ibexa.siteaccess_match_listener:
         class: Ibexa\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
         arguments:
             $siteAccessRouter: '@Ibexa\Core\MVC\Symfony\SiteAccess\Router'
             $eventDispatcher: '@event_dispatcher'
             $siteAccessMatcherRegistry: '@Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface'
+            $serializer: '@ibexa.core.mvc.serializer'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: routing/serializers.yml }
+
 parameters:
     ibexa.default_router.non_site_access_aware_routes: ['_assetic_', '_wdt', '_profiler', '_configurator_', 'ibexa.user_hash']
     # characters that may require encoding in the urlalias generator
@@ -14,63 +17,11 @@ services:
         calls:
             - [setContext, ["@router.request_context"]]
 
-    ibexa.core.mvc.serializer:
-        class: Symfony\Component\Serializer\Serializer
-        arguments:
-            $normalizers:
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\MatcherDenormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\HostElementNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\MapNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\URITextNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\HostTextNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexURINormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexHostNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\URIElementNormalizer'
-                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\SimplifiedRequestNormalizer'
-                - '@ibexa.core.mvc.serializer.normalizer.json_serializable_normalizer'
-                - '@ibexa.core.mvc.serializer.normalizer.property_normalizer'
-            $encoders:
-                - '@ibexa.core.mvc.serializer.json_encoder'
-
-    ibexa.core.mvc.serializer.json_encoder:
-        class: Symfony\Component\Serializer\Encoder\JsonEncoder
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\MatcherDenormalizer:
-        arguments:
-            $registry: '@Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface'
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\HostElementNormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\MapNormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\URITextNormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\HostTextNormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexURINormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexHostNormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexNormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\URIElementNormalizer: ~
-
-    Ibexa\Core\MVC\Symfony\Component\Serializer\SimplifiedRequestNormalizer: ~
-
-    ibexa.core.mvc.serializer.normalizer.json_serializable_normalizer:
-        class: Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer
-
-    ibexa.core.mvc.serializer.normalizer.property_normalizer:
-        class: Symfony\Component\Serializer\Normalizer\PropertyNormalizer
-
     ibexa.siteaccess_match_listener:
         class: Ibexa\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
         arguments:
             $siteAccessRouter: '@Ibexa\Core\MVC\Symfony\SiteAccess\Router'
             $eventDispatcher: '@event_dispatcher'
-            $siteAccessMatcherRegistry: '@Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface'
             $serializer: '@ibexa.core.mvc.serializer'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Core/Resources/config/routing/serializers.yml
+++ b/src/bundle/Core/Resources/config/routing/serializers.yml
@@ -21,6 +21,13 @@ services:
             $encoders:
                 - '@ibexa.core.mvc.serializer.json_encoder'
 
+    Ibexa\Bundle\Core\Fragment\SiteAccessSerializer:
+        arguments:
+            $serializer: '@ibexa.core.mvc.serializer'
+
+    Ibexa\Bundle\Core\Fragment\SiteAccessSerializerInterface:
+        alias: Ibexa\Bundle\Core\Fragment\SiteAccessSerializer
+
     ibexa.core.mvc.serializer.json_encoder:
         class: Symfony\Component\Serializer\Encoder\JsonEncoder
 

--- a/src/bundle/Core/Resources/config/routing/serializers.yml
+++ b/src/bundle/Core/Resources/config/routing/serializers.yml
@@ -1,0 +1,58 @@
+services:
+    ibexa.core.mvc.serializer:
+        class: Symfony\Component\Serializer\Serializer
+        arguments:
+            $normalizers:
+                - '@ibexa.core.mvc.serializer.normalizer.array_denormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\SiteAccessNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\MatcherDenormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\HostElementNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\MapNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\URITextNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\HostTextNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexURINormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexHostNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\RegexNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\URIElementNormalizer'
+                - '@Ibexa\Core\MVC\Symfony\Component\Serializer\SimplifiedRequestNormalizer'
+                - '@ibexa.core.mvc.serializer.normalizer.json_serializable_normalizer'
+                - '@ibexa.core.mvc.serializer.normalizer.property_normalizer'
+            $encoders:
+                - '@ibexa.core.mvc.serializer.json_encoder'
+
+    ibexa.core.mvc.serializer.json_encoder:
+        class: Symfony\Component\Serializer\Encoder\JsonEncoder
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\MatcherDenormalizer:
+        arguments:
+            $registry: '@Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface'
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\SiteAccessNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\HostElementNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\MapNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\URITextNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\HostTextNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexURINormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexHostNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\RegexNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\URIElementNormalizer: ~
+
+    Ibexa\Core\MVC\Symfony\Component\Serializer\SimplifiedRequestNormalizer: ~
+
+    ibexa.core.mvc.serializer.normalizer.json_serializable_normalizer:
+        class: Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer
+
+    ibexa.core.mvc.serializer.normalizer.property_normalizer:
+        class: Symfony\Component\Serializer\Normalizer\PropertyNormalizer
+
+    ibexa.core.mvc.serializer.normalizer.array_denormalizer:
+        class: Symfony\Component\Serializer\Normalizer\ArrayDenormalizer

--- a/src/lib/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
+++ b/src/lib/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
@@ -44,7 +44,7 @@ class CompoundMatcherNormalizer extends AbstractPropertyWhitelistNormalizer impl
 
     public function supportsDenormalization($data, string $type, string $format = null): bool
     {
-        return is_subclass_of($type, Matcher\Compound::class) || $type === Matcher\Compound::class;
+        return is_a($type, Matcher\Compound::class, true);
     }
 
     /**

--- a/src/lib/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
+++ b/src/lib/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
@@ -7,15 +7,25 @@
 namespace Ibexa\Core\MVC\Symfony\Component\Serializer;
 
 use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 
-class CompoundMatcherNormalizer extends AbstractPropertyWhitelistNormalizer
+class CompoundMatcherNormalizer extends AbstractPropertyWhitelistNormalizer implements DenormalizerAwareInterface
 {
+    use DenormalizerAwareTrait;
+
     /**
+     * @param \Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Compound $object
+     *
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     *
      * @see \Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Compound::__sleep.
      */
     public function normalize($object, string $format = null, array $context = [])
     {
         $data = parent::normalize($object, $format, $context);
+
+        /** @var array<string, mixed> $data */
         $data['config'] = [];
         $data['matchersMap'] = [];
 
@@ -34,7 +44,29 @@ class CompoundMatcherNormalizer extends AbstractPropertyWhitelistNormalizer
 
     public function supportsDenormalization($data, string $type, string $format = null): bool
     {
-        return $type === Matcher\Compound::class;
+        return is_subclass_of($type, Matcher\Compound::class) || $type === Matcher\Compound::class;
+    }
+
+    /**
+     * @phpstan-param class-string<\Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Compound> $type
+     *
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     */
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): object
+    {
+        $compoundMatcher = new $type([]);
+        $subMatchers = [];
+        foreach ($context['serialized_siteaccess_sub_matchers'] ?? [] as $matcherType => $subMatcher) {
+            $subMatchers[$matcherType] = $this->serializer->deserialize(
+                $subMatcher,
+                $matcherType,
+                $format ?? 'json',
+                $context
+            );
+        }
+        $compoundMatcher->setSubMatchers($subMatchers);
+
+        return $compoundMatcher;
     }
 }
 

--- a/src/lib/MVC/Symfony/Component/Serializer/MatcherDenormalizer.php
+++ b/src/lib/MVC/Symfony/Component/Serializer/MatcherDenormalizer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Ibexa\Core\MVC\Symfony\Component\Serializer;
+
+use Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class MatcherDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface, ContextAwareDenormalizerInterface
+{
+    private const MATCHER_NORMALIZER_ALREADY_WORKED = self::class . '_ALREADY_CALLED';
+
+    use DenormalizerAwareTrait;
+
+    private SiteAccessMatcherRegistryInterface $registry;
+
+    public function __construct(SiteAccessMatcherRegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): object
+    {
+        $matcher = $this->registry->getMatcher($type);
+
+        return $this->denormalizer->denormalize($data, $type, $format, $context + [
+            AbstractNormalizer::OBJECT_TO_POPULATE => $matcher,
+            self::MATCHER_NORMALIZER_ALREADY_WORKED => true,
+        ]);
+    }
+
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
+    {
+        if ($context[self::MATCHER_NORMALIZER_ALREADY_WORKED] ?? false) {
+            return false;
+        }
+
+        return $this->registry->hasMatcher($type);
+    }
+}

--- a/src/lib/MVC/Symfony/Component/Serializer/MatcherDenormalizer.php
+++ b/src/lib/MVC/Symfony/Component/Serializer/MatcherDenormalizer.php
@@ -1,15 +1,25 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
 namespace Ibexa\Core\MVC\Symfony\Component\Serializer;
 
 use Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
-class MatcherDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface, ContextAwareDenormalizerInterface
+/**
+ * @internal
+ */
+final class MatcherDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface, ContextAwareDenormalizerInterface
 {
     private const MATCHER_NORMALIZER_ALREADY_WORKED = self::class . '_ALREADY_CALLED';
 
@@ -22,6 +32,10 @@ class MatcherDenormalizer implements DenormalizerInterface, DenormalizerAwareInt
         $this->registry = $registry;
     }
 
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     */
     public function denormalize($data, string $type, ?string $format = null, array $context = []): object
     {
         $matcher = $this->registry->getMatcher($type);
@@ -38,6 +52,6 @@ class MatcherDenormalizer implements DenormalizerInterface, DenormalizerAwareInt
             return false;
         }
 
-        return $this->registry->hasMatcher($type);
+        return is_subclass_of($type, Matcher::class) && $this->registry->hasMatcher($type);
     }
 }

--- a/src/lib/MVC/Symfony/Component/Serializer/SiteAccessNormalizer.php
+++ b/src/lib/MVC/Symfony/Component/Serializer/SiteAccessNormalizer.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\Component\Serializer;
+
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccessGroup;
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+
+/**
+ * @internal
+ */
+final class SiteAccessNormalizer implements DenormalizerInterface, DenormalizerAwareInterface, NormalizerInterface, SerializerAwareInterface, ContextAwareDenormalizerInterface
+{
+    use DenormalizerAwareTrait;
+    use SerializerAwareTrait;
+
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): object
+    {
+        // BC for SiteAccess being serialized/normalized using json_encode via \Ibexa\Bundle\Core\Fragment\SiteAccessSerializer
+        $matcherType = $data['matcher']['type'] ?? $data['matcher'];
+        $matcherData = $data['matcher']['data'] ?? $context['serialized_siteaccess_matcher'];
+
+        return new SiteAccess(
+            $data['name'],
+            $data['matchingType'],
+            $data['matcher'] !== null
+                ? $this->serializer->deserialize(
+                    $matcherData,
+                    $matcherType,
+                    $format ?? 'json',
+                    $context
+                )
+                : null,
+            $data['provider'] ?? null,
+            $this->denormalizer->denormalize($data['groups'] ?? [], SiteAccessGroup::class . '[]', $format, $context)
+        );
+    }
+
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === SiteAccess::class;
+    }
+
+    public function supportsNormalization($data, ?string $format = null): bool
+    {
+        return $data instanceof SiteAccess;
+    }
+
+    /**
+     * @param \Ibexa\Core\MVC\Symfony\SiteAccess $object
+     *
+     * @return array{name: string, matchingType: string, matcher: array{type: class-string, data: string}|null, provider: string|null, groups: array<mixed>}
+     */
+    public function normalize($object, ?string $format = null, array $context = []): array
+    {
+        $matcherData = null;
+        if (is_object($object->matcher)) {
+            $matcherData = [
+                'type' => get_class($object->matcher),
+                'data' => $this->serializer->serialize($object->matcher, $format ?? 'json', $context),
+            ];
+        }
+
+        return [
+            'name' => $object->name,
+            'matchingType' => $object->matchingType,
+            'matcher' => $matcherData,
+            'provider' => $object->provider,
+            'groups' => $object->groups,
+        ];
+    }
+}

--- a/src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -6,22 +6,16 @@
  */
 namespace Ibexa\Core\MVC\Symfony\EventListener;
 
-// @todo Move SiteAccessMatcherRegistryInterface to \Ibexa\Core\MVC\Symfony\SiteAccess\Matcher
-use Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface;
-use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
-use Ibexa\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use Ibexa\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router as SiteAccessRouter;
-use Ibexa\Core\MVC\Symfony\SiteAccessGroup;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -30,32 +24,23 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class SiteAccessMatchListener implements EventSubscriberInterface
 {
-    use SerializerTrait;
+    protected SiteAccess\Router $siteAccessRouter;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\Router */
-    protected $siteAccessRouter;
-
-    /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
-    protected $eventDispatcher;
-
-    /** @var \Ibexa\Bundle\Core\SiteAccess\SiteAccessMatcherRegistryInterface */
-    private $siteAccessMatcherRegistry;
+    protected EventDispatcherInterface $eventDispatcher;
 
     private SerializerInterface $serializer;
 
     public function __construct(
         SiteAccessRouter $siteAccessRouter,
         EventDispatcherInterface $eventDispatcher,
-        SiteAccessMatcherRegistryInterface $siteAccessMatcherRegistry,
         SerializerInterface $serializer
     ) {
         $this->siteAccessRouter = $siteAccessRouter;
         $this->eventDispatcher = $eventDispatcher;
-        $this->siteAccessMatcherRegistry = $siteAccessMatcherRegistry;
         $this->serializer = $serializer;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // Should take place just after FragmentListener (priority 48) in order to get rebuilt request attributes in case of subrequest
@@ -75,18 +60,15 @@ class SiteAccessMatchListener implements EventSubscriberInterface
 
         // We have a serialized siteaccess object from a fragment (sub-request), we need to get it back.
         if ($request->attributes->has('serialized_siteaccess')) {
-            $serializer = $this->getSerializer();
             /** @var \Ibexa\Core\MVC\Symfony\SiteAccess $siteAccess */
-            $siteAccess = $serializer->deserialize($request->attributes->get('serialized_siteaccess'), SiteAccess::class, 'json');
-            if ($siteAccess->matcher !== null) {
-                $siteAccess->matcher = $this->deserializeMatcher(
-                    $siteAccess->matcher,
-                    $request->attributes->get('serialized_siteaccess_matcher'),
-                    $request->attributes->get('serialized_siteaccess_sub_matchers')
-                );
-            }
-            $siteAccess->groups = $this->buildGroups(
-                $siteAccess->groups
+            $siteAccess = $this->serializer->deserialize(
+                $request->attributes->get('serialized_siteaccess'),
+                SiteAccess::class,
+                'json',
+                [
+                    'serialized_siteaccess_matcher' => $request->attributes->get('serialized_siteaccess_matcher'),
+                    'serialized_siteaccess_sub_matchers' => $request->attributes->get('serialized_siteaccess_sub_matchers'),
+                ]
             );
             $request->attributes->set(
                 'siteaccess',
@@ -128,75 +110,6 @@ class SiteAccessMatchListener implements EventSubscriberInterface
                     'headers' => $request->headers->all(),
                 ]
             )
-        );
-    }
-
-    /**
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     */
-    private function deserializeMatcher(
-        string $matcherFQCN,
-        string $serializedMatcher,
-        ?array $serializedSubMatchers
-    ): SiteAccess\Matcher {
-        $matcher = null;
-        if (in_array(SiteAccess\Matcher::class, class_implements($matcherFQCN), true)) {
-            $matcher = $this->buildMatcherFromSerializedClass(
-                $matcherFQCN,
-                $serializedMatcher
-            );
-        } else {
-            throw new InvalidArgumentException(
-                'matcher',
-                sprintf(
-                    'SiteAccess matcher must implement %s or %s',
-                    SiteAccess\Matcher::class,
-                    SiteAccess\URILexer::class
-                )
-            );
-        }
-        if (!empty($serializedSubMatchers)) {
-            $subMatchers = [];
-            foreach ($serializedSubMatchers as $subMatcherFQCN => $serializedData) {
-                $subMatchers[$subMatcherFQCN] = $this->buildMatcherFromSerializedClass(
-                    $subMatcherFQCN,
-                    $serializedData
-                );
-            }
-            $matcher->setSubMatchers($subMatchers);
-        }
-
-        return $matcher;
-    }
-
-    /**
-     * @param array<array{'name': string}> $serializedGroups
-     *
-     * @return \Ibexa\Core\MVC\Symfony\SiteAccessGroup[]
-     */
-    private function buildGroups(
-        array $serializedGroups
-    ): array {
-        return array_map(
-            static function (array $serializedGroup): SiteAccessGroup {
-                return new SiteAccessGroup($serializedGroup['name']);
-            },
-            $serializedGroups
-        );
-    }
-
-    /**
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
-     */
-    private function buildMatcherFromSerializedClass(
-        string $matcherClass,
-        string $serializedMatcher
-    ): SiteAccess\Matcher {
-        return $this->serializer->deserialize(
-            $serializedMatcher,
-            $matcherClass,
-            'json',
         );
     }
 }

--- a/src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/src/lib/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -21,6 +21,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -193,9 +194,14 @@ class SiteAccessMatchListener implements EventSubscriberInterface
         string $matcherClass,
         string $serializedMatcher
     ): SiteAccess\Matcher {
-        $matcher = null;
         if ($this->siteAccessMatcherRegistry->hasMatcher($matcherClass)) {
             $matcher = $this->siteAccessMatcherRegistry->getMatcher($matcherClass);
+            $matcher = $serializer->deserialize(
+                $serializedMatcher,
+                $matcherClass,
+                'json',
+                [AbstractNormalizer::OBJECT_TO_POPULATE => $matcher]
+            );
         } else {
             $matcher = $serializer->deserialize(
                 $serializedMatcher,

--- a/tests/bundle/Core/DependencyInjection/Compiler/FragmentPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/FragmentPassTest.php
@@ -10,6 +10,7 @@ use Ibexa\Bundle\Core\DependencyInjection\Compiler\FragmentPass;
 use Ibexa\Bundle\Core\Fragment\DecoratedFragmentRenderer;
 use Ibexa\Bundle\Core\Fragment\FragmentListenerFactory;
 use Ibexa\Bundle\Core\Fragment\InlineFragmentRenderer;
+use Ibexa\Bundle\Core\Fragment\SiteAccessSerializerInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -65,7 +66,7 @@ class FragmentPassTest extends AbstractCompilerPassTestCase
         $decoratedInlineDef = $this->container->getDefinition('fragment.renderer.inline');
         $this->assertSame(['kernel.fragment_renderer' => [[]]], $decoratedInlineDef->getTags());
         $this->assertEquals(
-            [new Reference('fragment.renderer.inline.inner')],
+            [new Reference('fragment.renderer.inline.inner'), new Reference(SiteAccessSerializerInterface::class)],
             $decoratedInlineDef->getArguments()
         );
         $this->assertSame(InlineFragmentRenderer::class, $decoratedInlineDef->getClass());
@@ -74,7 +75,7 @@ class FragmentPassTest extends AbstractCompilerPassTestCase
         $decoratedEsiDef = $this->container->getDefinition('fragment.renderer.esi');
         $this->assertSame(['kernel.fragment_renderer' => [[]]], $decoratedEsiDef->getTags());
         $this->assertEquals(
-            [new Reference('fragment.renderer.esi.inner')],
+            [new Reference('fragment.renderer.esi.inner'), new Reference(SiteAccessSerializerInterface::class)],
             $decoratedEsiDef->getArguments()
         );
 
@@ -82,7 +83,7 @@ class FragmentPassTest extends AbstractCompilerPassTestCase
         $decoratedHincludeDef = $this->container->getDefinition('fragment.renderer.hinclude');
         $this->assertSame(['kernel.fragment_renderer' => [[]]], $decoratedHincludeDef->getTags());
         $this->assertEquals(
-            [new Reference('fragment.renderer.hinclude.inner')],
+            [new Reference('fragment.renderer.hinclude.inner'), new Reference(SiteAccessSerializerInterface::class)],
             $decoratedHincludeDef->getArguments()
         );
     }

--- a/tests/bundle/Core/Fragment/InlineFragmentRendererTest.php
+++ b/tests/bundle/Core/Fragment/InlineFragmentRendererTest.php
@@ -7,14 +7,21 @@
 namespace Ibexa\Tests\Bundle\Core\Fragment;
 
 use Ibexa\Bundle\Core\Fragment\InlineFragmentRenderer;
+use Ibexa\Bundle\Core\Fragment\SiteAccessSerializer;
+use Ibexa\Core\MVC\Symfony\Component\Serializer\SerializerTrait;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
+/**
+ * @covers \Ibexa\Bundle\Core\Fragment\InlineFragmentRenderer
+ */
 class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
 {
+    use SerializerTrait;
+
     public function testRendererControllerReference()
     {
         $reference = new ControllerReference('FooBundle:bar:baz');
@@ -36,7 +43,7 @@ class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
             ->with($reference, $request, $options)
             ->will($this->returnValue($expectedReturn));
 
-        $renderer = new InlineFragmentRenderer($this->innerRenderer);
+        $renderer = $this->getRenderer();
         $this->assertSame($expectedReturn, $renderer->render($reference, $request, $options));
         $this->assertTrue(isset($reference->attributes['serialized_siteaccess']));
         $serializedSiteAccess = json_encode($siteAccess);
@@ -80,7 +87,7 @@ class InlineFragmentRendererTest extends DecoratedFragmentRendererTest
 
     public function getRenderer(): FragmentRendererInterface
     {
-        return new InlineFragmentRenderer($this->innerRenderer);
+        return new InlineFragmentRenderer($this->innerRenderer, new SiteAccessSerializer($this->getSerializer()));
     }
 }
 

--- a/tests/bundle/Core/Fragment/SiteAccessSerializerTest.php
+++ b/tests/bundle/Core/Fragment/SiteAccessSerializerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Tests\Bundle\Core\Fragment;
+
+use Ibexa\Bundle\Core\Fragment\SiteAccessSerializer;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Tests\Core\MVC\Symfony\Component\Serializer\Stubs\CompoundStub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @covers \Ibexa\Bundle\Core\Fragment\SiteAccessSerializer
+ */
+final class SiteAccessSerializerTest extends TestCase
+{
+    /**
+     * @dataProvider getDataForTestSerializeSiteAccessAsControllerAttributes
+     *
+     * @throws \JsonException
+     */
+    public function testSerializeSiteAccessAsControllerAttributes(SiteAccess $siteAccess): void
+    {
+        $serializerMock = $this->createMock(SerializerInterface::class);
+        $siteAccessSerializer = new SiteAccessSerializer($serializerMock);
+
+        $controllerReference = new ControllerReference('foo');
+
+        $serializerMock->method('serialize')
+                       ->with(
+                           self::isInstanceOf(SiteAccess\Matcher::class),
+                           'json',
+                           self::isType('array')
+                       )->willReturn('{"foo":"bar"}')
+        ;
+
+        $siteAccessSerializer->serializeSiteAccessAsControllerAttributes($siteAccess, $controllerReference);
+
+        self::assertJson($controllerReference->attributes['serialized_siteaccess']);
+
+        // this just tests internal flow instead of actual serializer, covered elsewhere. Hence, comparing to mocked values
+        self::assertSame('{"foo":"bar"}', $controllerReference->attributes['serialized_siteaccess_matcher']);
+        if ($siteAccess->matcher instanceof SiteAccess\Matcher\CompoundInterface) {
+            foreach ($siteAccess->matcher->getSubMatchers() as $subMatcher) {
+                self::assertJson(
+                    $controllerReference->attributes['serialized_siteaccess_sub_matchers'][get_class($subMatcher)]
+                );
+            }
+        }
+    }
+
+    /**
+     * @return iterable<string, array{\Ibexa\Core\MVC\Symfony\SiteAccess}>
+     */
+    public static function getDataForTestSerializeSiteAccessAsControllerAttributes(): iterable
+    {
+        yield 'SiteAccess with simple matcher' => [
+            new SiteAccess('foo', SiteAccess::DEFAULT_MATCHING_TYPE, new SiteAccess\Matcher\URIElement(1)),
+        ];
+
+        yield 'SiteAccess with compound matcher' => [
+            new SiteAccess(
+                'foo',
+                SiteAccess::DEFAULT_MATCHING_TYPE,
+                new CompoundStub(
+                    [
+                        new SiteAccess\Matcher\HostElement(2),
+                        new SiteAccess\Matcher\URIElement(2),
+                    ]
+                )
+            ),
+        ];
+    }
+}

--- a/tests/lib/MVC/Symfony/EventListener/CustomMatcher.php
+++ b/tests/lib/MVC/Symfony/EventListener/CustomMatcher.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Tests\Core\MVC\Symfony\EventListener;
 
 use Ibexa\Bundle\Core\SiteAccess\Matcher;
@@ -13,5 +15,6 @@ class CustomMatcher extends URI implements Matcher
 {
     public function setMatchingConfiguration($matchingConfiguration): void
     {
+        // nothing to do
     }
 }

--- a/tests/lib/MVC/Symfony/EventListener/CustomMatcher.php
+++ b/tests/lib/MVC/Symfony/EventListener/CustomMatcher.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Tests\Core\MVC\Symfony\EventListener;
+
+use Ibexa\Bundle\Core\SiteAccess\Matcher;
+use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Map\URI;
+
+class CustomMatcher extends URI implements Matcher
+{
+    public function setMatchingConfiguration($matchingConfiguration): void
+    {
+    }
+}

--- a/tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
+++ b/tests/lib/MVC/Symfony/EventListener/SiteAccessMatchListenerTest.php
@@ -158,21 +158,21 @@ final class SiteAccessMatchListenerTest extends TestCase
      */
     public function testOnKernelRequestSerializedSAWithMatcherInMatcherRegistry(): void
     {
-        $matcher = new CustomMatcher([]);
+        $matcher = new TestMatcher([]);
 
-        $matcher2 = new CustomMatcher([]);
+        $matcher2 = new TestMatcher([]);
         $matcher2->setMapKey('key_foobar');
 
         $this->registry
             ->expects(self::once())
             ->method('hasMatcher')
-            ->with(CustomMatcher::class)
+            ->with(TestMatcher::class)
             ->willReturn(true);
 
         $this->registry
             ->expects(self::once())
             ->method('getMatcher')
-            ->with(CustomMatcher::class)
+            ->with(TestMatcher::class)
             ->willReturn($matcher);
 
         $siteAccess = $this->createSiteAccess(
@@ -182,7 +182,7 @@ final class SiteAccessMatchListenerTest extends TestCase
         );
 
         $request = $this->createAndDispatchRequest($siteAccess);
-        /** @var \Ibexa\Tests\Core\MVC\Symfony\EventListener\CustomMatcher $siteAccessMatcher */
+        /** @var \Ibexa\Tests\Core\MVC\Symfony\EventListener\TestMatcher $siteAccessMatcher */
         $siteAccessMatcher = $siteAccess->matcher;
         self::assertEquals('key_foobar', $siteAccessMatcher->getMapKey());
         self::assertFalse($request->attributes->has('serialized_siteaccess'));

--- a/tests/lib/MVC/Symfony/EventListener/TestMatcher.php
+++ b/tests/lib/MVC/Symfony/EventListener/TestMatcher.php
@@ -11,7 +11,7 @@ namespace Ibexa\Tests\Core\MVC\Symfony\EventListener;
 use Ibexa\Bundle\Core\SiteAccess\Matcher;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Map\URI;
 
-class CustomMatcher extends URI implements Matcher
+class TestMatcher extends URI implements Matcher
 {
     public function setMatchingConfiguration($matchingConfiguration): void
     {


### PR DESCRIPTION
| :ticket: Issue | IBX-8957 |
|----------------|-----------|

#### Description:
When unserializing SiteaccessMatcher in ESI, custom matchers was only fetch from registry. Serialized configuration of the matcher was not restored.

In case of [sitefactoy's SiteAccessMatcher](https://github.com/ibexa/site-factory/blob/main/src/lib/SiteAccessMatcher.php#L18), it meant that [mapKey](https://github.com/ibexa/core/blob/main/src/lib/MVC/Symfony/SiteAccess/Matcher/Map.php#L20) was never restored, causing incorrect links to be generated.
(Map is an ancestor of SiteAccessMatcher)

---
<ins>_Maintainer update_:</ins> this issue uncovered a few other underlying issues. We were using traits in production code to configure serializers. Instead I've (@alongosz) changed it to configured `ibexa.core.mvc.serializer` service.

Moreover the same mirrored code was used to serialize and deserialize data and store them into 3 separate request attributes. While the latter case needs to be tackled separately via IBX-9102, I've made the code uniformly use the same serializer for both serialization and deserialization of data. The `SerializerTrait` is left only for unit test purposes.

I've introduced  `...\Fragment\SiteAccessSerializer` service to wrap what `SiteAccessSerializationTrait` was doing for production code.

The end goal is to have serialization/deserialization handled by configured Symfony serializers entirely. The question now is if we should move parts of the scope resolved here to IBX-9102, or should we keep this and only improve in IBX-9102?

---

#### For QA:
See ticket for instructions on how to reproduce.

<ins>_Maintainer update_:</ins> sanities on SiteAccess matchers, including compound matchers are needed.

Regression run: :green_circle:   https://github.com/ibexa/commerce/pull/1081
Matchers tests: :green_circle: https://github.com/ibexa/experience/pull/500

#### Documentation:
