### PR TITLE
Reduced row extraction time complexity from n^2 to 2n in persistence content type mapper 

### DIFF
--- a/src/lib/Persistence/Legacy/Content/Type/Mapper.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Mapper.php
@@ -57,9 +57,9 @@ class Mapper
      *
      * @param \Ibexa\Contracts\Core\Persistence\Content\Type\Group\CreateStruct $struct
      *
-     * @todo $description is not supported by database, yet
-     *
      * @return \Ibexa\Contracts\Core\Persistence\Content\Type\Group
+     *
+     * @todo $description is not supported by database, yet
      */
     public function createGroupFromCreateStruct(GroupCreateStruct $struct)
     {
@@ -119,6 +119,16 @@ class Mapper
         $types = [];
         $fields = [];
 
+        $rowsByAttributeId = [];
+        foreach ($rows as $row) {
+            $attributeId = (int)$row['ezcontentclass_attribute_id'];
+            if (!isset($rowsByAttributeId[$attributeId])) {
+                $rowsByAttributeId[$attributeId] = [];
+            }
+
+            $rowsByAttributeId[$attributeId][] = $row;
+        }
+
         foreach ($rows as $row) {
             $typeId = (int)$row['ezcontentclass_id'];
             if (!isset($types[$typeId])) {
@@ -128,9 +138,7 @@ class Mapper
             $fieldId = (int)$row['ezcontentclass_attribute_id'];
 
             if ($fieldId && !isset($fields[$fieldId])) {
-                $fieldDataRows = array_filter($rows, static function (array $row) use ($fieldId) {
-                    return (int) $row['ezcontentclass_attribute_id'] === (int) $fieldId;
-                });
+                $fieldDataRows = $rowsByAttributeId[$fieldId];
 
                 $multilingualData = $this->extractMultilingualData($fieldDataRows);
 


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Reduced Ibexa\Core\Persistence\Legacy\Content\Type\Mapper::extractTypesFromRows computational complexity from n^2 to 2n

![image](https://github.com/user-attachments/assets/d8f1cde0-98ce-4951-8871-103517956f04)


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
