### PR TITLE
IBX-8418: Remove draft when trashing or deleting its parent or ancestor location

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19011,11 +19011,6 @@ parameters:
 			path: src/lib/Persistence/Legacy/User/Mapper.php
 
 		-
-			message: "#^array\\|string does not accept array\\<int, mixed\\>\\.$#"
-			count: 1
-			path: src/lib/Persistence/Legacy/User/Mapper.php
-
-		-
 			message: "#^Method Ibexa\\\\Core\\\\Persistence\\\\Legacy\\\\User\\\\Role\\\\Gateway\\:\\:addPolicyLimitations\\(\\) has parameter \\$limitations with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Persistence/Legacy/User/Role/Gateway.php
@@ -27091,13 +27086,13 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
-			count: 12
+			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			count: 7
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 7
+			message: "#^Cannot access offset 0 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
+			count: 12
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
@@ -27106,13 +27101,13 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset 1 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
-			count: 4
+			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			count: 2
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset 1 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
-			count: 2
+			message: "#^Cannot access offset 1 on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\.$#"
+			count: 4
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
@@ -27141,12 +27136,12 @@ parameters:
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset mixed on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\>\\.$#"
+			message: "#^Cannot access offset int on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
-			message: "#^Cannot access offset int on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>\\.$#"
+			message: "#^Cannot access offset mixed on iterable\\<int, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\ContentInfo\\>\\.$#"
 			count: 1
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 

--- a/src/contracts/Persistence/Content/Location/Handler.php
+++ b/src/contracts/Persistence/Content/Location/Handler.php
@@ -216,6 +216,11 @@ interface Handler
     public function removeSubtree($locationId);
 
     /**
+     * Removes all draft contents that have no location assigned to them under the given parent location.
+     */
+    public function deleteChildrenDrafts(int $locationId): void;
+
+    /**
      * Set section on all content objects in the subtree.
      * Only main locations will be updated.
      *

--- a/src/contracts/Test/IbexaKernelTestTrait.php
+++ b/src/contracts/Test/IbexaKernelTestTrait.php
@@ -19,6 +19,7 @@ use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\RoleService;
 use Ibexa\Contracts\Core\Repository\SearchService;
 use Ibexa\Contracts\Core\Repository\SectionService;
+use Ibexa\Contracts\Core\Repository\TrashService;
 use Ibexa\Contracts\Core\Repository\URLAliasService;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\Core\Test\Persistence\Fixture\FixtureImporter;
@@ -167,6 +168,11 @@ trait IbexaKernelTestTrait
     protected static function getUrlAliasService(): URLAliasService
     {
         return self::getServiceByClassName(URLAliasService::class);
+    }
+
+    protected static function getTrashService(): TrashService
+    {
+        return self::getServiceByClassName(TrashService::class);
     }
 
     protected static function setAnonymousUser(): void

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -92,6 +92,7 @@ class IbexaTestKernel extends Kernel implements IbexaTestKernelInterface
         Repository\TokenService::class,
         Repository\URLAliasService::class,
         Repository\BookmarkService::class,
+        Repository\TrashService::class,
         Handler::class,
     ];
 

--- a/src/lib/Persistence/Cache/LocationHandler.php
+++ b/src/lib/Persistence/Cache/LocationHandler.php
@@ -415,6 +415,20 @@ class LocationHandler extends AbstractInMemoryPersistenceHandler implements Loca
         return $return;
     }
 
+    public function deleteChildrenDrafts(int $locationId): void
+    {
+        $this->logger->logCall(__METHOD__, ['location' => $locationId]);
+
+        $this->persistenceHandler->locationHandler()->deleteChildrenDrafts($locationId);
+
+        $this->cache->invalidateTags([
+            $this->cacheIdentifierGenerator->generateTag(
+                self::LOCATION_PATH_IDENTIFIER,
+                [$locationId],
+            ),
+        ]);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/lib/Persistence/Legacy/Content/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Handler.php
@@ -650,6 +650,7 @@ class Handler implements BaseContentHandler
             $this->removeRawContent($contentId);
         } else {
             foreach ($contentLocations as $locationId) {
+                $this->treeHandler->deleteChildrenDrafts($locationId);
                 $this->treeHandler->removeSubtree($locationId);
             }
         }

--- a/src/lib/Persistence/Legacy/Content/Location/Gateway.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Gateway.php
@@ -111,6 +111,13 @@ abstract class Gateway
      */
     abstract public function getSubtreeContent(int $sourceId, bool $onlyIds = false): array;
 
+    /**
+     * Finds draft contents created under the given parent location.
+     *
+     * @return array<int>
+     */
+    abstract public function getSubtreeChildrenDraftContentIds(int $sourceId): array;
+
     abstract public function getSubtreeSize(string $path): int;
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Result;
 use Ibexa\Contracts\Core\Persistence\Content\ContentInfo;
 use Ibexa\Contracts\Core\Persistence\Content\Location;
 use Ibexa\Contracts\Core\Persistence\Content\Location\CreateStruct;

--- a/src/lib/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -106,6 +106,18 @@ final class ExceptionConversion extends Gateway
         }
     }
 
+    /**
+     * @return array<int>
+     */
+    public function getSubtreeChildrenDraftContentIds(int $sourceId): array
+    {
+        try {
+            return $this->innerGateway->getSubtreeChildrenDraftContentIds($sourceId);
+        } catch (PDOException $e) {
+            throw DatabaseException::wrap($e);
+        }
+    }
+
     public function getSubtreeSize(string $path): int
     {
         try {

--- a/src/lib/Persistence/Legacy/Content/Location/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Handler.php
@@ -546,6 +546,11 @@ class Handler implements BaseLocationHandler
         $this->treeHandler->removeSubtree($locationId);
     }
 
+    public function deleteChildrenDrafts(int $locationId): void
+    {
+        $this->treeHandler->deleteChildrenDrafts($locationId);
+    }
+
     /**
      * Set section on all content objects in the subtree.
      *

--- a/src/lib/Persistence/Legacy/Content/TreeHandler.php
+++ b/src/lib/Persistence/Legacy/Content/TreeHandler.php
@@ -216,6 +216,26 @@ class TreeHandler
     }
 
     /**
+     * Removes draft contents assigned to the given parent location and its descendant locations.
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     */
+    public function deleteChildrenDrafts(int $locationId): void
+    {
+        $subLocations = $this->locationGateway->getChildren($locationId);
+        foreach ($subLocations as $subLocation) {
+            $this->deleteChildrenDrafts($subLocation['node_id']);
+        }
+
+        // Fetch child draft content ids
+        $subtreeChildrenDraftIds = $this->locationGateway->getSubtreeChildrenDraftContentIds($locationId);
+
+        foreach ($subtreeChildrenDraftIds as $contentId) {
+            $this->removeRawContent($contentId);
+        }
+    }
+
+    /**
      * Set section on all content objects in the subtree.
      *
      * @param mixed $locationId

--- a/src/lib/Repository/TrashService.php
+++ b/src/lib/Repository/TrashService.php
@@ -146,6 +146,7 @@ class TrashService implements TrashServiceInterface
 
         $this->repository->beginTransaction();
         try {
+            $this->persistenceHandler->locationHandler()->deleteChildrenDrafts($location->id);
             $spiTrashItem = $this->persistenceHandler->trashHandler()->trashSubtree($location->id);
             $this->persistenceHandler->urlAliasHandler()->locationDeleted($location->id);
             $this->repository->commit();

--- a/tests/integration/Core/Repository/ContentService/DeleteContentTest.php
+++ b/tests/integration/Core/Repository/ContentService/DeleteContentTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Integration\Core\Repository\ContentService;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Tests\Integration\Core\RepositoryTestCase;
 use PHPUnit\Framework\Assert;
 

--- a/tests/integration/Core/Repository/ContentService/DeleteContentTest.php
+++ b/tests/integration/Core/Repository/ContentService/DeleteContentTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\ContentService;
+
+use Ibexa\Tests\Integration\Core\RepositoryTestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @covers \Ibexa\Contracts\Core\Repository\ContentService
+ */
+final class DeleteContentTest extends RepositoryTestCase
+{
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\Exception
+     */
+    public function testDeleteContentDeletesChildrenDrafts(): void
+    {
+        $contentService = self::getContentService();
+
+        [$folder, $draft1, $draft2, $draft3, $draftSecondDepth] = $this->prepareContentStructure();
+
+        $contentService->deleteContent($folder->getContentInfo());
+
+        $contentInfos = $contentService->loadContentInfoList([
+            $draft1->getId(),
+            $draft2->getId(),
+            $draft3->getId(),
+            $draftSecondDepth->getId(),
+        ]);
+
+        self::assertEmpty($contentInfos);
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\Exception
+     */
+    public function testTrashLocationDeletesChildrenDrafts(): void
+    {
+        $trashService = self::getTrashService();
+        $contentService = self::getContentService();
+
+        [$folder, $draft1, $draft2, $draft3, $draftSecondDepth] = $this->prepareContentStructure();
+
+        $folderMainLocationId = $folder->getVersionInfo()->getContentInfo()->getMainLocationId();
+        Assert::assertIsNumeric($folderMainLocationId);
+
+        $locationToTrash = self::getLocationService()->loadLocation($folderMainLocationId);
+
+        $trashService->trash($locationToTrash);
+
+        $contentInfos = $contentService->loadContentInfoList([
+            $draft1->getId(),
+            $draft2->getId(),
+            $draft3->getId(),
+            $draftSecondDepth->getId(),
+        ]);
+
+        self::assertEmpty($contentInfos);
+    }
+
+    /**
+     * @return array<Content>
+     */
+    private function prepareContentStructure(): array
+    {
+        $folder = $this->createFolder(['eng-GB' => 'Folder'], 2);
+        $folderMainLocationId = $folder->getVersionInfo()->getContentInfo()->getMainLocationId();
+        Assert::assertIsNumeric($folderMainLocationId);
+
+        $childFolder = $this->createFolder(
+            ['eng-GB' => 'Child folder'],
+            $folderMainLocationId,
+        );
+        $childFolderMainLocationId = $childFolder->getVersionInfo()->getContentInfo()->getMainLocationId();
+        Assert::assertIsNumeric($childFolderMainLocationId);
+
+        $secondDepthChildFolder = $this->createFolder(
+            ['eng-GB' => 'Second depth folder'],
+            $childFolderMainLocationId,
+        );
+        $secondDepthChildFolderLocationId = $secondDepthChildFolder
+            ->getVersionInfo()
+            ->getContentInfo()
+            ->getMainLocationId()
+        ;
+        Assert::assertIsNumeric($secondDepthChildFolderLocationId);
+
+        $draft1 = $this->createFolderDraft(['eng-GB' => 'Folder draft 1'], $folderMainLocationId);
+        $draft2 = $this->createFolderDraft(['eng-GB' => 'Folder draft 2'], $childFolderMainLocationId);
+        $draft3 = $this->createFolderDraft(['eng-GB' => 'Folder draft 3'], $childFolderMainLocationId);
+        $draftSecondDepth = $this->createFolderDraft(
+            ['eng-GB' => 'Folder draft 4'],
+            $secondDepthChildFolderLocationId,
+        );
+
+        return [
+            $folder,
+            $draft1,
+            $draft2,
+            $draft3,
+            $draftSecondDepth,
+        ];
+    }
+}

--- a/tests/lib/Persistence/Cache/LocationHandlerTest.php
+++ b/tests/lib/Persistence/Cache/LocationHandlerTest.php
@@ -67,6 +67,7 @@ class LocationHandlerTest extends AbstractInMemoryCacheHandlerTest
                 ['c-4', 'ragl-4'],
             ],
             ['removeSubtree', [12], [['location_path', [12], false]], null, ['lp-12']],
+            ['deleteChildrenDrafts', [12], [['location_path', [12], false]], null, ['lp-12']],
             ['setSectionForSubtree', [12, 2], [['location_path', [12], false]], null, ['lp-12']],
             ['changeMainLocation', [4, 12], [['content', [4], false]], null, ['c-4']],
             ['countLocationsByContent', [4]],

--- a/tests/lib/Persistence/Legacy/Content/LocationHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/LocationHandlerTest.php
@@ -453,6 +453,18 @@ class LocationHandlerTest extends TestCase
         $handler->removeSubtree(42);
     }
 
+    public function testDeleteChildrenDrafts(): void
+    {
+        $handler = $this->getLocationHandler();
+
+        $this->treeHandler
+            ->expects(self::once())
+            ->method('deleteChildrenDrafts')
+            ->with(42);
+
+        $handler->deleteChildrenDrafts(42);
+    }
+
     /**
      * Test for the copySubtree() method.
      */

--- a/tests/lib/Persistence/Legacy/Content/TreeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/TreeHandlerTest.php
@@ -400,6 +400,61 @@ class TreeHandlerTest extends TestCase
         $this->assertTrue($location instanceof Location);
     }
 
+    public function testDeleteChildrenDraftsRecursive(): void
+    {
+        $locationGatewayMock = $this->getLocationGatewayMock();
+        $contentGatewayMock = $this->getContentGatewayMock();
+        $contentMapperMock = $this->getContentMapperMock();
+
+        $locationGatewayMock
+            ->expects(self::exactly(3))
+            ->method('getChildren')
+            ->willReturnMap([
+                [42, [
+                    ['node_id' => 201],
+                    ['node_id' => 202],
+                ]],
+                [201, []],
+                [202, []],
+            ]);
+
+        $locationGatewayMock
+            ->expects(self::exactly(3))
+            ->method('getSubtreeChildrenDraftContentIds')
+            ->willReturnMap([
+                [201, [101]],
+                [202, [102]],
+                [42, [99]],
+            ]);
+
+        $contentGatewayMock
+            ->expects(self::exactly(3))
+            ->method('loadContentInfo')
+            ->willReturnMap([
+                [101, ['main_node_id' => 201]],
+                [102, ['main_node_id' => 202]],
+                [99, ['main_node_id' => 42]],
+            ]);
+
+        $contentMapperMock
+            ->expects(self::exactly(3))
+            ->method('extractContentInfoFromRow')
+            ->willReturnCallback(static function (array $row): ContentInfo {
+                return new ContentInfo(['mainLocationId' => $row['main_node_id']]);
+            });
+
+        $contentGatewayMock
+            ->expects(self::exactly(3))
+            ->method('deleteContent')
+            ->willReturnCallback(static function (int $contentId): void {
+                self::assertContains($contentId, [99, 101, 102]);
+            });
+
+        $treeHandler = $this->getTreeHandler();
+
+        $treeHandler->deleteChildrenDrafts(42);
+    }
+
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Core\Persistence\Legacy\Content\Location\Gateway */
     protected $locationGatewayMock;
 


### PR DESCRIPTION
| :ticket: Issue | IBX-8418 |
|----------------|-----------|

Continuation of https://github.com/ibexa/core/pull/398

#### Related PRs:
https://github.com/ibexa/admin-ui/pull/1321
https://github.com/ibexa/content-tree/pull/85

#### Description:
Currently, drafts without a location (so not yet published) that are orphaned due to missing ancestor location are forever stuck in the void. They cause multiple issues in different parts of DXP and they are not easily removable. 

This PR makes sure that every time a location is trashed drafts under this given location or its child locations are removed. 

#### Documentation:
Probably required

![image](https://github.com/user-attachments/assets/723174d0-2096-42a2-8753-4b0c3b8ae04c)


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
