### PR TITLE
[Composer] Dropped ibexa/ci-scripts from dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
     "require-dev": {
         "behat/behat": "^3.6.1",
         "friends-of-behat/mink-extension": "^2.4",
-        "ibexa/ci-scripts": "^0.2@dev",
         "ibexa/code-style": "~2.0.0",
         "jenner/simple_fork": "^1.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",


### PR DESCRIPTION
| :ticket: Issue | IBX-8470 |
|----------------|----------|


#### Description:

This PR drops dev requirement on ibexa/ci-scripts introduced via ezsystems/ezplatform-kernel#173.
The idea there was to run regressions from any of the packages, therefore it was added there in core as a test.

After talking to @mnocon it seemed that this was not utilized in the end in favor of standalone CLI tool approach. 

This dependency affects Symfony 6 upgrade as ci-scripts are a standalone Symfony console app and is used as so, instead of as a dependency. Meaning otherwise I'd have to upgrade that app first, which is a project on its own (probably not too complicated tho).

#### For QA:

This does not affect regressions as this is dev dependency. If CI passes, it's enough.