### PR TITLE
IBX-9513: Fixed obsolete `ibexa_*` Controller references

### DIFF
--- a/src/bundle/Core/Features/QueryController/setup.feature
+++ b/src/bundle/Core/Features/QueryController/setup.feature
@@ -21,7 +21,7 @@ Feature: Query controller
                 template: "@IbexaBehat/tests/dump.html.twig"
                 match:
                     Id\Location: "%location_id(QueryControllerContainer/QueryControllerItem1)%"
-                controller: ibexa_query:locationQueryAction
+                controller: ibexa_query::locationQueryAction
                 params:
                     query:
                         query_type: 'LocationChildren'
@@ -32,7 +32,7 @@ Feature: Query controller
                 template: "@IbexaBehat/tests/dump.html.twig"
                 match:
                     Id\Location: "%location_id(QueryControllerContainer/QueryControllerItem2)%"
-                controller: ibexa_query:pagingQueryAction
+                controller: ibexa_query::pagingQueryAction
                 params:
                     query:
                         query_type: 'LocationChildren'
@@ -43,7 +43,7 @@ Feature: Query controller
                 template: tests.html.twig
                 match:
                     Id\Location: "%location_id(QueryControllerContainer/QueryControllerItem3)%"
-                controller: ibexa_query:pagingQueryAction
+                controller: ibexa_query::pagingQueryAction
                 params:
                     query:
                         query_type: 'LocationChildren'
@@ -55,7 +55,7 @@ Feature: Query controller
                 template: tests.html.twig
                 match:
                     Id\Location: "%location_id(QueryControllerContainer/QueryControllerItem4)%"
-                controller: ibexa_query:pagingQueryAction
+                controller: ibexa_query::pagingQueryAction
                 params:
                     query:
                         query_type: 'LocationChildren'

--- a/src/bundle/Core/Resources/views/content_fields.html.twig
+++ b/src/bundle/Core/Resources/views/content_fields.html.twig
@@ -460,7 +460,7 @@
     {% apply spaceless %}
         {% if not ibexa_field_is_empty(content, field) and parameters.available %}
             <div {{ block('field_attributes') }}>
-                {{ render(controller('ibexa_content:embedAction', {
+                {{ render(controller('ibexa_content::embedAction', {
                     contentId: field.value.destinationContentId,
                     viewType: 'asset_image',
                     no_layout: true,

--- a/src/lib/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/src/lib/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -285,7 +285,7 @@ class ContentViewBuilder implements ViewBuilder
      */
     private function isEmbed($parameters): bool
     {
-        if ($parameters['_controller'] === 'ibexa_content:embedAction') {
+        if ($parameters['_controller'] === 'ibexa_content::embedAction') {
             return true;
         }
         if (\in_array($parameters['viewType'], ['embed', 'embed-inline'])) {

--- a/tests/lib/MVC/Symfony/View/Builder/ContentViewBuilderTest.php
+++ b/tests/lib/MVC/Symfony/View/Builder/ContentViewBuilderTest.php
@@ -237,7 +237,7 @@ class ContentViewBuilderTest extends TestCase
 
         $parameters = [
             'viewType' => 'embed',
-            '_controller' => 'ibexa_content:embedAction',
+            '_controller' => 'ibexa_content::embedAction',
             'contentId' => $contentId,
         ];
 
@@ -273,7 +273,7 @@ class ContentViewBuilderTest extends TestCase
 
         $parameters = [
             'viewType' => 'embed',
-            '_controller' => 'ez_content:embedAction',
+            '_controller' => 'ibexa_content::embedAction',
             'contentId' => $contentId,
         ];
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9513 |
|----------------|-----------|


#### Related PRs: 
- [x] https://github.com/ibexa/core/pull/447
- [x] https://github.com/ibexa/fieldtype-query/pull/35
- [x] https://github.com/ibexa/http-cache/pull/56
- [x] https://github.com/ibexa/fieldtype-richtext/pull/205
- [x] https://github.com/ibexa/connector-dam/pull/66
- [x] https://github.com/ibexa/fieldtype-page/pull/150
- [x] https://github.com/ibexa/form-builder/pull/158
- [x] https://github.com/ibexa/product-catalog/pull/1236
- [x] https://github.com/ibexa/segmentation/pull/114
- [x] https://github.com/ibexa/storefront/pull/187

#### Description:

I found some old references to `ibexa_content` and `ibexa_query` controllers using single colon notation


#### For QA:

Probably not reproducible on fullstack app, as content fields are overridden by AdminUI.

Behat Query Controller tests should not fail.