### PR TITLE
IBX-6773: Fixed loading Bookmarks for non-accessible content items

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17707,6 +17707,12 @@ parameters:
 			path: src/lib/Persistence/Cache/UserPreferenceHandler.php
 
 		-
+			message: '#^Return type \(Doctrine\\ORM\\Mapping\\ClassMetadataFactory\) of method Ibexa\\Core\\Persistence\\Doctrine\\SiteAccessAwareEntityManager\:\:getMetadataFactory\(\) should be compatible with return type \(Doctrine\\Persistence\\Mapping\\ClassMetadataFactory\<Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\>\) of method Doctrine\\Persistence\\ObjectManager\:\:getMetadataFactory\(\)$#'
+			identifier: method.childReturnType
+			count: 2
+			path: src/lib/Persistence/Doctrine/SiteAccessAwareEntityManager.php
+
+		-
 			message: '#^Property Ibexa\\Core\\Persistence\\FieldTypeRegistry\:\:\$coreFieldTypes \(array\<Ibexa\\Contracts\\Core\\FieldType\\FieldType\>\) does not accept array\<Ibexa\\Core\\Persistence\\FieldType\>\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -25343,12 +25349,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Repository/TrashService.php
-
-		-
-			message: '#^Class Ibexa\\Contracts\\Core\\Persistence\\Content\\UrlAlias referenced with incorrect case\: Ibexa\\Contracts\\Core\\Persistence\\Content\\URLAlias\.$#'
-			identifier: class.nameCase
-			count: 2
-			path: src/lib/Repository/URLAliasService.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Repository\\URLAliasService\:\:choosePrioritizedLanguageCode\(\) has parameter \$entries with no value type specified in iterable type array\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17707,12 +17707,6 @@ parameters:
 			path: src/lib/Persistence/Cache/UserPreferenceHandler.php
 
 		-
-			message: '#^Return type \(Doctrine\\ORM\\Mapping\\ClassMetadataFactory\) of method Ibexa\\Core\\Persistence\\Doctrine\\SiteAccessAwareEntityManager\:\:getMetadataFactory\(\) should be compatible with return type \(Doctrine\\Persistence\\Mapping\\ClassMetadataFactory\<Doctrine\\Persistence\\Mapping\\ClassMetadata\<object\>\>\) of method Doctrine\\Persistence\\ObjectManager\:\:getMetadataFactory\(\)$#'
-			identifier: method.childReturnType
-			count: 2
-			path: src/lib/Persistence/Doctrine/SiteAccessAwareEntityManager.php
-
-		-
 			message: '#^Property Ibexa\\Core\\Persistence\\FieldTypeRegistry\:\:\$coreFieldTypes \(array\<Ibexa\\Contracts\\Core\\FieldType\\FieldType\>\) does not accept array\<Ibexa\\Core\\Persistence\\FieldType\>\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -25366,6 +25360,12 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Repository/TrashService.php
+
+		-
+			message: '#^Class Ibexa\\Contracts\\Core\\Persistence\\Content\\UrlAlias referenced with incorrect case\: Ibexa\\Contracts\\Core\\Persistence\\Content\\URLAlias\.$#'
+			identifier: class.nameCase
+			count: 2
+			path: src/lib/Repository/URLAliasService.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Repository\\URLAliasService\:\:choosePrioritizedLanguageCode\(\) has parameter \$entries with no value type specified in iterable type array\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -22306,12 +22306,6 @@ parameters:
 			message: '#^PHPDoc tag @var with type Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\SortClause is not subtype of native type Ibexa\\Contracts\\Core\\Repository\\Values\\Filter\\FilteringSortClause\.$#'
 			identifier: varTag.nativeType
 			count: 1
-			path: src/lib/Persistence/Legacy/Filter/SortClauseQueryBuilder/Bookmark/IdSortClauseQueryBuilder.php
-
-		-
-			message: '#^PHPDoc tag @var with type Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\SortClause is not subtype of native type Ibexa\\Contracts\\Core\\Repository\\Values\\Filter\\FilteringSortClause\.$#'
-			identifier: varTag.nativeType
-			count: 1
 			path: src/lib/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/DateModifiedSortClauseQueryBuilder.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32257,12 +32257,6 @@ parameters:
 			path: tests/integration/Core/Repository/BaseURLServiceTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Bookmark\\\\BookmarkList'' and Ibexa\\Contracts\\Core\\Repository\\Values\\Bookmark\\BookmarkList will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/integration/Core/Repository/BookmarkServiceTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Repository\\BookmarkServiceTest\:\:testCreateBookmark\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21889,6 +21889,17 @@ parameters:
 			path: src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/DepthQueryBuilder.php
 
 		-
+			message: "#^Cannot access offset 0 on array\\<bool\\|float\\|int\\|string\\>\\|bool\\|float\\|int\\|string\\.$#"
+			count: 1
+			path: src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+
+		-
+			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Filter\\CriterionQueryBuilder\\Location\\BookmarkQueryBuilder\:\:buildQueryConstraint\(\) never returns null so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+
+		-
 			message: '#^Parameter \#2 \$criterionValue of method Ibexa\\Contracts\\Core\\Persistence\\Filter\\Doctrine\\FilteringQueryBuilder\:\:buildOperatorBasedCriterionConstraint\(\) expects array, array\<bool\|float\|int\|string\>\|bool\|float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -22307,6 +22318,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/lib/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
+
+		-
+			message: '#^PHPDoc tag @var with type Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\SortClause is not subtype of native type Ibexa\\Contracts\\Core\\Repository\\Values\\Filter\\FilteringSortClause\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: src/lib/Persistence/Legacy/Filter/SortClauseQueryBuilder/Bookmark/IdSortClauseQueryBuilder.php
 
 		-
 			message: '#^PHPDoc tag @var with type Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query\\SortClause is not subtype of native type Ibexa\\Contracts\\Core\\Repository\\Values\\Filter\\FilteringSortClause\.$#'
@@ -69566,12 +69583,6 @@ parameters:
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Service\\Mock\\BookmarkTest\:\:testLoadBookmarks\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Service/Mock/BookmarkTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Service\\Mock\\BookmarkTest\:\:testLoadBookmarksEmptyList\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: tests/lib/Repository/Service/Mock/BookmarkTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21883,17 +21883,6 @@ parameters:
 			path: src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/DepthQueryBuilder.php
 
 		-
-			message: "#^Cannot access offset 0 on array\\<bool\\|float\\|int\\|string\\>\\|bool\\|float\\|int\\|string\\.$#"
-			count: 1
-			path: src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Filter\\CriterionQueryBuilder\\Location\\BookmarkQueryBuilder\:\:buildQueryConstraint\(\) never returns null so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
-
-		-
 			message: '#^Parameter \#2 \$criterionValue of method Ibexa\\Contracts\\Core\\Persistence\\Filter\\Doctrine\\FilteringQueryBuilder\:\:buildOperatorBasedCriterionConstraint\(\) expects array, array\<bool\|float\|int\|string\>\|bool\|float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/contracts/Persistence/Bookmark/Handler.php
+++ b/src/contracts/Persistence/Bookmark/Handler.php
@@ -50,6 +50,8 @@ interface Handler
     /**
      * Loads bookmarks owned by user.
      *
+     * @deprecated The "Handler::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     *
      * @param int $userId
      * @param int $offset the start offset for paging
      * @param int $limit the number of bookmarked locations returned
@@ -60,6 +62,8 @@ interface Handler
 
     /**
      * Count bookmarks owned by user.
+     *
+     * @deprecated The "Handler::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
      *
      * @param int $userId
      *

--- a/src/contracts/Persistence/Bookmark/Handler.php
+++ b/src/contracts/Persistence/Bookmark/Handler.php
@@ -50,7 +50,7 @@ interface Handler
     /**
      * Loads bookmarks owned by user.
      *
-     * @deprecated The "Handler::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     * @deprecated 4.6.30 The "Handler::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
      *
      * @param int $userId
      * @param int $offset the start offset for paging
@@ -63,7 +63,7 @@ interface Handler
     /**
      * Count bookmarks owned by user.
      *
-     * @deprecated The "Handler::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
+     * @deprecated 4.6.30 The "Handler::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
      *
      * @param int $userId
      *

--- a/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
+
+/**
+ * A criterion that matches locations of bookmarks for a given user id.
+ *
+ * Supported operators:
+ * - EQ: matches against a unique user id
+ */
+final class IsBookmarked extends Criterion implements FilteringCriterion
+{
+    /**
+     * Creates a new IsBookmarked criterion.
+     *
+     * @param int $value user id for which bookmarked locations must be matched against
+     *
+     * @throws \InvalidArgumentException if a non numeric id is given
+     * @throws \InvalidArgumentException if the value type doesn't match the operator
+     */
+    public function __construct($value)
+    {
+        parent::__construct(null, null, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+        ];
+    }
+}

--- a/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
@@ -9,12 +9,16 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications;
 use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
 
 /**
  * A criterion that matches locations of bookmarks for a given user id.
+ *
+ * Supported operators:
+ * - EQ: matches against a unique user id
  */
-final class IsBookmarked implements FilteringCriterion
+final class IsBookmarked extends Criterion implements FilteringCriterion
 {
     public bool $isBookmarked = true;
 
@@ -26,5 +30,12 @@ final class IsBookmarked implements FilteringCriterion
     ) {
         $this->isBookmarked = $isBookmarked;
         $this->userId = $userId;
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+        ];
     }
 }

--- a/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
@@ -17,7 +17,8 @@ use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
 final class IsBookmarked implements FilteringCriterion
 {
     public function __construct(
-        public readonly int $value
+        readonly bool $isBookmarked = true,
+        readonly ?int $userId = null,
     ) {
     }
 }

--- a/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
@@ -20,15 +20,7 @@ use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
  */
 final class IsBookmarked extends Criterion implements FilteringCriterion
 {
-    /**
-     * Creates a new IsBookmarked criterion.
-     *
-     * @param int $value user id for which bookmarked locations must be matched against
-     *
-     * @throws \InvalidArgumentException if a non numeric id is given
-     * @throws \InvalidArgumentException if the value type doesn't match the operator
-     */
-    public function __construct($value)
+    public function __construct(int $value)
     {
         parent::__construct(null, null, $value);
     }

--- a/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
@@ -9,26 +9,15 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
-use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications;
 use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
 
 /**
  * A criterion that matches locations of bookmarks for a given user id.
- *
- * Supported operators:
- * - EQ: matches against a unique user id
  */
-final class IsBookmarked extends Criterion implements FilteringCriterion
+final class IsBookmarked implements FilteringCriterion
 {
-    public function __construct(int $value)
-    {
-        parent::__construct(null, null, $value);
-    }
-
-    public function getSpecifications(): array
-    {
-        return [
-            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
-        ];
+    public function __construct(
+        public readonly int $value
+    ) {
     }
 }

--- a/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
@@ -16,9 +16,15 @@ use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
  */
 final class IsBookmarked implements FilteringCriterion
 {
+    public bool $isBookmarked = true;
+
+    public ?int $userId = null;
+
     public function __construct(
-        readonly bool $isBookmarked = true,
-        readonly ?int $userId = null,
+        bool $isBookmarked = true,
+        ?int $userId = null,
     ) {
+        $this->isBookmarked = $isBookmarked;
+        $this->userId = $userId;
     }
 }

--- a/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/IsBookmarked.php
@@ -20,22 +20,20 @@ use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
  */
 final class IsBookmarked extends Criterion implements FilteringCriterion
 {
-    public bool $isBookmarked = true;
-
     public ?int $userId = null;
 
     public function __construct(
         bool $isBookmarked = true,
-        ?int $userId = null,
+        ?int $userId = null
     ) {
-        $this->isBookmarked = $isBookmarked;
         $this->userId = $userId;
+        parent::__construct(null, null, $isBookmarked);
     }
 
     public function getSpecifications(): array
     {
         return [
-            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_INTEGER),
+            new Specifications(Operator::EQ, Specifications::FORMAT_SINGLE, Specifications::TYPE_BOOLEAN),
         ];
     }
 }

--- a/src/contracts/Repository/Values/Content/Query/SortClause/BookmarkId.php
+++ b/src/contracts/Repository/Values/Content/Query/SortClause/BookmarkId.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause;
+use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringSortClause;
+
+/**
+ * Sets sort direction on the bookmark id for a location query containing IsBookmarked criterion.
+ */
+final class BookmarkId extends SortClause implements FilteringSortClause
+{
+    public function __construct(string $sortDirection = Query::SORT_ASC)
+    {
+        parent::__construct('id', $sortDirection);
+    }
+}

--- a/src/lib/Persistence/Cache/BookmarkHandler.php
+++ b/src/lib/Persistence/Cache/BookmarkHandler.php
@@ -83,8 +83,6 @@ class BookmarkHandler extends AbstractHandler implements BookmarkHandlerInterfac
     }
 
     /**
-     * @deprecated The "BookmarkHandler::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
-     *
      * {@inheritdoc}
      */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
@@ -99,8 +97,6 @@ class BookmarkHandler extends AbstractHandler implements BookmarkHandlerInterfac
     }
 
     /**
-     * @deprecated The "BookmarkHandler::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
-     *
      * {@inheritdoc}
      */
     public function countUserBookmarks(int $userId): int

--- a/src/lib/Persistence/Cache/BookmarkHandler.php
+++ b/src/lib/Persistence/Cache/BookmarkHandler.php
@@ -83,6 +83,8 @@ class BookmarkHandler extends AbstractHandler implements BookmarkHandlerInterfac
     }
 
     /**
+     * @deprecated The "BookmarkHandler::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     *
      * {@inheritdoc}
      */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
@@ -97,6 +99,8 @@ class BookmarkHandler extends AbstractHandler implements BookmarkHandlerInterfac
     }
 
     /**
+     * @deprecated The "BookmarkHandler::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
+     *
      * {@inheritdoc}
      */
     public function countUserBookmarks(int $userId): int

--- a/src/lib/Persistence/Legacy/Bookmark/Gateway.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Gateway.php
@@ -52,6 +52,8 @@ abstract class Gateway
     /**
      * Load data for all bookmarks owned by given $userId.
      *
+     * @deprecated Gateway::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     *
      * @param int $userId ID of user
      * @param int $offset Offset to start listing from, 0 by default
      * @param int $limit Limit for the listing. -1 by default (no limit)
@@ -62,6 +64,8 @@ abstract class Gateway
 
     /**
      * Count bookmarks owned by given $userId.
+     *
+     * @deprecated The "Gateway::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
      *
      * @param int $userId ID of user
      *

--- a/src/lib/Persistence/Legacy/Bookmark/Gateway.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Gateway.php
@@ -52,7 +52,7 @@ abstract class Gateway
     /**
      * Load data for all bookmarks owned by given $userId.
      *
-     * @deprecated Gateway::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     * @deprecated 4.6.30 Gateway::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
      *
      * @param int $userId ID of user
      * @param int $offset Offset to start listing from, 0 by default
@@ -65,7 +65,7 @@ abstract class Gateway
     /**
      * Count bookmarks owned by given $userId.
      *
-     * @deprecated The "Gateway::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
+     * @deprecated 4.6.30 The "Gateway::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
      *
      * @param int $userId ID of user
      *

--- a/src/lib/Persistence/Legacy/Bookmark/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Gateway/DoctrineDatabase.php
@@ -124,6 +124,8 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
+     * @deprecated The "DoctrineDatabase::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     *
      * {@inheritdoc}
      */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
@@ -146,6 +148,8 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
+     * @deprecated The "DoctrineDatabase::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
+     *
      * {@inheritdoc}
      */
     public function countUserBookmarks(int $userId): int

--- a/src/lib/Persistence/Legacy/Bookmark/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Gateway/DoctrineDatabase.php
@@ -124,8 +124,6 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * @deprecated The "DoctrineDatabase::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
-     *
      * {@inheritdoc}
      */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
@@ -148,8 +146,6 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * @deprecated The "DoctrineDatabase::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
-     *
      * {@inheritdoc}
      */
     public function countUserBookmarks(int $userId): int

--- a/src/lib/Persistence/Legacy/Bookmark/Gateway/ExceptionConversion.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Gateway/ExceptionConversion.php
@@ -57,11 +57,6 @@ class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * @deprecated The "ExceptionConversion::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
-     *
-     * @return array
-     */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
     {
         try {
@@ -71,9 +66,6 @@ class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * @deprecated The "ExceptionConversion::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
-     */
     public function countUserBookmarks(int $userId): int
     {
         try {

--- a/src/lib/Persistence/Legacy/Bookmark/Gateway/ExceptionConversion.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Gateway/ExceptionConversion.php
@@ -57,6 +57,11 @@ class ExceptionConversion extends Gateway
         }
     }
 
+    /**
+     * @deprecated The "ExceptionConversion::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     *
+     * @return array
+     */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
     {
         try {
@@ -66,6 +71,9 @@ class ExceptionConversion extends Gateway
         }
     }
 
+    /**
+     * @deprecated The "ExceptionConversion::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
+     */
     public function countUserBookmarks(int $userId): int
     {
         try {

--- a/src/lib/Persistence/Legacy/Bookmark/Handler.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Handler.php
@@ -75,6 +75,8 @@ class Handler implements HandlerInterface
     }
 
     /**
+     * @deprecated The "Handler::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
+     *
      * {@inheritdoc}
      */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
@@ -85,6 +87,8 @@ class Handler implements HandlerInterface
     }
 
     /**
+     * @deprecated The "Handler::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
+     *
      * {@inheritdoc}
      */
     public function countUserBookmarks(int $userId): int

--- a/src/lib/Persistence/Legacy/Bookmark/Handler.php
+++ b/src/lib/Persistence/Legacy/Bookmark/Handler.php
@@ -75,8 +75,6 @@ class Handler implements HandlerInterface
     }
 
     /**
-     * @deprecated The "Handler::loadUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::find()" and "Criterion\IsBookmarked" instead.
-     *
      * {@inheritdoc}
      */
     public function loadUserBookmarks(int $userId, int $offset = 0, int $limit = -1): array
@@ -87,8 +85,6 @@ class Handler implements HandlerInterface
     }
 
     /**
-     * @deprecated The "Handler::countUserBookmarks()" method is deprecated, will be removed in 6.0.0. Use "LocationService::count()" and "Criterion\IsBookmarked" instead.
-     *
      * {@inheritdoc}
      */
     public function countUserBookmarks(int $userId): int

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Location;
+
+use Doctrine\DBAL\ParameterType;
+use Ibexa\Contracts\Core\Persistence\Filter\Doctrine\FilteringQueryBuilder;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked;
+use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
+use Ibexa\Core\Persistence\Legacy\Bookmark\Gateway\DoctrineDatabase;
+
+/**
+ * @internal for internal use by Repository Filtering
+ */
+final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
+{
+    public function accepts(FilteringCriterion $criterion): bool
+    {
+        return $criterion instanceof IsBookmarked;
+    }
+
+    public function buildQueryConstraint(
+        FilteringQueryBuilder $queryBuilder,
+        FilteringCriterion $criterion
+    ): ?string {
+        $queryBuilder
+            ->joinOnce(
+                'location',
+                DoctrineDatabase::TABLE_BOOKMARKS,
+                'bookmark',
+                'location.node_id = bookmark.node_id'
+            );
+
+        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked $criterion */
+        return $queryBuilder->expr()->eq(
+            'bookmark.user_id',
+            $queryBuilder->createNamedParameter(
+                (int)$criterion->value[0],
+                ParameterType::INTEGER
+            )
+        );
+    }
+}

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -23,7 +23,6 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
     public function __construct(
         private readonly PermissionResolver $permissionResolver,
     ) {
-
     }
 
     public function accepts(FilteringCriterion $criterion): bool
@@ -39,7 +38,7 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
         $isBookmarked = $criterion->isBookmarked;
         $userId = $criterion->userId ?? $this->permissionResolver->getCurrentUserReference()->getUserId();
 
-        if ( $isBookmarked ) {
+        if ($isBookmarked) {
             $queryBuilder
                 ->joinOnce(
                     'location',

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -27,7 +27,7 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
     public function buildQueryConstraint(
         FilteringQueryBuilder $queryBuilder,
         FilteringCriterion $criterion
-    ): ?string {
+    ): string {
         $queryBuilder
             ->joinOnce(
                 'location',
@@ -37,10 +37,19 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
             );
 
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked $criterion */
+        $value = $criterion->value;
+
+        if (\is_array($value)) {
+            if (!isset($value[0])) {
+                throw new \InvalidArgumentException('IsBookmarked criterion value must contain userId at index 0.');
+            }
+            $value = $value[0];
+        }
+
         return $queryBuilder->expr()->eq(
             'bookmark.user_id',
             $queryBuilder->createNamedParameter(
-                (int)$criterion->value[0],
+                (int)$value,
                 ParameterType::INTEGER
             )
         );

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -38,7 +38,7 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
         FilteringCriterion $criterion
     ): string {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked $criterion */
-        $isBookmarked = $criterion->value;
+        $isBookmarked = $criterion->value[0];
         $userId = $criterion->userId ?? $this->permissionResolver->getCurrentUserReference()->getUserId();
 
         if ($isBookmarked) {

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -20,9 +20,12 @@ use Ibexa\Core\Repository\Permission\PermissionResolver;
  */
 final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
 {
+    private PermissionResolver $permissionResolver;
+
     public function __construct(
-        private readonly PermissionResolver $permissionResolver,
+        PermissionResolver $permissionResolver
     ) {
+        $this->permissionResolver = $permissionResolver;
     }
 
     public function accepts(FilteringCriterion $criterion): bool

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -35,7 +35,7 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
         FilteringCriterion $criterion
     ): string {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked $criterion */
-        $isBookmarked = $criterion->isBookmarked;
+        $isBookmarked = $criterion->value;
         $userId = $criterion->userId ?? $this->permissionResolver->getCurrentUserReference()->getUserId();
 
         if ($isBookmarked) {

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -13,12 +13,19 @@ use Ibexa\Contracts\Core\Persistence\Filter\Doctrine\FilteringQueryBuilder;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked;
 use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
 use Ibexa\Core\Persistence\Legacy\Bookmark\Gateway\DoctrineDatabase;
+use Ibexa\Core\Repository\Permission\PermissionResolver;
 
 /**
  * @internal for internal use by Repository Filtering
  */
 final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
 {
+    public function __construct(
+        private readonly PermissionResolver $permissionResolver,
+    ) {
+
+    }
+
     public function accepts(FilteringCriterion $criterion): bool
     {
         return $criterion instanceof IsBookmarked;
@@ -28,30 +35,37 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
         FilteringQueryBuilder $queryBuilder,
         FilteringCriterion $criterion
     ): string {
-        $queryBuilder
-            ->joinOnce(
-                'location',
-                DoctrineDatabase::TABLE_BOOKMARKS,
-                'bookmark',
-                'location.node_id = bookmark.node_id'
-            );
-
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked $criterion */
-        $value = $criterion->value;
+        $isBookmarked = $criterion->isBookmarked;
+        $userId = $criterion->userId ?? $this->permissionResolver->getCurrentUserReference()->getUserId();
 
-        if (\is_array($value)) {
-            if (!isset($value[0])) {
-                throw new \InvalidArgumentException('IsBookmarked criterion value must contain userId at index 0.');
-            }
-            $value = $value[0];
+        if ( $isBookmarked ) {
+            $queryBuilder
+                ->joinOnce(
+                    'location',
+                    DoctrineDatabase::TABLE_BOOKMARKS,
+                    'bookmark',
+                    'location.node_id = bookmark.node_id'
+                );
+
+            return $queryBuilder->expr()->eq(
+                'bookmark.user_id',
+                $queryBuilder->createNamedParameter(
+                    $userId,
+                    ParameterType::INTEGER
+                )
+            );
+        } else {
+            $queryBuilder
+                ->leftJoinOnce(
+                    'location',
+                    DoctrineDatabase::TABLE_BOOKMARKS,
+                    'bookmark',
+                    'location.node_id = bookmark.node_id AND bookmark.user_id = :userId'
+                )
+            ->setParameter('userId', $userId);
+
+            return $queryBuilder->expr()->isNull('bookmark.id');
         }
-
-        return $queryBuilder->expr()->eq(
-            'bookmark.user_id',
-            $queryBuilder->createNamedParameter(
-                (int)$value,
-                ParameterType::INTEGER
-            )
-        );
     }
 }

--- a/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilder.php
@@ -38,7 +38,10 @@ final class BookmarkQueryBuilder extends BaseLocationCriterionQueryBuilder
         FilteringCriterion $criterion
     ): string {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\IsBookmarked $criterion */
-        $isBookmarked = $criterion->value[0];
+        $isBookmarked = $criterion->value[0] ?? null;
+        if (!is_bool($isBookmarked)) {
+            throw new \InvalidArgumentException('IsBookmarked criterion value must be boolean at index 0.');
+        }
         $userId = $criterion->userId ?? $this->permissionResolver->getCurrentUserReference()->getUserId();
 
         if ($isBookmarked) {

--- a/src/lib/Persistence/Legacy/Filter/SortClauseQueryBuilder/Bookmark/IdSortClauseQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/SortClauseQueryBuilder/Bookmark/IdSortClauseQueryBuilder.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Persistence\Legacy\Filter\SortClauseQueryBuilder\Bookmark;
+
+use Ibexa\Contracts\Core\Persistence\Filter\Doctrine\FilteringQueryBuilder;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\BookmarkId;
+use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringSortClause;
+use Ibexa\Contracts\Core\Repository\Values\Filter\SortClauseQueryBuilder;
+
+final class IdSortClauseQueryBuilder implements SortClauseQueryBuilder
+{
+    public function accepts(FilteringSortClause $sortClause): bool
+    {
+        return $sortClause instanceof BookmarkId;
+    }
+
+    public function buildQuery(
+        FilteringQueryBuilder $queryBuilder,
+        FilteringSortClause $sortClause
+    ): void {
+        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause $sortClause */
+        $queryBuilder->addSelect('bookmark.id');
+        $queryBuilder->addOrderBy('bookmark.id', $sortClause->direction);
+    }
+}

--- a/src/lib/Persistence/Legacy/Filter/SortClauseQueryBuilder/Bookmark/IdSortClauseQueryBuilder.php
+++ b/src/lib/Persistence/Legacy/Filter/SortClauseQueryBuilder/Bookmark/IdSortClauseQueryBuilder.php
@@ -24,7 +24,14 @@ final class IdSortClauseQueryBuilder implements SortClauseQueryBuilder
         FilteringQueryBuilder $queryBuilder,
         FilteringSortClause $sortClause
     ): void {
-        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause $sortClause */
+        if (!$sortClause instanceof BookmarkId) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected %s, got %s',
+                BookmarkId::class,
+                get_class($sortClause),
+            ));
+        }
+        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\BookmarkId $sortClause */
         $queryBuilder->addSelect('bookmark.id');
         $queryBuilder->addOrderBy('bookmark.id', $sortClause->direction);
     }

--- a/src/lib/Repository/BookmarkService.php
+++ b/src/lib/Repository/BookmarkService.php
@@ -102,12 +102,10 @@ class BookmarkService implements BookmarkServiceInterface
      */
     public function loadBookmarks(int $offset = 0, int $limit = 25): BookmarkList
     {
-        $currentUserId = $this->getCurrentUserId();
-
         $filter = new Filter();
         try {
             $filter
-                ->withCriterion(new Criterion\IsBookmarked($currentUserId))
+                ->withCriterion(new Criterion\IsBookmarked())
                 ->withSortClause(new SortClause\BookmarkId(Query::SORT_DESC))
                 ->sliceBy($limit, $offset);
 

--- a/src/lib/Repository/BookmarkService.php
+++ b/src/lib/Repository/BookmarkService.php
@@ -120,7 +120,7 @@ class BookmarkService implements BookmarkServiceInterface
 
         $list = new BookmarkList();
         $list->totalCount = $result->totalCount;
-        $list->items = $result->locations;
+        $list->items = iterator_to_array($result->getIterator());
 
         return $list;
     }

--- a/src/lib/Repository/BookmarkService.php
+++ b/src/lib/Repository/BookmarkService.php
@@ -38,7 +38,7 @@ class BookmarkService implements BookmarkServiceInterface
      * @param \Ibexa\Contracts\Core\Repository\Repository $repository
      * @param \Ibexa\Contracts\Core\Persistence\Bookmark\Handler $bookmarkHandler
      */
-    public function __construct(RepositoryInterface $repository, BookmarkHandler $bookmarkHandler, LoggerInterface $logger = null)
+    public function __construct(RepositoryInterface $repository, BookmarkHandler $bookmarkHandler, ?LoggerInterface $logger = null)
     {
         $this->repository = $repository;
         $this->bookmarkHandler = $bookmarkHandler;

--- a/src/lib/Repository/BookmarkService.php
+++ b/src/lib/Repository/BookmarkService.php
@@ -26,14 +26,11 @@ use Psr\Log\NullLogger;
 
 class BookmarkService implements BookmarkServiceInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    protected $repository;
+    protected RepositoryInterface $repository;
 
-    /** @var \Ibexa\Contracts\Core\Persistence\Bookmark\Handler */
-    protected $bookmarkHandler;
+    protected BookmarkHandler $bookmarkHandler;
 
-    /** @var \Psr\Log\LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * BookmarkService constructor.

--- a/src/lib/Repository/BookmarkService.php
+++ b/src/lib/Repository/BookmarkService.php
@@ -111,7 +111,7 @@ class BookmarkService implements BookmarkServiceInterface
                 ->withSortClause(new SortClause\BookmarkId(Query::SORT_DESC))
                 ->sliceBy($limit, $offset);
 
-            $result = $this->repository->getlocationService()->find($filter, []);
+            $result = $this->repository->getLocationService()->find($filter, []);
         } catch (BadStateException $e) {
             $this->logger->debug($e->getMessage(), [
                 'exception' => $e,

--- a/src/lib/Repository/Repository.php
+++ b/src/lib/Repository/Repository.php
@@ -608,7 +608,8 @@ class Repository implements RepositoryInterface
         if ($this->bookmarkService === null) {
             $this->bookmarkService = new BookmarkService(
                 $this,
-                $this->persistenceHandler->bookmarkHandler()
+                $this->persistenceHandler->bookmarkHandler(),
+                $this->logger
             );
         }
 

--- a/tests/integration/Core/Repository/BookmarkServiceTest.php
+++ b/tests/integration/Core/Repository/BookmarkServiceTest.php
@@ -145,10 +145,9 @@ class BookmarkServiceTest extends BaseTest
         $bookmarks = $repository->getBookmarkService()->loadBookmarks(1, 3);
         /* END: Use Case */
 
-        $this->assertInstanceOf(BookmarkList::class, $bookmarks);
-        $this->assertEquals($bookmarks->totalCount, 5);
+        self::assertEquals(5, $bookmarks->totalCount);
         // Assert bookmarks order: recently added should be first
-        $this->assertEquals([15, 13, 12], array_map(static function ($location) {
+        self::assertEquals([15, 13, 12], array_map(static function ($location) {
             return $location->id;
         }, $bookmarks->items));
     }
@@ -162,7 +161,7 @@ class BookmarkServiceTest extends BaseTest
             ->withCriterion(new Criterion\IsBookmarked(14));
         $count = $repository->getLocationService()->count($filter, []);
 
-        $this->assertEquals($count, 5);
+        $this->assertEquals(5, $count);
     }
 }
 

--- a/tests/integration/Core/Repository/BookmarkServiceTest.php
+++ b/tests/integration/Core/Repository/BookmarkServiceTest.php
@@ -153,9 +153,6 @@ class BookmarkServiceTest extends BaseTest
         }, $bookmarks->items));
     }
 
-    /**
-     * @covers \Ibexa\Contracts\Core\Repository\BookmarkService::loadBookmarks
-     */
     public function testCountBookmarks(): void
     {
         $repository = $this->getRepository();

--- a/tests/integration/Core/Repository/BookmarkServiceTest.php
+++ b/tests/integration/Core/Repository/BookmarkServiceTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Integration\Core\Repository;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
-use Ibexa\Contracts\Core\Repository\Values\Bookmark\BookmarkList;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Filter\Filter;
 

--- a/tests/integration/Core/Repository/BookmarkServiceTest.php
+++ b/tests/integration/Core/Repository/BookmarkServiceTest.php
@@ -157,7 +157,7 @@ class BookmarkServiceTest extends BaseTest
 
         $filter = new Filter();
         $filter
-            ->withCriterion(new Criterion\IsBookmarked(14));
+            ->withCriterion(new Criterion\IsBookmarked(true, 14));
         $count = $repository->getLocationService()->count($filter, []);
 
         self::assertEquals(5, $count);

--- a/tests/integration/Core/Repository/BookmarkServiceTest.php
+++ b/tests/integration/Core/Repository/BookmarkServiceTest.php
@@ -10,6 +10,8 @@ namespace Ibexa\Tests\Integration\Core\Repository;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\Values\Bookmark\BookmarkList;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Filter\Filter;
 
 /**
  * Test case for the BookmarkService.
@@ -149,6 +151,21 @@ class BookmarkServiceTest extends BaseTest
         $this->assertEquals([15, 13, 12], array_map(static function ($location) {
             return $location->id;
         }, $bookmarks->items));
+    }
+
+    /**
+     * @covers \Ibexa\Contracts\Core\Repository\BookmarkService::loadBookmarks
+     */
+    public function testCountBookmarks(): void
+    {
+        $repository = $this->getRepository();
+
+        $filter = new Filter();
+        $filter
+            ->withCriterion(new Criterion\IsBookmarked(14));
+        $count = $repository->getLocationService()->count($filter, []);
+
+        $this->assertEquals($count, 5);
     }
 }
 

--- a/tests/integration/Core/Repository/BookmarkServiceTest.php
+++ b/tests/integration/Core/Repository/BookmarkServiceTest.php
@@ -160,7 +160,7 @@ class BookmarkServiceTest extends BaseTest
             ->withCriterion(new Criterion\IsBookmarked(14));
         $count = $repository->getLocationService()->count($filter, []);
 
-        $this->assertEquals(5, $count);
+        self::assertEquals(5, $count);
     }
 }
 

--- a/tests/integration/Core/Repository/Filtering/Criterion/IsBookmarkedTest.php
+++ b/tests/integration/Core/Repository/Filtering/Criterion/IsBookmarkedTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Tests\Integration\Core\Repository\Filtering;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Filter\Filter;
+use Ibexa\Tests\Integration\Core\Repository\BaseTest;
+
+class IsBookmarkedTest extends BaseTest
+{
+    public function testBookmarkedAndNotBookmarkedCountsMatchTotal(): void
+    {
+        $repository = $this->getRepository(false);
+        $locationService = $repository->getLocationService();
+
+        $baseFilter = new Filter();
+        $totalCount = $locationService->count($baseFilter);
+
+        $bookmarkedFilter = clone $baseFilter;
+        $bookmarkedFilter->withCriterion(new Criterion\IsBookmarked(true));
+        $bookmarkedCount = $locationService->count($bookmarkedFilter);
+
+        $notBookmarkedFilter = clone $baseFilter;
+        $notBookmarkedFilter->withCriterion(new Criterion\IsBookmarked(false));
+        $notBookmarkedCount = $locationService->count($notBookmarkedFilter);
+
+        self::assertSame(
+            $totalCount,
+            $bookmarkedCount + $notBookmarkedCount,
+            sprintf(
+                'Mismatch: total=%d, bookmarked=%d, notBookmarked=%d',
+                $totalCount,
+                $bookmarkedCount,
+                $notBookmarkedCount
+            )
+        );
+    }
+
+    public function isBookmarkedProvider(): iterable
+    {
+        // [isBookmarkedCriterion, initialCount, afterCreateCount, afterDeleteCount]
+        return [
+            'bookmarked=true' => [true, 0, 1, 0],
+            'bookmarked=false' => [false, 1, 0, 1],
+        ];
+    }
+
+    /**
+     * @dataProvider isBookmarkedProvider
+     */
+    public function testIsBookmarkedTrueAndFalse(
+        bool $isBookmarked,
+        int $initialCount,
+        int $afterCreateCount,
+        int $afterDeleteCount
+    ): void {
+        $repository = $this->getRepository(false);
+        $locationService = $repository->getLocationService();
+        $bookmarkService = $repository->getBookmarkService();
+
+        $filesLocation = $locationService->loadLocation(52);
+
+        $filter = new Filter();
+        $filter->withCriterion(new Criterion\IsBookmarked($isBookmarked))
+            ->andWithCriterion(new Criterion\LocationId(52));
+
+        $locations = $locationService->find($filter);
+        self::assertCount(
+            $initialCount,
+            $locations,
+            'Unexpected initial bookmark state for IsBookmarked(' . ($isBookmarked ? 'true' : 'false') . ')'
+        );
+
+        $bookmarkService->createBookmark($filesLocation);
+
+        $filter = new Filter();
+        $filter->withCriterion(new Criterion\IsBookmarked($isBookmarked))
+            ->andWithCriterion(new Criterion\LocationId(52));
+
+        $locations = $locationService->find($filter);
+        self::assertCount(
+            $afterCreateCount,
+            $locations,
+            'Unexpected state after creating bookmark for IsBookmarked(' . ($isBookmarked ? 'true' : 'false') . ')'
+        );
+
+        $bookmarkService->deleteBookmark($filesLocation);
+
+        $filter = new Filter();
+        $filter->withCriterion(new Criterion\IsBookmarked($isBookmarked))
+            ->andWithCriterion(new Criterion\LocationId(52));
+
+        $locations = $locationService->find($filter);
+        self::assertCount(
+            $afterDeleteCount,
+            $locations,
+            'Unexpected state after deleting bookmark for IsBookmarked(' . ($isBookmarked ? 'true' : 'false') . ')'
+        );
+    }
+}

--- a/tests/integration/Core/Repository/Filtering/Criterion/IsBookmarkedTest.php
+++ b/tests/integration/Core/Repository/Filtering/Criterion/IsBookmarkedTest.php
@@ -40,6 +40,9 @@ class IsBookmarkedTest extends BaseTest
         );
     }
 
+    /**
+     * @return iterable<string, array{bool, int, int, int}>
+     */
     public function isBookmarkedProvider(): iterable
     {
         // [isBookmarkedCriterion, initialCount, afterCreateCount, afterDeleteCount]

--- a/tests/integration/Core/Repository/LocationServiceTest.php
+++ b/tests/integration/Core/Repository/LocationServiceTest.php
@@ -1968,6 +1968,7 @@ class LocationServiceTest extends BaseTest
 
         $mediaLocationId = $this->generateId('location', 43);
         $demoDesignLocationId = $this->generateId('location', 56);
+        $contactUsLocationId = $this->generateId('location', 60);
 
         /* BEGIN: Use Case */
         $locationService = $repository->getLocationService();
@@ -1975,6 +1976,7 @@ class LocationServiceTest extends BaseTest
 
         $mediaLocation = $locationService->loadLocation($mediaLocationId);
         $demoDesignLocation = $locationService->loadLocation($demoDesignLocationId);
+        $contactUsLocation = $locationService->loadLocation($contactUsLocationId);
 
         // Bookmark locations
         $bookmarkService->createBookmark($mediaLocation);
@@ -1983,13 +1985,13 @@ class LocationServiceTest extends BaseTest
         $beforeSwap = $bookmarkService->loadBookmarks();
 
         // Swaps the content referred to by the locations
-        $locationService->swapLocation($mediaLocation, $demoDesignLocation);
+        $locationService->swapLocation($demoDesignLocation, $contactUsLocation);
 
         $afterSwap = $bookmarkService->loadBookmarks();
         /* END: Use Case */
 
-        $this->assertEquals($beforeSwap->items[0]->id, $afterSwap->items[1]->id);
-        $this->assertEquals($beforeSwap->items[1]->id, $afterSwap->items[0]->id);
+        $this->assertEquals($contactUsLocationId, $afterSwap->items[0]->id);
+        $this->assertEquals($beforeSwap->items[1]->id, $afterSwap->items[1]->id);
     }
 
     /**

--- a/tests/integration/Core/Repository/LocationServiceTest.php
+++ b/tests/integration/Core/Repository/LocationServiceTest.php
@@ -1990,8 +1990,8 @@ class LocationServiceTest extends BaseTest
         $afterSwap = $bookmarkService->loadBookmarks();
         /* END: Use Case */
 
-        $this->assertEquals($contactUsLocationId, $afterSwap->items[0]->id);
-        $this->assertEquals($beforeSwap->items[1]->id, $afterSwap->items[1]->id);
+        self::assertEquals($contactUsLocationId, $afterSwap->items[0]->id);
+        self::assertEquals($beforeSwap->items[1]->id, $afterSwap->items[1]->id);
     }
 
     /**

--- a/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
+++ b/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Location;
+
+use Generator;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion as Criterion;
+use Ibexa\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Location\BookmarkQueryBuilder;
+use Ibexa\Tests\Core\Persistence\Legacy\Filter\BaseCriterionVisitorQueryBuilderTestCase;
+
+final class BookmarkQueryBuilderTest extends BaseCriterionVisitorQueryBuilderTestCase
+{
+    /**
+     * @return Generator<array-key, array{Criterion, string, array<string, int>}>
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidCriterionArgumentException
+     */
+    public function getFilteringCriteriaQueryData(): iterable
+    {
+        yield 'Bookmarks locations for user_id=14' => [
+            new Criterion\IsBookmarked(14),
+            'bookmark.user_id = :dcValue1',
+            ['dcValue1' => 14],
+        ];
+
+        yield 'Bookmarks locations for user_id=14 OR user_id=7' => [
+            new Criterion\LogicalOr(
+                [
+                    new Criterion\IsBookmarked(14),
+                    new Criterion\IsBookmarked(7),
+                ]
+            ),
+            '(bookmark.user_id = :dcValue1) OR (bookmark.user_id = :dcValue2)',
+            ['dcValue1' => 14, 'dcValue2' => 7],
+        ];
+    }
+
+    protected function getCriterionQueryBuilders(): iterable
+    {
+        return [new BookmarkQueryBuilder()];
+    }
+}

--- a/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
+++ b/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
@@ -28,8 +28,19 @@ final class BookmarkQueryBuilderTest extends BaseCriterionVisitorQueryBuilderTes
             ['dcValue1' => 14],
         ];
 
+        yield 'Bookmarks locations for user_id=14 OR user_id=7' => [
+            new Criterion\LogicalOr(
+                [
+                    new Criterion\IsBookmarked(true, 14),
+                    new Criterion\IsBookmarked(true, 7),
+               ]
+            ),
+            '(bookmark.user_id = :dcValue1) OR (bookmark.user_id = :dcValue2)',
+            ['dcValue1' => 14, 'dcValue2' => 7],
+        ];
+
         yield 'Bookmarks locations for user_id=7' => [
-                new Criterion\IsBookmarked(true, 7),
+            new Criterion\IsBookmarked(true, 7),
             'bookmark.user_id = :dcValue1',
             ['dcValue1' => 7],
         ];

--- a/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
+++ b/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Location;
 
-use Generator;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion as Criterion;
 use Ibexa\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Location\BookmarkQueryBuilder;
 use Ibexa\Tests\Core\Persistence\Legacy\Filter\BaseCriterionVisitorQueryBuilderTestCase;
@@ -16,7 +15,7 @@ use Ibexa\Tests\Core\Persistence\Legacy\Filter\BaseCriterionVisitorQueryBuilderT
 final class BookmarkQueryBuilderTest extends BaseCriterionVisitorQueryBuilderTestCase
 {
     /**
-     * @return Generator<array-key, array{Criterion, string, array<string, int>}>
+     * @return iterable<array-key, array{Criterion, string, array<string, int>}>
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidCriterionArgumentException
      */

--- a/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
+++ b/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BookmarkQueryBuilderTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Locat
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion as Criterion;
 use Ibexa\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Location\BookmarkQueryBuilder;
+use Ibexa\Core\Repository\Permission\PermissionResolver;
 use Ibexa\Tests\Core\Persistence\Legacy\Filter\BaseCriterionVisitorQueryBuilderTestCase;
 
 final class BookmarkQueryBuilderTest extends BaseCriterionVisitorQueryBuilderTestCase
@@ -22,25 +23,20 @@ final class BookmarkQueryBuilderTest extends BaseCriterionVisitorQueryBuilderTes
     public function getFilteringCriteriaQueryData(): iterable
     {
         yield 'Bookmarks locations for user_id=14' => [
-            new Criterion\IsBookmarked(14),
+            new Criterion\IsBookmarked(true, 14),
             'bookmark.user_id = :dcValue1',
             ['dcValue1' => 14],
         ];
 
-        yield 'Bookmarks locations for user_id=14 OR user_id=7' => [
-            new Criterion\LogicalOr(
-                [
-                    new Criterion\IsBookmarked(14),
-                    new Criterion\IsBookmarked(7),
-                ]
-            ),
-            '(bookmark.user_id = :dcValue1) OR (bookmark.user_id = :dcValue2)',
-            ['dcValue1' => 14, 'dcValue2' => 7],
+        yield 'Bookmarks locations for user_id=7' => [
+                new Criterion\IsBookmarked(true, 7),
+            'bookmark.user_id = :dcValue1',
+            ['dcValue1' => 7],
         ];
     }
 
     protected function getCriterionQueryBuilders(): iterable
     {
-        return [new BookmarkQueryBuilder()];
+        return [new BookmarkQueryBuilder($this->createMock(PermissionResolver::class))];
     }
 }

--- a/tests/lib/Repository/Service/Mock/BookmarkTest.php
+++ b/tests/lib/Repository/Service/Mock/BookmarkTest.php
@@ -235,6 +235,11 @@ class BookmarkTest extends BaseServiceMockTest
             ->method('getLocationService')
             ->willReturn($locationServiceMock);
 
+        // All tests in this class expect a call to getPermissionResolver()->getCurrentUserReference(), except this very test
+        // This is because PermissionResolver is called from BookmarkQueryBuilder, not from BookmarkService when loading bookmarks
+        // As it is defined in setup() that getCurrentUserReference needs to be called at least once, we'll force a call here
+        $repository->getPermissionResolver()->getCurrentUserReference();
+
         $bookmarks = $this->createBookmarkService()->loadBookmarks($offset, $limit);
 
         $this->assertEquals($expectedTotalCount, $bookmarks->totalCount);


### PR DESCRIPTION
| :ticket: Issue | IBX-6773 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/1835

#### Description:
If user bookmark some location which he later looses access too, then the bookmark list in admin-ui fails with an exception.
Simply fixing `BookmarkService::loadBookmarks()` would be easy. The problem is to implement `countUserBookmarks()` in persistence layer and having it taking into account user permissions so that BC would be kept.

Talked with Adam on how to solve this without breaking BC and he suggested implementing it using filtering

~~The Bookmark filter will only work with location filtering (`LocationService::find()`), not with content (`ContentService::find()`)~~


Code was initially based on https://github.com/ezsystems/ezplatform-kernel/pull/408 which was not approved and merge in time before 3.3 went EO, but has been heavily modified since.


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->
Read ticket for info on how to reproduce

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->
Documentation for the new filter needs to be made, indeed

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 


[IBX-6773]: https://ibexa.atlassian.net/browse/IBX-6773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ