### PR TITLE
PHP 8: Preventing Fatal error for ezobjectrelationlist datatype

### DIFF
--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
@@ -86,7 +86,7 @@ class RelationListConverter implements Converter
         $priorityByContentId = [];
 
         $dom = new DOMDocument('1.0', 'utf-8');
-        if ($dom->loadXML($value->dataText) === true) {
+        if ($value->dataText != "" && $dom->loadXML($value->dataText) === true) {
             foreach ($dom->getElementsByTagName('relation-item') as $relationItem) {
                 /* @var \DOMElement $relationItem */
                 $priorityByContentId[$relationItem->getAttribute('contentobject-id')] =


### PR DESCRIPTION
Preventing Fatal error in PHP 8 for ezobjectrelationlist datatype when data_text is an empty string or null

We want to standardize the data_text default value to an empty string because in PHP 8 most of operations with string will throw a Fatal error when passing null. The data_text value is initialized with a null value when adding a new attribute to an existing content class.