### PR TITLE
IBX-8534: Added cache invalidation for source content when adding relation

### DIFF
--- a/src/lib/Persistence/Cache/ContentHandler.php
+++ b/src/lib/Persistence/Cache/ContentHandler.php
@@ -445,6 +445,10 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
                 self::CONTENT_IDENTIFIER,
                 [$relation->destinationContentId]
             ),
+            $this->cacheIdentifierGenerator->generateTag(
+                self::CONTENT_IDENTIFIER,
+                [$relation->sourceContentId]
+            ),
         ]);
 
         return $this->persistenceHandler->contentHandler()->addRelation($relation);

--- a/tests/lib/Persistence/Cache/ContentHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentHandlerTest.php
@@ -51,7 +51,7 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             //['deleteContent', [2]], own tests for relations complexity
             ['deleteVersion', [2, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
-            ['addRelation', [new RelationCreateStruct(['destinationContentId' => 2])], [['content', [2], false]], null, ['c-2']],
+            ['addRelation', [new RelationCreateStruct(['destinationContentId' => 2, 'sourceContentId' => 4])], [['content', [2], false], ['content', [4], false]], null, ['c-2', 'c-4']],
             ['removeRelation', [66, APIRelation::COMMON, 2], [['content', [2], false], ['relation', [66], false]], null, ['c-2', 're-66']],
             ['loadRelations', [2, 1, 3]],
             ['loadReverseRelations', [2, 3]],


### PR DESCRIPTION
| :ticket: Issue | IBX-8534 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

It seems, in how `loadRelationList` cache is implemented, and by common sense, that invalidating source content cache is also needed when relation is added. 

#### For QA:

Regression build: :green_circle:  https://github.com/ibexa/commerce/pull/1099

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
