### PR TITLE
Introduced StructValidator to unpack validation errors for structs

### DIFF
--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -376,4 +376,4 @@ services:
         # Decorator priority is higher than debug.validator to ensure profiler receives struct errors
         decoration_priority: 500
         arguments:
-          $inner: '@.inner'
+            $inner: '@.inner'

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -371,6 +371,8 @@ services:
 
     Ibexa\Bundle\Core\Translation\Policy\PolicyTranslationDefinitionProvider: ~
 
+    Ibexa\Contracts\Core\Validation\StructValidator: ~
+
     Ibexa\Contracts\Core\Validation\StructWrapperValidator:
         decorates: 'validator'
         # Decorator priority is higher than debug.validator to ensure profiler receives struct errors

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -370,3 +370,9 @@ services:
             $entityManagers: '%doctrine.entity_managers%'
 
     Ibexa\Bundle\Core\Translation\Policy\PolicyTranslationDefinitionProvider: ~
+
+    Ibexa\Contracts\Core\Validation\StructValidator:
+        decorates: 'validator'
+        decoration_priority: -10
+        arguments:
+          $inner: '@.inner'

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -371,7 +371,9 @@ services:
 
     Ibexa\Bundle\Core\Translation\Policy\PolicyTranslationDefinitionProvider: ~
 
-    Ibexa\Contracts\Core\Validation\StructValidator: ~
+    Ibexa\Contracts\Core\Validation\StructValidator:
+        arguments:
+            $validator: '@validator'
 
     Ibexa\Contracts\Core\Validation\StructWrapperValidator:
         decorates: 'validator'

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -371,7 +371,7 @@ services:
 
     Ibexa\Bundle\Core\Translation\Policy\PolicyTranslationDefinitionProvider: ~
 
-    Ibexa\Contracts\Core\Validation\StructValidator:
+    Ibexa\Contracts\Core\Validation\StructWrapperValidator:
         decorates: 'validator'
         # Decorator priority is higher than debug.validator to ensure profiler receives struct errors
         decoration_priority: 500

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -373,6 +373,7 @@ services:
 
     Ibexa\Contracts\Core\Validation\StructValidator:
         decorates: 'validator'
-        decoration_priority: -10
+        # Decorator priority is higher than debug.validator to ensure profiler receives struct errors
+        decoration_priority: 500
         arguments:
           $inner: '@.inner'

--- a/src/contracts/Validation/AbstractValidationStructWrapper.php
+++ b/src/contracts/Validation/AbstractValidationStructWrapper.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\Core\Validation;
 
 use Symfony\Component\Validator\Constraints as Assert;

--- a/src/contracts/Validation/AbstractValidationStructWrapper.php
+++ b/src/contracts/Validation/AbstractValidationStructWrapper.php
@@ -10,8 +10,6 @@ namespace Ibexa\Contracts\Core\Validation;
 
 /**
  * @template T of object
- *
- * @implements \Ibexa\Contracts\Core\Validation\ValidationStructWrapperInterface<T>
  */
 abstract class AbstractValidationStructWrapper implements ValidationStructWrapperInterface
 {

--- a/src/contracts/Validation/AbstractValidationStructWrapper.php
+++ b/src/contracts/Validation/AbstractValidationStructWrapper.php
@@ -11,9 +11,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @template T of object
  *
- * @implements \Ibexa\Contracts\Core\Validation\ValidatorStructWrapperInterface<T>
+ * @implements \Ibexa\Contracts\Core\Validation\ValidationStructWrapperInterface<T>
  */
-abstract class AbstractValidationStructWrapper implements ValidatorStructWrapperInterface
+abstract class AbstractValidationStructWrapper implements ValidationStructWrapperInterface
 {
     /**
      * @phpstan-var T

--- a/src/contracts/Validation/AbstractValidationStructWrapper.php
+++ b/src/contracts/Validation/AbstractValidationStructWrapper.php
@@ -19,10 +19,8 @@ abstract class AbstractValidationStructWrapper implements ValidationStructWrappe
 {
     /**
      * @phpstan-var T
-     *
-     * @Assert\Valid()
      */
-    private object $struct;
+    protected object $struct;
 
     /**
      * @phpstan-param T $struct
@@ -38,10 +36,5 @@ abstract class AbstractValidationStructWrapper implements ValidationStructWrappe
     final public function getStruct(): object
     {
         return $this->struct;
-    }
-
-    final public function getStructName(): string
-    {
-        return 'struct';
     }
 }

--- a/src/contracts/Validation/AbstractValidationStructWrapper.php
+++ b/src/contracts/Validation/AbstractValidationStructWrapper.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Contracts\Core\Validation;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @template T of object
+ */
+abstract class AbstractValidationStructWrapper implements ValidatorStructWrapperInterface
+{
+    /**
+     * @phpstan-var T
+     *
+     * @Assert\Valid()
+     */
+    private object $struct;
+
+    /**
+     * @phpstan-param T $struct
+     */
+    public function __construct(object $struct)
+    {
+        $this->struct = $struct;
+    }
+
+    /**
+     * @phpstan-return T
+     */
+    final public function getStruct(): object
+    {
+        return $this->struct;
+    }
+
+    final public function getStructName(): string
+    {
+        return 'struct';
+    }
+}

--- a/src/contracts/Validation/AbstractValidationStructWrapper.php
+++ b/src/contracts/Validation/AbstractValidationStructWrapper.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Validation;
 
-use Symfony\Component\Validator\Constraints as Assert;
-
 /**
  * @template T of object
  *

--- a/src/contracts/Validation/AbstractValidationStructWrapper.php
+++ b/src/contracts/Validation/AbstractValidationStructWrapper.php
@@ -10,6 +10,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @template T of object
+ *
+ * @implements \Ibexa\Contracts\Core\Validation\ValidatorStructWrapperInterface<T>
  */
 abstract class AbstractValidationStructWrapper implements ValidatorStructWrapperInterface
 {

--- a/src/contracts/Validation/StructValidator.php
+++ b/src/contracts/Validation/StructValidator.php
@@ -47,15 +47,17 @@ final class StructValidator implements ValidatorInterface
         $prefix = ltrim($value->getStructName(), '$') . '.';
         foreach ($result as $error) {
             $path = $error->getPropertyPath();
+            $root = $error->getRoot();
             if (str_starts_with($path, $prefix)) {
                 $path = substr($path, strlen($prefix));
+                $root = $value->getStruct();
             }
 
             $unwrappedError = new ConstraintViolation(
                 $error->getMessage(),
                 $error->getMessageTemplate(),
                 $error->getParameters(),
-                $error->getRoot(),
+                $root,
                 $path,
                 $error->getInvalidValue(),
                 $error->getPlural(),

--- a/src/contracts/Validation/StructValidator.php
+++ b/src/contracts/Validation/StructValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Validation;
+
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class StructValidator
+{
+    private ValidatorInterface $validator;
+
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Validation\ValidationFailedException
+     *
+     * @param string[] $groups
+     */
+    public function assertValidStruct(string $name, object $struct, array $groups): void
+    {
+        $errors = $this->validator->validate($struct, null, ['Default', ...$groups]);
+        if ($errors->count() > 0) {
+            throw new ValidationFailedException($name, $errors);
+        }
+    }
+}

--- a/src/contracts/Validation/StructValidator.php
+++ b/src/contracts/Validation/StructValidator.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Contracts\Core\Validation;
+
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class StructValidator implements ValidatorInterface
+{
+    private ValidatorInterface $inner;
+
+    public function __construct(ValidatorInterface $inner)
+    {
+        $this->inner = $inner;
+    }
+
+    public function getMetadataFor($value): MetadataInterface
+    {
+        return $this->inner->getMetadataFor($value);
+    }
+
+    public function hasMetadataFor($value): bool
+    {
+        return $this->inner->hasMetadataFor($value);
+    }
+
+    public function validate($value, $constraints = null, $groups = null): ConstraintViolationListInterface
+    {
+        $result = $this->inner->validate($value, $constraints, $groups);
+
+        if (!$value instanceof ValidatorStructWrapperInterface) {
+            return $result;
+        }
+
+        $unwrappedErrors = new ConstraintViolationList();
+
+        // Skip $ from argument name
+        $prefix = ltrim($value->getStructName(), '$') . '.';
+        foreach ($result as $error) {
+            $path = $error->getPropertyPath();
+            if (str_starts_with($path, $prefix)) {
+                $path = substr($path, strlen($prefix));
+            }
+
+            $unwrappedError = new ConstraintViolation(
+                $error->getMessage(),
+                $error->getMessageTemplate(),
+                $error->getParameters(),
+                $error->getRoot(),
+                $path,
+                $error->getInvalidValue(),
+                $error->getPlural(),
+                $error->getCode(),
+                $error->getConstraint(),
+                $error->getCause()
+            );
+
+            $unwrappedErrors->add($unwrappedError);
+        }
+
+        return $unwrappedErrors;
+    }
+
+    public function validateProperty(object $object, string $propertyName, $groups = null): ConstraintViolationListInterface
+    {
+        return $this->inner->validatePropertyValue($object, $propertyName, $groups);
+    }
+
+    public function validatePropertyValue($objectOrClass, string $propertyName, $value, $groups = null): ConstraintViolationListInterface
+    {
+        return $this->inner->validatePropertyValue($objectOrClass, $propertyName, $groups);
+    }
+
+    public function startContext(): ContextualValidatorInterface
+    {
+        return $this->inner->startContext();
+    }
+
+    public function inContext(ExecutionContextInterface $context): ContextualValidatorInterface
+    {
+        return $this->inner->inContext($context);
+    }
+}

--- a/src/contracts/Validation/StructWrapperValidator.php
+++ b/src/contracts/Validation/StructWrapperValidator.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\Core\Validation;
 
 use Symfony\Component\Validator\ConstraintViolation;

--- a/src/contracts/Validation/StructWrapperValidator.php
+++ b/src/contracts/Validation/StructWrapperValidator.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Mapping\MetadataInterface;
 use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-final class StructValidator implements ValidatorInterface
+final class StructWrapperValidator implements ValidatorInterface
 {
     private ValidatorInterface $inner;
 
@@ -37,7 +37,7 @@ final class StructValidator implements ValidatorInterface
     {
         $result = $this->inner->validate($value, $constraints, $groups);
 
-        if (!$value instanceof ValidatorStructWrapperInterface) {
+        if (!$value instanceof ValidationStructWrapperInterface) {
             return $result;
         }
 

--- a/src/contracts/Validation/StructWrapperValidator.php
+++ b/src/contracts/Validation/StructWrapperValidator.php
@@ -45,13 +45,11 @@ final class StructWrapperValidator implements ValidatorInterface
 
         $unwrappedErrors = new ConstraintViolationList();
 
-        // Skip $ from argument name
-        $prefix = ltrim($value->getStructName(), '$') . '.';
         foreach ($result as $error) {
             $path = $error->getPropertyPath();
             $root = $error->getRoot();
-            if (str_starts_with($path, $prefix)) {
-                $path = substr($path, strlen($prefix));
+            if (str_starts_with($path, 'struct.')) {
+                $path = substr($path, strlen('struct.'));
                 $root = $value->getStruct();
             }
 

--- a/src/contracts/Validation/ValidationFailedException.php
+++ b/src/contracts/Validation/ValidationFailedException.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Validation;
+
+use Exception;
+use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+final class ValidationFailedException extends InvalidArgumentException
+{
+    private ConstraintViolationListInterface $errors;
+
+    public function __construct(
+        string $argumentName,
+        ConstraintViolationListInterface $errors,
+        Exception $previous = null
+    ) {
+        parent::__construct($this->createMessage($argumentName, $errors), 0, $previous);
+
+        $this->errors = $errors;
+    }
+
+    public function getErrors(): ConstraintViolationListInterface
+    {
+        return $this->errors;
+    }
+
+    private function createMessage(string $argumentName, ConstraintViolationListInterface $errors): string
+    {
+        if ($errors->count() === 0) {
+            throw new \InvalidArgumentException(sprintf(
+                'Cannot create %s with empty validation error list.',
+                self::class,
+            ));
+        }
+
+        if ($errors->count() === 1) {
+            return sprintf(
+                "Argument '%s->%s' is invalid: %s",
+                $argumentName,
+                $errors->get(0)->getPropertyPath(),
+                $errors->get(0)->getMessage()
+            );
+        }
+
+        return sprintf(
+            "Argument '%s->%s' is invalid: %s and %d more errors",
+            $argumentName,
+            $errors->get(0)->getPropertyPath(),
+            $errors->get(0)->getMessage(),
+            $errors->count() - 1
+        );
+    }
+}

--- a/src/contracts/Validation/ValidationStructWrapperInterface.php
+++ b/src/contracts/Validation/ValidationStructWrapperInterface.php
@@ -10,14 +10,9 @@ namespace Ibexa\Contracts\Core\Validation;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @template T of object
- */
 interface ValidationStructWrapperInterface
 {
     /**
-     * @phpstan-return T
-     *
      * @Assert\Valid()
      */
     public function getStruct(): object;

--- a/src/contracts/Validation/ValidationStructWrapperInterface.php
+++ b/src/contracts/Validation/ValidationStructWrapperInterface.php
@@ -9,7 +9,7 @@ namespace Ibexa\Contracts\Core\Validation;
 /**
  * @template T of object
  */
-interface ValidatorStructWrapperInterface
+interface ValidationStructWrapperInterface
 {
     public function getStructName(): string;
 

--- a/src/contracts/Validation/ValidationStructWrapperInterface.php
+++ b/src/contracts/Validation/ValidationStructWrapperInterface.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\Core\Validation;
 
 /**

--- a/src/contracts/Validation/ValidationStructWrapperInterface.php
+++ b/src/contracts/Validation/ValidationStructWrapperInterface.php
@@ -8,15 +8,17 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Validation;
 
+use Symfony\Component\Validator\Constraints as Assert;
+
 /**
  * @template T of object
  */
 interface ValidationStructWrapperInterface
 {
-    public function getStructName(): string;
-
     /**
      * @phpstan-return T
+     *
+     * @Assert\Valid()
      */
     public function getStruct(): object;
 }

--- a/src/contracts/Validation/ValidatorStructWrapperInterface.php
+++ b/src/contracts/Validation/ValidatorStructWrapperInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Contracts\Core\Validation;
+
+interface ValidatorStructWrapperInterface
+{
+    public function getStructName(): string;
+}

--- a/src/contracts/Validation/ValidatorStructWrapperInterface.php
+++ b/src/contracts/Validation/ValidatorStructWrapperInterface.php
@@ -6,7 +6,15 @@
  */
 namespace Ibexa\Contracts\Core\Validation;
 
+/**
+ * @template T of object
+ */
 interface ValidatorStructWrapperInterface
 {
     public function getStructName(): string;
+
+    /**
+     * @phpstan-return T
+     */
+    public function getStruct(): object;
 }

--- a/tests/lib/Validation/StructValidatorTest.php
+++ b/tests/lib/Validation/StructValidatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Validation;
+
+use Ibexa\Contracts\Core\Validation\StructValidator;
+use Ibexa\Contracts\Core\Validation\ValidationFailedException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @covers \Ibexa\Contracts\Core\Validation\StructValidator
+ */
+final class StructValidatorTest extends TestCase
+{
+    /** @var \Symfony\Component\Validator\Validator\ValidatorInterface&\PHPUnit\Framework\MockObject\MockObject) */
+    private ValidatorInterface $validator;
+
+    private StructValidator $structValidator;
+
+    protected function setUp(): void
+    {
+        $this->validator = $this->createMock(ValidatorInterface::class);
+        $this->structValidator = new StructValidator($this->validator);
+    }
+
+    public function testAssertValidStructWithValidStruct(): void
+    {
+        $struct = new stdClass();
+        $errors = $this->createMock(ConstraintViolationListInterface::class);
+        $errors->method('count')->willReturn(0);
+
+        $this->validator
+            ->expects(self::once())
+            ->method('validate')
+            ->with(
+                $struct,
+                null,
+                ['Default', 'group']
+            )->willReturn($errors);
+
+        $this->structValidator->assertValidStruct('struct', new stdClass(), ['group']);
+    }
+
+    public function testAssertValidStructWithInvalidStruct(): void
+    {
+        $errors = $this->createExampleConstraintViolationList(
+            $this->createExampleConstraintViolation()
+        );
+
+        $this->validator
+            ->method('validate')
+            ->with(
+                new stdClass(),
+                null,
+                ['Default', 'group']
+            )->willReturn($errors);
+
+        try {
+            $this->structValidator->assertValidStruct('struct', new stdClass(), ['group']);
+        } catch (ValidationFailedException $e) {
+            self::assertSame("Argument 'struct->property' is invalid: validation error", $e->getMessage());
+            self::assertSame($errors, $e->getErrors());
+        }
+    }
+
+    private function createExampleConstraintViolation(): ConstraintViolationInterface
+    {
+        return new ConstraintViolation(
+            'validation error',
+            null,
+            [],
+            '',
+            'property',
+            'example'
+        );
+    }
+
+    private function createExampleConstraintViolationList(
+        ConstraintViolationInterface $error
+    ): ConstraintViolationListInterface {
+        return new ConstraintViolationList([$error]);
+    }
+}

--- a/tests/lib/Validation/StructWrapperValidatorTest.php
+++ b/tests/lib/Validation/StructWrapperValidatorTest.php
@@ -6,8 +6,8 @@
  */
 namespace Ibexa\Tests\Core\Validation;
 
-use Ibexa\Contracts\Core\Validation\StructValidator;
-use Ibexa\Contracts\Core\Validation\ValidatorStructWrapperInterface;
+use Ibexa\Contracts\Core\Validation\StructWrapperValidator;
+use Ibexa\Contracts\Core\Validation\ValidationStructWrapperInterface;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -17,19 +17,19 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
- * @covers \Ibexa\Contracts\Core\Validation\StructValidator
+ * @covers \Ibexa\Contracts\Core\Validation\StructWrapperValidator
  */
-final class StructValidatorTest extends TestCase
+final class StructWrapperValidatorTest extends TestCase
 {
     /** @var \Symfony\Component\Validator\Validator\ValidatorInterface&\PHPUnit\Framework\MockObject\MockObject */
     private ValidatorInterface $validator;
 
-    private StructValidator $structValidator;
+    private StructWrapperValidator $structValidator;
 
     protected function setUp(): void
     {
         $this->validator = $this->createMock(ValidatorInterface::class);
-        $this->structValidator = new StructValidator($this->validator);
+        $this->structValidator = new StructWrapperValidator($this->validator);
     }
 
     public function testAssertValidStructWithValidStruct(): void
@@ -80,7 +80,7 @@ final class StructValidatorTest extends TestCase
         $initialError = $this->createExampleConstraintViolation();
         $initialErrors = $this->createExampleConstraintViolationList($initialError);
 
-        $wrapper = $this->createMock(ValidatorStructWrapperInterface::class);
+        $wrapper = $this->createMock(ValidationStructWrapperInterface::class);
         $wrapper->expects(self::once())
             ->method('getStructName')
             ->willReturn('$struct');

--- a/tests/lib/Validation/StructWrapperValidatorTest.php
+++ b/tests/lib/Validation/StructWrapperValidatorTest.php
@@ -83,9 +83,6 @@ final class StructWrapperValidatorTest extends TestCase
         $initialErrors = $this->createExampleConstraintViolationList($initialError);
 
         $wrapper = $this->createMock(ValidationStructWrapperInterface::class);
-        $wrapper->expects(self::once())
-            ->method('getStructName')
-            ->willReturn('$struct');
 
         $struct = new stdClass();
         $wrapper->expects(self::once())

--- a/tests/lib/Validation/StructWrapperValidatorTest.php
+++ b/tests/lib/Validation/StructWrapperValidatorTest.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Tests\Core\Validation;
 
 use Ibexa\Contracts\Core\Validation\StructWrapperValidator;

--- a/tests/lib/Validation/ValidationFailedExceptionTest.php
+++ b/tests/lib/Validation/ValidationFailedExceptionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Validation;
+
+use Ibexa\Contracts\Core\Validation\ValidationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+final class ValidationFailedExceptionTest extends TestCase
+{
+    public function testSingleError(): void
+    {
+        $errors = new ConstraintViolationList([
+            new ConstraintViolation('__error__', null, [], null, '__property_path__', null),
+        ]);
+
+        $exception = new ValidationFailedException('__argument_name__', $errors);
+
+        self::assertSame(
+            "Argument '__argument_name__->__property_path__' is invalid: __error__",
+            $exception->getMessage(),
+        );
+        self::assertSame($errors, $exception->getErrors());
+    }
+
+    public function testMultipleErrors(): void
+    {
+        $errors = new ConstraintViolationList([
+            new ConstraintViolation('__error_1__', null, [], null, '__property_path_1__', null),
+            new ConstraintViolation('__error_2__', null, [], null, '__property_path_2__', null),
+        ]);
+
+        $exception = new ValidationFailedException('__argument_name__', $errors);
+
+        self::assertSame(
+            "Argument '__argument_name__->__property_path_1__' is invalid: __error_1__ and 1 more errors",
+            $exception->getMessage(),
+        );
+        self::assertSame($errors, $exception->getErrors());
+    }
+
+    public function testEmptyErrorList(): void
+    {
+        $errors = new ConstraintViolationList([]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Cannot create %s with empty validation error list.',
+            ValidationFailedException::class,
+        ));
+        new ValidationFailedException('__argument_name__', $errors);
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR introduces `StructWrapperValidator` (which implements `ValidatorInterface` from Symfony).

It is intended to decorate Symfony's Validator and unpack errors coming from struct assertions. This means it does not require any additional processing on the side of services, as long as the structs are packed using either the provided wrapper abstract, or the wrapper interface.

Before:
![image](https://github.com/user-attachments/assets/b8849f74-38b9-4816-af98-2a3137b65c48)

After:
![image](https://github.com/user-attachments/assets/1a11e9ad-d86f-4616-9126-8adc514b8cc5)


![image](https://github.com/user-attachments/assets/db3ad9dc-b09d-4d5f-bf99-b84ea9143548)

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
