### PR TITLE
[PHPStan] Aligned baseline after PHPStan release

### DIFF
--- a/phpstan-baseline-gte-8.0.neon
+++ b/phpstan-baseline-gte-8.0.neon
@@ -446,11 +446,6 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/UrlAliasTest.php
 
 		-
-			message: "#^Trying to invoke Closure\\|null but it might not be a callable\\.$#"
-			count: 2
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$array of function key expects array\\|object, string given\\.$#"
 			count: 4
 			path: tests/lib/Search/FieldNameResolverTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9466,11 +9466,6 @@ parameters:
 			path: src/lib/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
 
 		-
-			message: "#^Cannot call method warning\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
-			count: 2
-			path: src/lib/FieldType/Image/ImageThumbnailStrategy.php
-
-		-
 			message: "#^Parameter \\#3 \\$pad_string of function str_pad expects string, int given\\.$#"
 			count: 1
 			path: src/lib/FieldType/Image/PathGenerator/LegacyPathGenerator.php


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|


#### Description:

Seems there was a PHPStan relase and we need to update the baseline files.

Also most likely missed thing when merging #438 - additional logger error report is not needed in the baseline, as it was moved to the main configuration.

