### PR TITLE
IBX-9421: Removed tag for CompoundMatcherNormalizer

### DIFF
--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -27,8 +27,7 @@ services:
             - { name: kernel.event_subscriber }
 
     Ibexa\Core\MVC\Symfony\Component\Serializer\CompoundMatcherNormalizer:
-        tags:
-            - { name: serializer.normalizer }
+        autoconfigure: false
 
     Ibexa\Core\MVC\Symfony\Routing\Generator:
         class: Ibexa\Core\MVC\Symfony\Routing\Generator


### PR DESCRIPTION
| :ticket: Issue | IBX-9421 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
I have removed tag for CompoundMatcherNormalizer to prevent a scenario where our normalizer could be overwritten by a third-party vendor which would result in a incorrectly generated URLs. 

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
