### PR TITLE
IBX-8897: Parentheses in the name pattern field causes it to be displayed incorrectly FIX

### DIFF
--- a/src/lib/Repository/NameSchema/NameSchemaService.php
+++ b/src/lib/Repository/NameSchema/NameSchemaService.php
@@ -251,6 +251,11 @@ class NameSchemaService implements NameSchemaServiceInterface
         if ($foundGroups) {
             $i = 0;
             foreach ($groupArray[1] as $group) {
+                // Skip the group if it has no fields to parse
+                if (!preg_match('/<.*>/', $group)) {
+                    continue;
+                }
+
                 // Create meta-token for group
                 $metaToken = self::META_STRING . $i;
 

--- a/tests/lib/Repository/NameSchema/NameSchemaServiceTest.php
+++ b/tests/lib/Repository/NameSchema/NameSchemaServiceTest.php
@@ -76,13 +76,13 @@ final class NameSchemaServiceTest extends BaseServiceMockTest
         yield 'Default: Field Map and Languages taken from Content Version' => [
             [],
             [
-                'eng-GB' => ['text2' => 'two'],
-                'cro-HR' => ['text2' => 'dva'],
+                'eng-GB' => ['text1' => 'one', 'text2' => 'two'],
+                'cro-HR' => ['text1' => 'jedan', 'text2' => 'dva'],
             ],
             [],
             [
-                'eng-GB' => 'two',
-                'cro-HR' => 'dva',
+                'eng-GB' => 'one - two (testString)',
+                'cro-HR' => 'jedan - dva (testString)',
             ],
         ];
 
@@ -98,8 +98,8 @@ final class NameSchemaServiceTest extends BaseServiceMockTest
             ],
             ['eng-GB', 'cro-HR'],
             [
-                'eng-GB' => 'three',
-                'cro-HR' => 'Dva',
+                'eng-GB' => 'three (testString)',
+                'cro-HR' => ' - Dva (testString)',
             ],
         ];
     }
@@ -119,11 +119,11 @@ final class NameSchemaServiceTest extends BaseServiceMockTest
         array $expectedNames
     ): void {
         $content = $this->buildTestContentObject();
-        $nameSchema = '<text3|text2>';
+        $nameSchema = '<text3|(<text1> - <text2>)> (testString)';
         $contentType = $this->buildTestContentTypeStub($nameSchema, $nameSchema);
         $event = new ResolveContentNameSchemaEvent(
             $content,
-            ['field' => ['text3', 'text2']],
+            ['field' => ['text3', 'text2', 'text1']],
             $contentType,
             $fieldMap,
             $languageCodes


### PR DESCRIPTION
| :ticket: Issue | IBX-8897 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fixing the regression introduced in https://github.com/ibexa/core/pull/242. Right now, for example, if we us this name schema `<title|(<field1> - <field2>)> (foobar)` the foobar would be parsed to `(EZMETAGROUP_0)` regardless of the previously parsed fields. Grouping functionality with `()` has no use if the content inside this group has no `<fields>`.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
