### PR TITLE
[PHPUnit] Bumped number of expected direct deprecations

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
   >
   <php>
     <ini name="error_reporting" value="-1" />
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=82&amp;max[direct]=854&amp;max[indirect]=11&amp;verbose=0"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=82&amp;max[direct]=855&amp;max[indirect]=11&amp;verbose=0"/>
   </php>
   <testsuites>
     <testsuite name="unit_core">


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Related PRs: 
- https://github.com/ibexa/core/pull/467
- https://github.com/ibexa/core/pull/481

#### Description:

Fixing failing CI after https://github.com/ibexa/core/commit/7c30793299 merge commit.

Wild guess is that there's one more deprecation for:
```
16x: Since twig/twig 3.14: The "Twig\Environment::mergeGlobals" method is deprecated.
    16x in FieldRenderingExtensionIntegrationTest::testIntegration from Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension
```
after merging up #467.

This is probably due to pre-existing condition, not the changes themselves, so it's fine to just bump the number.

