### PR TITLE
IBX-9421: Fixed global `@serializer` service overwriting Ibexa serializer variant

### DIFF
--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -26,9 +26,7 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer:
-        tags:
-            - { name: serializer.normalizer }
+    Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer: ~
 
     Ibexa\Core\MVC\Symfony\Routing\Generator:
         class: Ibexa\Core\MVC\Symfony\Routing\Generator

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -26,7 +26,8 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer: ~
+    Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer:
+        autoconfigure: false
 
     Ibexa\Core\MVC\Symfony\Routing\Generator:
         class: Ibexa\Core\MVC\Symfony\Routing\Generator


### PR DESCRIPTION
| :ticket: Issue | IBX-9421 |
|----------------|-----------|

#### Description:
The problem here stems from `Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer` being erroneously tagged with `serializer.normalizer` tag, which means that once the global `@serializer` service is initialized (e.g. when used in a listener as outlined in the issue description), the Ibexa variant of the serializer which was injected into `CompoundMatcherNormalizer` will be overwritten by the global instance, causing the problem described in the issue.