### PR TITLE
Fixed issues found by by PHPStan

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -16,11 +16,6 @@ parameters:
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\|iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/CleanupVersionsCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php

--- a/phpstan-baseline-gte-8.0.neon
+++ b/phpstan-baseline-gte-8.0.neon
@@ -16,11 +16,6 @@ parameters:
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
-			count: 1
-			path: src/bundle/Core/Command/CleanupVersionsCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
 			count: 1
 			path: src/bundle/Core/Command/CleanupVersionsCommand.php

--- a/src/bundle/Core/Features/Context/BasicContentContext.php
+++ b/src/bundle/Core/Features/Context/BasicContentContext.php
@@ -41,7 +41,7 @@ class BasicContentContext implements Context
         ContentTypeService $contentTypeService,
         ContentService $contentService
     ) {
-        $this->$repository = $repository;
+        $this->repository = $repository;
         $this->contentTypeService = $contentTypeService;
         $this->contentService = $contentService;
     }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

This PR resolves 2 issues which surfaced after PHPStan release.

1. Issue no longer exists:
```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/bundle/Core/Command/CleanupVersionsCommand.php                                                                                                                         
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Ignored error pattern #^Parameter \#1 \$var of function count expects array\|Countable, array\|iterable<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\VersionInfo>  
         given\.$# in path /home/andrew/Product/packages/ibexa/core/src/bundle/Core/Command/CleanupVersionsCommand.php was not matched in reported errors.                          
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```


2. Fixed incorrect property assignment in Behat Context class (most likely not used as it should cause a fatal error otherwise)
```
 ------ ----------------------------------------------------------------------------------------------------------- 
  Line   src/bundle/Core/Features/Context/BasicContentContext.php                                                   
 ------ ----------------------------------------------------------------------------------------------------------- 
  37     Property Ibexa\Bundle\Core\Features\Context\BasicContentContext::$repository is never written, only read.  
         💡 See: https://phpstan.org/developing-extensions/always-read-written-properties                            
 ------ ----------------------------------------------------------------------------------------------------------- 
```