### PR TITLE
IBX-9103: Fixed cache tag name not including relation type

### DIFF
--- a/src/lib/Persistence/Cache/ContentHandler.php
+++ b/src/lib/Persistence/Cache/ContentHandler.php
@@ -620,18 +620,18 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
         $cacheItem = $this->cache->getItem(
             $this->cacheIdentifierGenerator->generateKey(
                 self::CONTENT_REVERSE_RELATIONS_COUNT_IDENTIFIER,
-                [$destinationContentId],
+                [$destinationContentId, $type],
                 true
             )
         );
 
         if ($cacheItem->isHit()) {
-            $this->logger->logCacheHit(['content' => $destinationContentId]);
+            $this->logger->logCacheHit(['content' => $destinationContentId, 'type' => $type]);
 
             return $cacheItem->get();
         }
 
-        $this->logger->logCacheMiss(['content' => $destinationContentId]);
+        $this->logger->logCacheMiss(['content' => $destinationContentId, 'type' => $type]);
         $reverseRelationsCount = $this->persistenceHandler->contentHandler()->countReverseRelations($destinationContentId, $type);
         $cacheItem->set($reverseRelationsCount);
         $tags = [

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -121,7 +121,7 @@ parameters:
         content_locations: 'cl-%s'
         content_relations_count_with_by_version_type_suffix: 'crc-%%s-v-%%s-t-%%s'
         content_relations_list_with_by_version_type_suffix: 'crl-%%s-l-%%s-o-%%s-v-%%s-t-%%s'
-        content_reverse_relations_count: 'crrc-%s'
+        content_reverse_relations_count: 'crrc-%%s-t-%%s'
         content_version_info: 'cvi-%s'
         content_version_list: 'c-%s-vl'
         content_version: 'c-%%s-v-%%s'

--- a/tests/lib/Persistence/Cache/ContentHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentHandlerTest.php
@@ -93,7 +93,8 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
 
         // string $method, array $arguments, string $key, array? $tagGeneratingArguments, array? $tagGeneratingResults, array? $keyGeneratingArguments, array? $keyGeneratingResults, mixed? $data, bool $multi = false, array $additionalCalls
         return [
-            ['countReverseRelations', [2], 'ibx-crrc-2', null, null, [['content_reverse_relations_count', [2], true]], ['ibx-crrc-2'], 10],
+            ['countReverseRelations', [2, null], 'ibx-crrc-2-t-', null, null, [['content_reverse_relations_count', [2, null], true]], ['ibx-crrc-2-t-'], 10],
+            ['countReverseRelations', [2, 8], 'ibx-crrc-2-t-8', null, null, [['content_reverse_relations_count', [2, 8], true]], ['ibx-crrc-2-t-8'], 10],
             ['countRelations', [2], 'ibx-crc-2-v--t-', null, null, [['content_relations_count_with_by_version_type_suffix', [2, null, null], true]], ['ibx-crc-2-v--t-'], 10],
             ['countRelations', [2, 2], 'ibx-crc-2-v-2-t-', null, null, [['content_relations_count_with_by_version_type_suffix', [2, 2, null], true]], ['ibx-crc-2-v-2-t-'], 10],
             ['countRelations', [2, null, 1], 'ibx-crc-2-v--t-1', null, null, [['content_relations_count_with_by_version_type_suffix', [2, null, 1], true]], ['ibx-crc-2-v--t-1'], 10],
@@ -136,15 +137,29 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             [
                 'countReverseRelations',
                 [2],
-                'ibx-crrc-2',
+                'ibx-crrc-2-t-',
                 [
                     ['content', [2], false],
                 ],
                 ['c-2'],
                 [
-                    ['content_reverse_relations_count', [2], true],
+                    ['content_reverse_relations_count', [2, null], true],
                 ],
-                ['ibx-crrc-2'],
+                ['ibx-crrc-2-t-'],
+                10,
+            ],
+            [
+                'countReverseRelations',
+                [2, 8],
+                'ibx-crrc-2-t-8',
+                [
+                    ['content', [2], false],
+                ],
+                ['c-2'],
+                [
+                    ['content_reverse_relations_count', [2, 8], true],
+                ],
+                ['ibx-crrc-2-t-8'],
                 10,
             ],
             [


### PR DESCRIPTION
| :ticket: Issue | IBX-9103 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
During work on extending relation methods it turned out that cache tag is not including relation type - as a result, reverse count always returned value for all relations

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
