### PR TITLE
IBX-9302: Improved default image variations to auto rotate

### DIFF
--- a/src/bundle/Core/Resources/config/default_settings.yml
+++ b/src/bundle/Core/Resources/config/default_settings.yml
@@ -182,6 +182,7 @@ parameters:
         reference:
             reference: ~
             filters:
+                auto_rotate: []
                 geometry/scaledownonly: [600, 600]
         small:
             reference: reference


### PR DESCRIPTION
| :ticket: Issue | IBX-9302 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Small improvement that enables auto rotation of the images when using one of the default filters (small, tiny, medium, large). While it is a very small change it still changes the default behavior so maybe we don't want to proceed with this yet. Or maybe have it implemented in a different way.

For this to work after applying the changes on latest Ibexa installation we need to run `php bin/console cache:clear` then `php bin/console liip:imagine:cache:remove -v`


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
