### PR TITLE
Optimized content thumbnail resolving

### DIFF
--- a/src/lib/Repository/Strategy/ContentThumbnail/FirstMatchingFieldStrategy.php
+++ b/src/lib/Repository/Strategy/ContentThumbnail/FirstMatchingFieldStrategy.php
@@ -37,19 +37,22 @@ final class FirstMatchingFieldStrategy implements ThumbnailStrategy
         $fieldDefinitions = $contentType->getFieldDefinitions();
 
         foreach ($fieldDefinitions as $fieldDefinition) {
-            $field = $this->getFieldByIdentifier($fieldDefinition->getIdentifier(), $fields);
+            if (!$fieldDefinition->isThumbnail()) {
+                continue;
+            }
 
+            $field = $this->getFieldByIdentifier($fieldDefinition->getIdentifier(), $fields);
             if ($field === null) {
+                continue;
+            }
+
+            if (!$this->contentFieldStrategy->hasStrategy($field->getFieldTypeIdentifier())) {
                 continue;
             }
 
             $fieldType = $this->fieldTypeService->getFieldType($fieldDefinition->getFieldTypeIdentifier());
 
-            if (
-                $fieldDefinition->isThumbnail()
-                && $this->contentFieldStrategy->hasStrategy($field->getFieldTypeIdentifier())
-                && !$fieldType->isEmptyValue($field->getValue())
-            ) {
+            if (!$fieldType->isEmptyValue($field->getValue())) {
                 return $this->contentFieldStrategy->getThumbnail($field, $versionInfo);
             }
         }


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

For a content items based on large content types with multiple translations  `\Ibexa\Core\Repository\Strategy\ContentThumbnail\FirstMatchingFieldStrategy::getThumbnail` can be very costly:

![image](https://github.com/user-attachments/assets/d9bd8437-a620-4a23-9ce3-17c785877fe1)

We can skip field definitions not marked as "Can be thumbnail" to optimize thumbnail resolution time to near zero.

#### For QA:

Please run only sanities suite.


#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
