### PR TITLE
Added additional tag cleaning to limit down number of orphaned tag en…

### DIFF
--- a/src/lib/Persistence/Cache/ContentHandler.php
+++ b/src/lib/Persistence/Cache/ContentHandler.php
@@ -335,12 +335,33 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
     {
         $this->logger->logCall(__METHOD__, ['content' => $contentId, 'version' => $versionNo, 'struct' => $struct]);
         $content = $this->persistenceHandler->contentHandler()->updateContent($contentId, $versionNo, $struct);
-        $this->cache->invalidateTags([
-            $this->cacheIdentifierGenerator->generateTag(
+        $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
+        $locationTags = array_map(function (Content\Location $location): string {
+            return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$location->id]);
+        }, $locations);
+        $locationPathTags = array_map(function (Content\Location $location): string {
+            return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_PATH_IDENTIFIER, [$location->id]);
+        }, $locations);
+
+        $versionTags = [];
+        $versionTags[] = $this->cacheIdentifierGenerator->generateTag(
+            self::CONTENT_VERSION_IDENTIFIER,
+            [$contentId, $versionNo]
+        );
+
+        if ($versionNo > 1) {
+            $versionTags[] = $this->cacheIdentifierGenerator->generateTag(
                 self::CONTENT_VERSION_IDENTIFIER,
-                [$contentId, $versionNo]
-            ),
-        ]);
+                [$contentId, $versionNo - 1]
+            );
+        }
+
+        $tags = array_merge(
+            $locationTags,
+            $locationPathTags,
+            $versionTags
+        );
+        $this->cache->invalidateTags($tags);
 
         return $content;
     }
@@ -357,6 +378,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
             $contentId,
             APIRelation::FIELD | APIRelation::ASSET
         );
+        $contentLocations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
 
         $return = $this->persistenceHandler->contentHandler()->deleteContent($contentId);
 
@@ -372,7 +394,11 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
             $tags = [];
         }
         $tags[] = $this->cacheIdentifierGenerator->generateTag(self::CONTENT_IDENTIFIER, [$contentId]);
+
         $this->cache->invalidateTags($tags);
+        foreach ($contentLocations as $location) {
+            $tags[] = $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$location->id]);
+        }
 
         return $return;
     }

--- a/tests/lib/Persistence/Cache/ContentHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentHandlerTest.php
@@ -48,7 +48,8 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['setStatus', [2, 0, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['setStatus', [2, 1, 1], [['content', [2], false]], null, ['c-2']],
             ['updateMetadata', [2, new MetadataUpdateStruct()], [['content', [2], false]], null, ['c-2']],
-            ['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
+            //updateContent has its own test now due to relations complexity
+            //['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             //['deleteContent', [2]], own tests for relations complexity
             ['deleteVersion', [2, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['addRelation', [new RelationCreateStruct(['destinationContentId' => 2, 'sourceContentId' => 4])], [['content', [2], false], ['content', [4], false]], null, ['c-2', 'c-4']],
@@ -437,18 +438,103 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
         ];
     }
 
-    public function testDeleteContent()
+    public function testUpdateContent(): void
+    {
+        $this->loggerMock->expects($this->once())->method('logCall');
+
+        $innerContentHandlerMock = $this->createMock(SPIContentHandler::class);
+        $innerLocationHandlerMock = $this->createMock(SPILocationHandler::class);
+
+        $this->prepareHandlerMocks(
+            $innerContentHandlerMock,
+            $innerLocationHandlerMock,
+            1,
+            1,
+            0
+        );
+
+        $innerContentHandlerMock
+            ->expects($this->once())
+            ->method('updateContent')
+            ->with(2, 1, new UpdateStruct())
+            ->willReturn(new Content());
+
+        $this->cacheIdentifierGeneratorMock
+            ->expects($this->exactly(5))
+            ->method('generateTag')
+            ->will(
+                self::returnValueMap([
+                    ['location', [3], false, 'l-3'],
+                    ['location', [4], false, 'l-4'],
+                    ['location_path', [3], false, 'lp-3'],
+                    ['location_path', [4], false, 'lp-4'],
+                    ['content_version', [2, 1], false, 'c-2-v-1'],
+                ])
+            );
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('invalidateTags')
+            ->with(['l-3', 'l-4', 'lp-3', 'lp-4', 'c-2-v-1']);
+
+        $handler = $this->persistenceCacheHandler->contentHandler();
+        $handler->updateContent(2, 1, new UpdateStruct());
+    }
+
+    public function testDeleteContent(): void
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
         $innerHandlerMock = $this->createMock(SPIContentHandler::class);
-        $this->persistenceHandlerMock
-            ->expects($this->exactly(2))
-            ->method('contentHandler')
-            ->willReturn($innerHandlerMock);
+        $innerLocationHandlerMock = $this->createMock(SPILocationHandler::class);
 
-        $innerHandlerMock
+        $this->prepareHandlerMocks(
+            $innerContentHandlerMock,
+            $innerLocationHandlerMock,
+            2
+        );
+
+        $innerContentHandlerMock
             ->expects($this->once())
+            ->method('deleteContent')
+            ->with(2)
+            ->method('deleteItem');
+
+        $this->cacheIdentifierGeneratorMock
+            ->expects($this->exactly(4))
+            ->method('generateTag')
+            ->withConsecutive(
+                ['content', [42], false],
+                ['content', [2], false],
+                ['location', [3], false],
+                ['location', [4], false]
+            )
+            ->willReturnOnConsecutiveCalls('c-42', 'c-2', 'l-3', 'l-4');
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('invalidateTags')
+            ->with(['c-42', 'c-2', 'l-3', 'l-4']);
+
+        $handler = $this->persistenceCacheHandler->contentHandler();
+        $handler->deleteContent(2);
+    }
+
+    private function prepareHandlerMocks(
+        MockObject $innerContentHandlerMock,
+        MockObject $innerLocationHandlerMock,
+        int $contentHandlerCount = 1,
+        int $locationHandlerCount = 1,
+        int $loadReverseRelationsCount = 1,
+        int $loadLocationsByContentCount = 1
+    ): void {
+        $this->persistenceHandlerMock
+            ->expects($this->exactly($contentHandlerCount))
+            ->method('contentHandler')
+            ->willReturn($innerContentHandlerMock);
+
+        $innerContentHandlerMock
+            ->expects($this->exactly($loadReverseRelationsCount))
             ->method('loadReverseRelations')
             ->with(2, APIRelation::FIELD | APIRelation::ASSET)
             ->willReturn(
@@ -457,32 +543,21 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
                 ]
             );
 
-        $innerHandlerMock
-            ->expects($this->once())
-            ->method('deleteContent')
+        $this->persistenceHandlerMock
+            ->expects($this->exactly($locationHandlerCount))
+            ->method('locationHandler')
+            ->willReturn($innerLocationHandlerMock);
+
+        $innerLocationHandlerMock
+            ->expects($this->exactly($loadLocationsByContentCount))
+            ->method('loadLocationsByContent')
             ->with(2)
-            ->willReturn(true);
-
-        $this->cacheMock
-            ->expects($this->never())
-            ->method('deleteItem');
-
-        $this->cacheIdentifierGeneratorMock
-            ->expects($this->exactly(2))
-            ->method('generateTag')
-            ->withConsecutive(
-                ['content', [42], false],
-                ['content', [2], false]
-            )
-            ->willReturnOnConsecutiveCalls('c-42', 'c-2');
-
-        $this->cacheMock
-            ->expects($this->once())
-            ->method('invalidateTags')
-            ->with(['c-42', 'c-2']);
-
-        $handler = $this->persistenceCacheHandler->contentHandler();
-        $handler->deleteContent(2);
+            ->willReturn(
+                [
+                    new Content\Location(['id' => 3]),
+                    new Content\Location(['id' => 4]),
+                ]
+            );
     }
 }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5502](https://issues.ibexa.co/browse/IBX-5502)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Due to how the cache is implemented in Symfony-based projects using the Redis adapter (and probably - not only Redis), entries (Members) inside a Tag (Set) are removed only when the tag is purged. Due to that, we can encounter on multiple occasions a situation, when a Tag is purged, resulting in cache items (Keys) being purged as well, but only the Tag that triggered a purge is cleaned up. All other tags that contain entries pointing to cache items that no longer exist will remain there until the affected tag is purged - which often is "never".

This results in orphaned entries in tags (or even in whole orphaned tags) filling up the memory. Memory allocated to tags in Redis is nonevictable, therefore it is freed only when purged on purpose (`maxmemory-policy` setting won't affect orphaned members/sets). On very big and/or constantly changing content structures, this unevictable memory allocated to orphaned tags and entries can significantly lower the amount of memory available for standard cache items to be stored.

Additional Tag purging added in this PR reduces this effect, but - unfortunately - it is not possible to resolve it fully with current Symfony's cache adapters implementation, due to the fact that there is no available interface to remove an entry from a Tag, without purging it whole - and that would result in purging cache items that were nor related to the original action performed on content.

Additional tag purging introduced by PR:
- `ContentHandler::updateContent`:
Multiple content-related entries (`ibx-c-<contentId>-<versionNo>-0`, `ibx-c-<contentId>-<versionNo>-<languageCode>`, `ibx-cvi-<contentId>`,  `ibx-cl-<contentId>-pfd` are orphaned in tags: `l-<locationId>`, `lp-<locationId>`, `c-<contentId>-v-<versionNo>`, `c-<contentId>-v-<prevVersionNo>`. Added purging of those tags to avoid it.

- `TrashHandler::trashSubtree`:
Multiple content-related entries are orphaned (`ibx-c-<contentId>-v<versionNumber>`, `ibx-cl-<contentId>`, `ibx-cvi-<contentId>`, `ibx-l-<locationId>-<languageCode>`, `ibx-c-<contentId>-<versionNo>-0`, `ibx-c-<contentId>-<versionNo>-<languageCode>`, `ibx-cvi-<contentId>` ... (many more) are orphaned in tags: `l-<locationId>`, `c-<contentId>-v-<versionNo>`.

Handling those two occurrences helps to limit greatly the number of orphaned members.

My tests show, that one of the biggest culprits here is `lp-<locationIdOfParent>` tag, which can have multiple orphaned entries - therefore it might be a good idea to purge it as well, to avoid blocked memory in cost of potentially small performance loss - up for discussion.

This PR won't resolve the issue fully but limits the scope of it using available tools. To resolve this fully, we will need (in my opinion):
- an interface to remove entries from sets
- a garbage collector, as entries in tags might become orphaned as well when a key is evicted by Redis when maxmemory limit is reached.
But those two are out of this PR scope.


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
