### PR TITLE
[CI] Skipped MaxLanguagesContentServiceTest::testCreateContent on solr, due to not mapped languages

### DIFF
--- a/tests/integration/Core/Repository/ContentService/MaxLanguagesContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentService/MaxLanguagesContentServiceTest.php
@@ -42,6 +42,10 @@ final class MaxLanguagesContentServiceTest extends RepositoryTestCase
      */
     public function testCreateContent(): void
     {
+        if (getenv('SEARCH_ENGINE') === 'solr') {
+            self::markTestSkipped('Skipped on Solr as languages are not mapped to solr endpoints');
+        }
+
         $names = array_merge(...array_map(
             static fn (array $languageData): array => [
                 $languageData['languageCode'] => $languageData['name'] . ' name',


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Found in this solr job
https://github.com/ibexa/solr/actions/runs/12257191193/job/34195175068?pr=80
#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
