### PR TITLE
[PHPDoc] Prefixed template mentioning annotation with phpstan-

### DIFF
--- a/src/contracts/Pool/Pool.php
+++ b/src/contracts/Pool/Pool.php
@@ -20,7 +20,7 @@ final class Pool implements PoolInterface
 
     private string $class;
 
-    /** @var iterable<string,T> */
+    /** @phpstan-var iterable<string,T> */
     private iterable $entries;
 
     private string $exceptionArgumentName = '$alias';
@@ -28,7 +28,7 @@ final class Pool implements PoolInterface
     private string $exceptionMessageTemplate = self::DEFAULT_EXCEPTION_MESSAGE_TEMPLATE;
 
     /**
-     * @param iterable<string,T> $entries
+     * @phpstan-param iterable<string,T> $entries
      */
     public function __construct(string $class, iterable $entries = [])
     {
@@ -44,7 +44,7 @@ final class Pool implements PoolInterface
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      *
-     * @return T
+     * @phpstan-return T
      */
     public function get(string $alias)
     {
@@ -64,7 +64,7 @@ final class Pool implements PoolInterface
     }
 
     /**
-     * @return T|null
+     * @phpstan-return T|null
      */
     private function findEntry(string $needle)
     {
@@ -78,7 +78,7 @@ final class Pool implements PoolInterface
     }
 
     /**
-     * @return iterable<string,T>
+     * @phpstan-return iterable<string,T>
      */
     public function getEntries(): iterable
     {

--- a/src/contracts/Pool/PoolInterface.php
+++ b/src/contracts/Pool/PoolInterface.php
@@ -18,12 +18,12 @@ interface PoolInterface
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      *
-     * @return T
+     * @phpstan-return T
      */
     public function get(string $alias);
 
     /**
-     * @return iterable<string,T>
+     * @phpstan-return iterable<string,T>
      */
     public function getEntries(): iterable;
 


### PR DESCRIPTION
| :ticket: Issue | In/a |
|----------------|-----------|

While working on https://github.com/ibexa/documentation-developer/pull/2512 we've noticed that some of the template-mentioning annotations make their way into the PHP doc.

https://ez-systems-developer-documentation--2512.com.readthedocs.build/en/2512/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Pool-Pool.html

The PHP reference does not have a clear way of showing the template annotations - they look like a missing class, so it's best to mark them as PHPStan specific and hide them from the reference.

#### For QA:
Not needed

#### Documentation:
Not needed
