### PR TITLE
IBX-9415: Added support for ContentAwareInterface in ibexa_* Twig functions

### DIFF
--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -96,12 +96,12 @@ class ContentExtension extends AbstractExtension
                 $this->getDeprecationOptions('ibexa_field_is_empty'),
             ),
             new TwigFunction(
-                'ibexa_field_is_empty',
-                [$this, 'isFieldEmpty']
-            ),
-            new TwigFunction(
                 'ibexa_has_field',
                 [$this, 'hasField']
+            ),
+            new TwigFunction(
+                'ibexa_field_is_empty',
+                [$this, 'isFieldEmpty']
             ),
             new TwigFunction(
                 'ez_field_name',

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -8,6 +8,7 @@ namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
@@ -95,12 +96,12 @@ class ContentExtension extends AbstractExtension
                 $this->getDeprecationOptions('ibexa_field_is_empty'),
             ),
             new TwigFunction(
-                'ibexa_has_field',
-                [$this, 'hasField']
-            ),
-            new TwigFunction(
                 'ibexa_field_is_empty',
                 [$this, 'isFieldEmpty']
+            ),
+            new TwigFunction(
+                'ibexa_has_field',
+                [$this, 'hasField']
             ),
             new TwigFunction(
                 'ez_field_name',
@@ -137,15 +138,16 @@ class ContentExtension extends AbstractExtension
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $content Must be a valid Content or ContentInfo object.
+     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be a valid Content or ContentInfo object.
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content or ContentInfo object.
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content, ContentInfo or ContentAwareInterface object.
      *
      * @return string
      */
-    public function getTranslatedContentName(ValueObject $content, $forcedLanguage = null)
+    public function getTranslatedContentName($data, $forcedLanguage = null)
     {
+        $content = $this->getValueObject($data);
         if ($content instanceof Content) {
             return $this->translationHelper->getTranslatedContentName($content, $forcedLanguage);
         } elseif ($content instanceof ContentInfo) {
@@ -153,9 +155,9 @@ class ContentExtension extends AbstractExtension
         }
 
         throw new InvalidArgumentType(
-            '$content',
-            sprintf('%s or %s', Content::class, ContentInfo::class),
-            $content
+            '$data',
+            sprintf('%s or %s or %s', Content::class, ContentInfo::class, ContentAwareInterface::class),
+            $data
         );
     }
 
@@ -163,43 +165,43 @@ class ContentExtension extends AbstractExtension
      * Returns the translated field, very similar to getTranslatedFieldValue but this returns the whole field.
      * To be used with ibexa_image_alias for example, which requires the whole field.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
      * @param string $fieldDefIdentifier Identifier for the field we want to get.
      * @param string $forcedLanguage Locale we want the field in (e.g. "cro-HR"). Null by default (takes current locale).
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Field
      */
-    public function getTranslatedField(Content $content, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedField($data, $fieldDefIdentifier, $forcedLanguage = null)
     {
-        return $this->translationHelper->getTranslatedField($content, $fieldDefIdentifier, $forcedLanguage);
+        return $this->translationHelper->getTranslatedField($this->getContent($data), $fieldDefIdentifier, $forcedLanguage);
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
      * @param string $fieldDefIdentifier Identifier for the field we want to get the value from.
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale).
      *
      * @return mixed A primitive type or a field type Value object depending on the field type.
      */
-    public function getTranslatedFieldValue(Content $content, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedFieldValue($data, $fieldDefIdentifier, $forcedLanguage = null)
     {
-        return $this->translationHelper->getTranslatedField($content, $fieldDefIdentifier, $forcedLanguage)->value;
+        return $this->translationHelper->getTranslatedField($this->getContent($data), $fieldDefIdentifier, $forcedLanguage)->value;
     }
 
     /**
-     * Gets name of a FieldDefinition name by loading ContentType based on Content/ContentInfo object.
+     * Gets name of a FieldDefinition name by loading ContentType based on Content/ContentInfo/ContentAwareInterface object.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $content Must be Content or ContentInfo object
+     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
      * @param string $fieldDefIdentifier Identifier for the field we want to get the name from
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content object.
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content, ContentInfo or ContentAwareInterface object.
      *
      * @return string|null
      */
-    public function getTranslatedFieldDefinitionName(ValueObject $content, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedFieldDefinitionName($data, $fieldDefIdentifier, $forcedLanguage = null)
     {
-        if ($contentType = $this->getContentType($content)) {
+        if ($contentType = $this->getContentType($this->getValueObject($data))) {
             return $this->translationHelper->getTranslatedFieldDefinitionProperty(
                 $contentType,
                 $fieldDefIdentifier,
@@ -208,23 +210,25 @@ class ContentExtension extends AbstractExtension
             );
         }
 
-        throw new InvalidArgumentType('$content', 'Content|ContentInfo', $content);
+        throw new InvalidArgumentType(
+            '$data',
+            sprintf('%s or %s or %s', Content::class, ContentInfo::class, ContentAwareInterface::class),
+            $data
+        );
     }
 
     /**
-     * Gets name of a FieldDefinition description by loading ContentType based on Content/ContentInfo object.
+     * Gets name of a FieldDefinition description by loading ContentType based on Content/ContentInfo/ContentAwareInterface object.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $content Must be Content or ContentInfo object
+     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
      * @param string $fieldDefIdentifier Identifier for the field we want to get the name from
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content object.
-     *
      * @return string|null
      */
-    public function getTranslatedFieldDefinitionDescription(ValueObject $content, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedFieldDefinitionDescription($data, $fieldDefIdentifier, $forcedLanguage = null)
     {
-        if ($contentType = $this->getContentType($content)) {
+        if ($contentType = $this->getContentType($this->getValueObject($data))) {
             return $this->translationHelper->getTranslatedFieldDefinitionProperty(
                 $contentType,
                 $fieldDefIdentifier,
@@ -233,11 +237,20 @@ class ContentExtension extends AbstractExtension
             );
         }
 
-        throw new InvalidArgumentType('$content', 'Content|ContentInfo', $content);
+        throw new InvalidArgumentType(
+            '$data',
+            sprintf('%s or %s or %s', Content::class, ContentInfo::class, ContentAwareInterface::class),
+            $data
+        );
     }
 
-    public function hasField(Content $content, string $fieldDefIdentifier): bool
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
+     */
+    public function hasField($data, string $fieldDefIdentifier): bool
     {
+        $content = $this->getContent($data);
+
         return $content->getContentType()->hasFieldDefinition($fieldDefIdentifier);
     }
 
@@ -250,7 +263,7 @@ class ContentExtension extends AbstractExtension
      * Checks if a given field is considered empty.
      * This method accepts field as Objects or by identifiers.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field|string $fieldDefIdentifier Field or Field Identifier to
      *                                                                                   get the value from.
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR").
@@ -258,13 +271,13 @@ class ContentExtension extends AbstractExtension
      *
      * @return bool
      */
-    public function isFieldEmpty(Content $content, $fieldDefIdentifier, $forcedLanguage = null)
+    public function isFieldEmpty($data, $fieldDefIdentifier, $forcedLanguage = null)
     {
         if ($fieldDefIdentifier instanceof Field) {
             $fieldDefIdentifier = $fieldDefIdentifier->fieldDefIdentifier;
         }
 
-        return $this->fieldHelper->isFieldEmpty($content, $fieldDefIdentifier, $forcedLanguage);
+        return $this->fieldHelper->isFieldEmpty($this->getContent($data), $fieldDefIdentifier, $forcedLanguage);
     }
 
     /**
@@ -285,8 +298,12 @@ class ContentExtension extends AbstractExtension
         }
     }
 
-    public function getFirstFilledImageFieldIdentifier(Content $content)
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
+     */
+    public function getFirstFilledImageFieldIdentifier($data)
     {
+        $content = $this->getContent($data);
         foreach ($content->getFieldsByLanguage() as $field) {
             $fieldTypeIdentifier = $content->getContentType()
                 ->getFieldDefinition($field->fieldDefIdentifier)
@@ -304,6 +321,46 @@ class ContentExtension extends AbstractExtension
         }
 
         return null;
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
+     *
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
+     */
+    private function getValueObject($data): ValueObject
+    {
+        if ($data instanceof ContentAwareInterface) {
+            $data = $data->getContent();
+        } elseif (!$data instanceof ValueObject) {
+            throw new InvalidArgumentType(
+                '$data',
+                sprintf('%s', ValueObject::class),
+                $data
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
+     *
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
+     */
+    private function getContent($data): Content
+    {
+        if ($data instanceof ContentAwareInterface) {
+            $data = $data->getContent();
+        } elseif (!$data instanceof Content) {
+            throw new InvalidArgumentType(
+                '$data',
+                sprintf('%s', Content::class),
+                $data
+            );
+        }
+
+        return $data;
     }
 }
 

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -330,17 +330,19 @@ class ContentExtension extends AbstractExtension
      */
     private function resolveData(object $data): ValueObject
     {
-        if ($data instanceof ContentAwareInterface) {
-            $data = $data->getContent();
-        } elseif (!$data instanceof Content && !$data instanceof ContentInfo) {
-            throw new InvalidArgumentType(
-                '$data',
-                sprintf('%s or %s or %s', Content::class, ContentInfo::class, ContentAwareInterface::class),
-                $data
-            );
+        if ($data instanceof Content || $data instanceof ContentInfo) {
+            return $data;
         }
 
-        return $data;
+        if ($data instanceof ContentAwareInterface) {
+            return $data->getContent();
+        }
+
+        throw new InvalidArgumentType(
+            '$content',
+            sprintf('%s or %s or %s', Content::class, ContentInfo::class, ContentAwareInterface::class),
+            $data,
+        );
     }
 
     /**
@@ -350,17 +352,19 @@ class ContentExtension extends AbstractExtension
      */
     private function getContent(object $data): Content
     {
-        if ($data instanceof ContentAwareInterface) {
-            $data = $data->getContent();
-        } elseif (!$data instanceof Content) {
-            throw new InvalidArgumentType(
-                '$data',
-                sprintf('%s pr %s', Content::class, ContentAwareInterface::class),
-                $data
-            );
+        if ($data instanceof Content) {
+            return $data;
         }
 
-        return $data;
+        if ($data instanceof ContentAwareInterface) {
+            return $data->getContent();
+        }
+
+        throw new InvalidArgumentType(
+            '$content',
+            sprintf('%s or %s', Content::class, ContentAwareInterface::class),
+            $data,
+        );
     }
 }
 

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -335,7 +335,7 @@ class ContentExtension extends AbstractExtension
         } elseif (!$data instanceof ValueObject) {
             throw new InvalidArgumentType(
                 '$data',
-                sprintf('%s', ValueObject::class),
+                sprintf('%s or %s', ValueObject::class, ContentAwareInterface::class),
                 $data
             );
         }
@@ -355,7 +355,7 @@ class ContentExtension extends AbstractExtension
         } elseif (!$data instanceof Content) {
             throw new InvalidArgumentType(
                 '$data',
-                sprintf('%s', Content::class),
+                sprintf('%s pr %s', Content::class, ContentAwareInterface::class),
                 $data
             );
         }

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -138,7 +138,7 @@ class ContentExtension extends AbstractExtension
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be a valid Content, ContentInfo or ContentAware object.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be a valid Content, ContentInfo, or ContentAwareInterface object.
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content, ContentInfo, or ContentAwareInterface object.

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -191,7 +191,7 @@ class ContentExtension extends AbstractExtension
     /**
      * Gets name of a FieldDefinition name by loading ContentType based on Content/ContentInfo/ContentAwareInterface object.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo, or ContentAwareInterface object
      * @param string $fieldDefIdentifier Identifier for the field we want to get the name from
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
@@ -220,7 +220,7 @@ class ContentExtension extends AbstractExtension
     /**
      * Gets name of a FieldDefinition description by loading ContentType based on Content/ContentInfo/ContentAwareInterface object.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo, or ContentAwareInterface object
      * @param string $fieldDefIdentifier Identifier for the field we want to get the name from
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -138,16 +138,16 @@ class ContentExtension extends AbstractExtension
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be a valid Content or ContentInfo object.
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be a valid Content, ContentInfo or ContentAware object.
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content, ContentInfo or ContentAwareInterface object.
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content, ContentInfo, or ContentAwareInterface object.
      *
      * @return string
      */
-    public function getTranslatedContentName($data, $forcedLanguage = null)
+    public function getTranslatedContentName(object $data, $forcedLanguage = null)
     {
-        $content = $this->getValueObject($data);
+        $content = $this->resolveData($data);
         if ($content instanceof Content) {
             return $this->translationHelper->getTranslatedContentName($content, $forcedLanguage);
         } elseif ($content instanceof ContentInfo) {
@@ -171,7 +171,7 @@ class ContentExtension extends AbstractExtension
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Field
      */
-    public function getTranslatedField($data, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedField(object $data, $fieldDefIdentifier, $forcedLanguage = null)
     {
         return $this->translationHelper->getTranslatedField($this->getContent($data), $fieldDefIdentifier, $forcedLanguage);
     }
@@ -183,7 +183,7 @@ class ContentExtension extends AbstractExtension
      *
      * @return mixed A primitive type or a field type Value object depending on the field type.
      */
-    public function getTranslatedFieldValue($data, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedFieldValue(object $data, $fieldDefIdentifier, $forcedLanguage = null)
     {
         return $this->translationHelper->getTranslatedField($this->getContent($data), $fieldDefIdentifier, $forcedLanguage)->value;
     }
@@ -191,17 +191,17 @@ class ContentExtension extends AbstractExtension
     /**
      * Gets name of a FieldDefinition name by loading ContentType based on Content/ContentInfo/ContentAwareInterface object.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
      * @param string $fieldDefIdentifier Identifier for the field we want to get the name from
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content, ContentInfo or ContentAwareInterface object.
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content, ContentInfo, or ContentAwareInterface object.
      *
      * @return string|null
      */
-    public function getTranslatedFieldDefinitionName($data, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedFieldDefinitionName(object $data, $fieldDefIdentifier, $forcedLanguage = null)
     {
-        if ($contentType = $this->getContentType($this->getValueObject($data))) {
+        if ($contentType = $this->getContentType($this->resolveData($data))) {
             return $this->translationHelper->getTranslatedFieldDefinitionProperty(
                 $contentType,
                 $fieldDefIdentifier,
@@ -220,15 +220,15 @@ class ContentExtension extends AbstractExtension
     /**
      * Gets name of a FieldDefinition description by loading ContentType based on Content/ContentInfo/ContentAwareInterface object.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data Must be Content, ContentInfo or ContentAwareInterface object
      * @param string $fieldDefIdentifier Identifier for the field we want to get the name from
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
      *
      * @return string|null
      */
-    public function getTranslatedFieldDefinitionDescription($data, $fieldDefIdentifier, $forcedLanguage = null)
+    public function getTranslatedFieldDefinitionDescription(object $data, $fieldDefIdentifier, $forcedLanguage = null)
     {
-        if ($contentType = $this->getContentType($this->getValueObject($data))) {
+        if ($contentType = $this->getContentType($this->resolveData($data))) {
             return $this->translationHelper->getTranslatedFieldDefinitionProperty(
                 $contentType,
                 $fieldDefIdentifier,
@@ -247,7 +247,7 @@ class ContentExtension extends AbstractExtension
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
      */
-    public function hasField($data, string $fieldDefIdentifier): bool
+    public function hasField(object $data, string $fieldDefIdentifier): bool
     {
         $content = $this->getContent($data);
 
@@ -271,7 +271,7 @@ class ContentExtension extends AbstractExtension
      *
      * @return bool
      */
-    public function isFieldEmpty($data, $fieldDefIdentifier, $forcedLanguage = null)
+    public function isFieldEmpty(object $data, $fieldDefIdentifier, $forcedLanguage = null)
     {
         if ($fieldDefIdentifier instanceof Field) {
             $fieldDefIdentifier = $fieldDefIdentifier->fieldDefIdentifier;
@@ -301,7 +301,7 @@ class ContentExtension extends AbstractExtension
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
      */
-    public function getFirstFilledImageFieldIdentifier($data)
+    public function getFirstFilledImageFieldIdentifier(object $data)
     {
         $content = $this->getContent($data);
         foreach ($content->getFieldsByLanguage() as $field) {
@@ -324,18 +324,18 @@ class ContentExtension extends AbstractExtension
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    private function getValueObject($data): ValueObject
+    private function resolveData(object $data): ValueObject
     {
         if ($data instanceof ContentAwareInterface) {
             $data = $data->getContent();
-        } elseif (!$data instanceof ValueObject) {
+        } elseif (!$data instanceof Content && !$data instanceof ContentInfo) {
             throw new InvalidArgumentType(
                 '$data',
-                sprintf('%s or %s', ValueObject::class, ContentAwareInterface::class),
+                sprintf('%s or %s or %s', Content::class, ContentInfo::class, ContentAwareInterface::class),
                 $data
             );
         }
@@ -348,7 +348,7 @@ class ContentExtension extends AbstractExtension
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    private function getContent($data): Content
+    private function getContent(object $data): Content
     {
         if ($data instanceof ContentAwareInterface) {
             $data = $data->getContent();

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -223,7 +223,7 @@ class FieldRenderingExtension extends AbstractExtension
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    private function getContent($content): Content
+    private function getContent(object $content): Content
     {
         if ($content instanceof ContentAwareInterface) {
             $content = $content->getContent();

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -68,8 +68,8 @@ class FieldRenderingExtension extends AbstractExtension
             ) {
                 $this->fieldBlockRenderer->setTwig($environment);
 
-            return $this->renderFieldDefinitionSettings($fieldDefinition, $params);
-        };
+                return $this->renderFieldDefinitionSettings($fieldDefinition, $params);
+            };
 
         return [
             new TwigFunction(

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -230,7 +230,7 @@ class FieldRenderingExtension extends AbstractExtension
         } elseif (!$content instanceof Content) {
             throw new InvalidArgumentType(
                 '$content',
-                sprintf('%s', Content::class),
+                sprintf('%s or %s', Content::class, ContentAwareInterface::class),
                 $content
             );
         }

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -225,17 +225,18 @@ class FieldRenderingExtension extends AbstractExtension
      */
     private function getContent(object $content): Content
     {
+        if ($content instanceof Content) {
+            return $content;
+        }
         if ($content instanceof ContentAwareInterface) {
-            $content = $content->getContent();
-        } elseif (!$content instanceof Content) {
-            throw new InvalidArgumentType(
-                '$content',
-                sprintf('%s or %s', Content::class, ContentAwareInterface::class),
-                $content
-            );
+            return $content->getContent();
         }
 
-        return $content;
+        throw new InvalidArgumentType(
+            '$content',
+            sprintf('%s or %s', Content::class, ContentAwareInterface::class),
+            $content,
+        );
     }
 }
 

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -63,7 +63,7 @@ final class RenderContentExtension extends AbstractExtension
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
      */
-    public function renderContent($data, array $options = []): string
+    public function renderContent(object $data, array $options = []): string
     {
         $renderOptions = new RenderOptions($options);
         $event = $this->eventDispatcher->dispatch(
@@ -78,7 +78,7 @@ final class RenderContentExtension extends AbstractExtension
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    private function getContent($data): Content
+    private function getContent(object $data): Content
     {
         if ($data instanceof ContentAwareInterface) {
             $data = $data->getContent();

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace Ibexa\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\MVC\Symfony\Event\ResolveRenderOptionsEvent;
 use Ibexa\Core\MVC\Symfony\Templating\RenderContentStrategy;
 use Ibexa\Core\MVC\Symfony\Templating\RenderOptions;
@@ -58,14 +60,37 @@ final class RenderContentExtension extends AbstractExtension
         ];
     }
 
-    public function renderContent(Content $content, array $options = []): string
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
+     */
+    public function renderContent($data, array $options = []): string
     {
         $renderOptions = new RenderOptions($options);
         $event = $this->eventDispatcher->dispatch(
             new ResolveRenderOptionsEvent($renderOptions)
         );
 
-        return $this->renderContentStrategy->render($content, $event->getRenderOptions());
+        return $this->renderContentStrategy->render($this->getContent($data), $event->getRenderOptions());
+    }
+
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $data
+     *
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
+     */
+    private function getContent($data): Content
+    {
+        if ($data instanceof ContentAwareInterface) {
+            $data = $data->getContent();
+        } elseif (!$data instanceof Content) {
+            throw new InvalidArgumentType(
+                '$data',
+                sprintf('%s', Content::class),
+                $data
+            );
+        }
+
+        return $data;
     }
 }
 

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -80,17 +80,19 @@ final class RenderContentExtension extends AbstractExtension
      */
     private function getContent(object $data): Content
     {
-        if ($data instanceof ContentAwareInterface) {
-            $data = $data->getContent();
-        } elseif (!$data instanceof Content) {
-            throw new InvalidArgumentType(
-                '$data',
-                sprintf('%s or %s', Content::class, ContentAwareInterface::class),
-                $data
-            );
+        if ($data instanceof Content) {
+            return $data;
         }
 
-        return $data;
+        if ($data instanceof ContentAwareInterface) {
+            return $data->getContent();
+        }
+
+        throw new InvalidArgumentType(
+            '$content',
+            sprintf('%s or %s', Content::class, ContentAwareInterface::class),
+            $data,
+        );
     }
 }
 

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -85,7 +85,7 @@ final class RenderContentExtension extends AbstractExtension
         } elseif (!$data instanceof Content) {
             throw new InvalidArgumentType(
                 '$data',
-                sprintf('%s', Content::class),
+                sprintf('%s or %s', Content::class, ContentAwareInterface::class),
                 $data
             );
         }

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
@@ -9,7 +9,6 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Repository;
-use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
@@ -131,24 +130,17 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
     /**
      * @param array<string, mixed>  $fieldsData
      * @param array<mixed>  $namesData
+     *
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): ContentAwareInterface
+    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): object
     {
         $content = $this->getContent($contentTypeIdentifier, $fieldsData, $namesData);
 
-        return new class($content) implements ContentAwareInterface {
-            private APIContent $content;
+        $mock = $this->createMock(ContentAwareInterface::class);
+        $mock->method('getContent')->willReturn($content);
 
-            public function __construct(APIContent $content)
-            {
-                $this->content = $content;
-            }
-
-            public function getContent(): APIContent
-            {
-                return $this->content;
-            }
-        };
+        return $mock;
     }
 
     private function getConfigResolverMock()

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
@@ -130,10 +130,8 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
     /**
      * @param array<string, mixed>  $fieldsData
      * @param array<mixed>  $namesData
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): object
+    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): ContentAwareInterface
     {
         $content = $this->getContent($contentTypeIdentifier, $fieldsData, $namesData);
 

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/ContentExtensionTest.php
@@ -9,6 +9,8 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
@@ -124,6 +126,29 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
         );
 
         return $content;
+    }
+
+    /**
+     * @param array<string, mixed>  $fieldsData
+     * @param array<mixed>  $namesData
+     */
+    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): ContentAwareInterface
+    {
+        $content = $this->getContent($contentTypeIdentifier, $fieldsData, $namesData);
+
+        return new class($content) implements ContentAwareInterface {
+            private APIContent $content;
+
+            public function __construct(APIContent $content)
+            {
+                $this->content = $content;
+            }
+
+            public function getContent(): APIContent
+            {
+                return $this->content;
+            }
+        };
     }
 
     private function getConfigResolverMock()

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
@@ -7,7 +7,6 @@
 namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\ContentService;
-use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
@@ -136,24 +135,17 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
     /**
      * @param array<mixed>  $fieldsData
      * @param array<mixed>  $namesData
+     *
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): ContentAwareInterface
+    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): object
     {
         $content = $this->getContent($contentTypeIdentifier, $fieldsData, $namesData);
 
-        return new class($content) implements ContentAwareInterface {
-            private APIContent $content;
+        $mock = $this->createMock(ContentAwareInterface::class);
+        $mock->method('getContent')->willReturn($content);
 
-            public function __construct(APIContent $content)
-            {
-                $this->content = $content;
-            }
-
-            public function getContent(): APIContent
-            {
-                return $this->content;
-            }
-        };
+        return $mock;
     }
 
     private function getTemplatePath($tpl)

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
@@ -7,6 +7,8 @@
 namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
@@ -129,6 +131,29 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
         );
 
         return $content;
+    }
+
+    /**
+     * @param array<mixed>  $fieldsData
+     * @param array<mixed>  $namesData
+     */
+    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): ContentAwareInterface
+    {
+        $content = $this->getContent($contentTypeIdentifier, $fieldsData, $namesData);
+
+        return new class($content) implements ContentAwareInterface {
+            private APIContent $content;
+
+            public function __construct(APIContent $content)
+            {
+                $this->content = $content;
+            }
+
+            public function getContent(): APIContent
+            {
+                return $this->content;
+            }
+        };
     }
 
     private function getTemplatePath($tpl)

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
@@ -135,10 +135,8 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
     /**
      * @param array<mixed>  $fieldsData
      * @param array<mixed>  $namesData
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): object
+    protected function getContentAwareObject(string $contentTypeIdentifier, array $fieldsData, array $namesData = []): ContentAwareInterface
     {
         $content = $this->getContent($contentTypeIdentifier, $fieldsData, $namesData);
 

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_content_field_identifier_first_filled_image.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_content_field_identifier_first_filled_image.test
@@ -1,0 +1,59 @@
+--TEST--
+"ez_content_field_identifier_first_filled_image" function
+--TEMPLATE--
+{% if not ez_content_field_identifier_first_filled_image(content) %}
+    empty
+{% else %}
+    {{ ez_content_field_identifier_first_filled_image(content) }}
+{% endif %}
+
+--DATA--
+return [
+    'content' => $this->getContent(
+         'test_content',
+         [
+            'ezimage' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'photo',
+                 'value' => 'value',
+                 'languageCode' => 'fre-FR',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+photo
+
+--DATA--
+return [
+    'content' => $this->getContent(
+         'test_content',
+         [
+            'ezstring' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'string',
+                 'value' => 'value',
+                 'languageCode' => 'fre-FR',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+empty
+
+--DATA--
+return [
+    'content' => $this->getContentAwareObject(
+         'test_content',
+         [
+            'ezimage' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'photo',
+                 'value' => 'value',
+                 'languageCode' => 'fre-FR',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+photo

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field.test
@@ -47,3 +47,21 @@ return array(
 --EXPECT--
 foo2
 bar3
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    )
+)
+--EXPECT--
+foo2
+foo2

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field_description.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field_description.test
@@ -47,3 +47,25 @@ return array(
 --EXPECT--
 American description
 British description
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR',
+                'fieldDefDescriptions' => array(
+                    'eng-US' => 'American description',
+                    'fre-FR' => 'French description',
+                )
+            )
+        )
+    )
+)
+--EXPECT--
+French description
+French description

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field_name.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field_name.test
@@ -47,3 +47,25 @@ return array(
 --EXPECT--
 American name
 British name
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR',
+                'fieldDefNames' => array(
+                    'eng-US' => 'American name',
+                    'fre-FR' => 'French name',
+                )
+            )
+        )
+    )
+)
+--EXPECT--
+French name
+French name

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field_value.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_field_value.test
@@ -47,3 +47,21 @@ return array(
 --EXPECT--
 foo2
 bar3
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    )
+)
+--EXPECT--
+foo2
+foo2

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_is_field_empty.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ez_is_field_empty.test
@@ -78,3 +78,21 @@ return array(
 )
 --EXPECT--
 empty
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'data',
+        array(
+            'ezdata' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    ),
+    'field' => $this->getField( false )->fieldDefIdentifier
+)
+--EXPECT--
+not empty

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_content_field_identifier_first_filled_image.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_content_field_identifier_first_filled_image.test
@@ -1,0 +1,59 @@
+--TEST--
+"ibexa_content_field_identifier_first_filled_image" function
+--TEMPLATE--
+{% if not ibexa_content_field_identifier_first_filled_image(content) %}
+    empty
+{% else %}
+    {{ ibexa_content_field_identifier_first_filled_image(content) }}
+{% endif %}
+
+--DATA--
+return [
+    'content' => $this->getContent(
+         'test_content',
+         [
+            'ezimage' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'photo',
+                 'value' => 'value',
+                 'languageCode' => 'fre-FR',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+photo
+
+--DATA--
+return [
+    'content' => $this->getContent(
+         'test_content',
+         [
+            'ezstring' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'string',
+                 'value' => 'value',
+                 'languageCode' => 'fre-FR',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+empty
+
+--DATA--
+return [
+    'content' => $this->getContentAwareObject(
+         'test_content',
+         [
+            'ezimage' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'photo',
+                 'value' => 'value',
+                 'languageCode' => 'fre-FR',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+photo

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_content_name.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_content_name.test
@@ -21,6 +21,21 @@ French
 
 --DATA--
 return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(),
+        array(
+            'eng-US' => 'American',
+            'fre-FR' => 'French'
+        )
+    )
+)
+--EXPECT--
+French
+French
+
+--DATA--
+return array(
     'content' => $this->getContent(
         'article',
         array(),

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field.test
@@ -47,3 +47,21 @@ return array(
 --EXPECT--
 foo2
 bar3
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    )
+)
+--EXPECT--
+foo2
+foo2

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_description.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_description.test
@@ -1,4 +1,5 @@
 --TEST--
+
 "ibexa_field_description" function
 --TEMPLATE--
 {{ ibexa_field_description( content, 'testfield' ) }}
@@ -47,3 +48,25 @@ return array(
 --EXPECT--
 American description
 British description
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR',
+                'fieldDefDescriptions' => array(
+                    'eng-US' => 'American description',
+                    'fre-FR' => 'French description',
+                )
+            )
+        )
+    )
+)
+--EXPECT--
+French description
+French description

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_name.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_name.test
@@ -47,3 +47,25 @@ return array(
 --EXPECT--
 American name
 British name
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR',
+                'fieldDefNames' => array(
+                    'eng-US' => 'American name',
+                    'fre-FR' => 'French name',
+                )
+            )
+        )
+    )
+)
+--EXPECT--
+French name
+French name

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_value.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_field_value.test
@@ -47,3 +47,21 @@ return array(
 --EXPECT--
 foo2
 bar3
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'article',
+        array(
+            'ezstring' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    )
+)
+--EXPECT--
+foo2
+foo2

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_has_field.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_has_field.test
@@ -21,3 +21,21 @@ return [
 --EXPECT--
 YES
 NO
+
+--DATA--
+return [
+    'content' => $this->getContentAwareObject(
+         'test_content',
+         [
+            'ezstring' => [
+                 'id' => 125,
+                 'fieldDefIdentifier' => 'existing',
+                 'value' => 'value',
+                 'languageCode' => 'eng-GB',
+            ],
+         ]
+     ),
+];
+--EXPECT--
+YES
+NO

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_is_field_empty.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/content_functions/ibexa_is_field_empty.test
@@ -78,3 +78,21 @@ return array(
 )
 --EXPECT--
 empty
+
+--DATA--
+return array(
+    'content' => $this->getContentAwareObject(
+        'data',
+        array(
+            'ezdata' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    ),
+    'field' => $this->getField( false )->fieldDefIdentifier
+)
+--EXPECT--
+not empty

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field.test
@@ -4,7 +4,7 @@
 {% extends 'templates/base.html.twig' %}
 {% block content %}
 {{ ez_render_field( nooverride, 'testfield' ) }}
-{{ ibexa_render_field( contentaware, 'testfield' ) }}
+{{ ez_render_field( contentaware, 'testfield' ) }}
 {{ ez_render_field( overrides, 'testfield' ) }}
 {{ ez_render_field( notdefault, 'testfield' ) }}
 {{ ez_render_field( data, 'testfield' ) }}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field.test
@@ -4,6 +4,7 @@
 {% extends 'templates/base.html.twig' %}
 {% block content %}
 {{ ez_render_field( nooverride, 'testfield' ) }}
+{{ ibexa_render_field( contentaware, 'testfield' ) }}
 {{ ez_render_field( overrides, 'testfield' ) }}
 {{ ez_render_field( notdefault, 'testfield' ) }}
 {{ ez_render_field( data, 'testfield' ) }}
@@ -26,6 +27,17 @@ return array(
             ),
         )
     ),
+    'contentaware' => $this->getContentAwareObject(
+            'contentaware',
+            array(
+                     'eznooverride' => array(
+                         'id' => 2,
+                         'fieldDefIdentifier' => 'testfield',
+                         'value' => 'foo2',
+                         'languageCode' => 'fre-FR'
+                     ),
+                 )
+             ),
     'overrides' => $this->getContent(
         'overrides',
         array(
@@ -62,6 +74,7 @@ return array(
 
 )
 --EXPECT--
+default (no override)
 default (no override)
 override2
 not default

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/field_rendering_functions/ibexa_render_field.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/field_rendering_functions/ibexa_render_field.test
@@ -4,6 +4,7 @@
 {% extends 'templates/base.html.twig' %}
 {% block content %}
 {{ ibexa_render_field( nooverride, 'testfield' ) }}
+{{ ibexa_render_field( contentaware, 'testfield' ) }}
 {{ ibexa_render_field( overrides, 'testfield' ) }}
 {{ ibexa_render_field( notdefault, 'testfield' ) }}
 {{ ibexa_render_field( data, 'testfield' ) }}
@@ -26,6 +27,17 @@ return array(
             ),
         )
     ),
+    'contentaware' => $this->getContentAwareObject(
+        'contentaware',
+        array(
+                 'eznooverride' => array(
+                     'id' => 2,
+                     'fieldDefIdentifier' => 'testfield',
+                     'value' => 'foo2',
+                     'languageCode' => 'fre-FR'
+                 ),
+             )
+         ),
     'overrides' => $this->getContent(
         'overrides',
         array(
@@ -62,6 +74,7 @@ return array(
 
 )
 --EXPECT--
+default (no override)
 default (no override)
 override2
 not default


### PR DESCRIPTION
| :ticket: Issue | IBX-9415 |
|----------------|-----------|


#### Related PRs: 

- https://github.com/ibexa/taxonomy/pull/313
- https://github.com/ibexa/seo/pull/38

#### Description:

Added support for ContentAwareInterface objects (e.g. product) to following Twing functions

- ibexa_render_field
- ibexa_field_value - core
- ibexa_field
- ibexa_field_name
- ibexa_field_description
- ibexa_field_is_empty
- ibexa_has_field
- ibexa_content_field_identifier_first_filled_image
- ibexa_content_name
- ibexa_render_content 


#### For QA:
It needs to be chcked if all theses functions can instead of `content` as a first argument also work with for example `product`

#### Documentation:
Docs for all theses functions should be changed that they are working also with ContentAwareInterfaced objects


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
