### PR TITLE
IBX-9617: Fixed DB schema reinstallation

### DIFF
--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace Ibexa\Bundle\RepositoryInstaller\Command;
 
 use Doctrine\DBAL\Connection;

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -88,7 +88,7 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
         $schemaManager = $this->connection->getSchemaManager();
         if (!empty($schemaManager->listTables())) {
             $io = new SymfonyStyle($input, $output);
-            if (!$io->confirm('Running this command will delete data in all Ibexa generated tables. Continue?', )) {
+            if (!$io->confirm('Running this command will delete data in all Ibexa generated tables. Continue?', false)) {
                 return 0;
             }
         }

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -4,7 +4,6 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace Ibexa\Bundle\RepositoryInstaller\Command;
 
 use Doctrine\DBAL\Connection;

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -76,6 +76,12 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
             InputOption::VALUE_NONE,
             'Skip indexing (ibexa:reindex)'
         );
+        $this->addOption(
+            'force',
+            'f',
+            InputOption::VALUE_NONE,
+            'Install over existing database without asking for confirmation.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -86,7 +92,7 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
         $this->checkCreateDatabase($output);
 
         $schemaManager = $this->connection->getSchemaManager();
-        if (!empty($schemaManager->listTables())) {
+        if (!empty($schemaManager->listTables()) && !$input->getOption('force')) {
             $io = new SymfonyStyle($input, $output);
             if (!$io->confirm('Running this command will delete data in all Ibexa generated tables. Continue?', false)) {
                 return 0;

--- a/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
+++ b/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
@@ -99,8 +99,7 @@ class CoreInstaller extends DbBasedInstaller implements Installer
     ): array {
         $existingSchema = $this->db->getSchemaManager()->createSchema();
         $statements = [];
-        // reverse table order for clean-up (due to FKs)
-        $tables = array_reverse($newSchema->getTables());
+        $tables = $newSchema->getTables();
         if ($databasePlatform->supportsForeignKeyConstraints()) {
             // cleanup pre-existing database: drop foreign keys
             foreach ($tables as $table) {

--- a/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
+++ b/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
@@ -105,7 +105,7 @@ class CoreInstaller extends DbBasedInstaller implements Installer
             // cleanup pre-existing database: drop foreign keys
             foreach ($tables as $table) {
                 if ($existingSchema->hasTable($table->getName())) {
-                    foreach($this->db->getSchemaManager()->listTableForeignKeys($table->getName()) as $foreignKeyConstraint) {
+                    foreach ($this->db->getSchemaManager()->listTableForeignKeys($table->getName()) as $foreignKeyConstraint) {
                         $statements[] = $databasePlatform->getDropForeignKeySQL($foreignKeyConstraint->getName(), $table->getName());
                     }
                 }

--- a/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
+++ b/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
@@ -98,10 +98,20 @@ class CoreInstaller extends DbBasedInstaller implements Installer
         AbstractPlatform $databasePlatform
     ): array {
         $existingSchema = $this->db->getSchemaManager()->createSchema();
-        $statements = ['SET FOREIGN_KEY_CHECKS=0'];
+        $statements = [];
         // reverse table order for clean-up (due to FKs)
         $tables = array_reverse($newSchema->getTables());
-        // cleanup pre-existing database
+        if ($databasePlatform->supportsForeignKeyConstraints()) {
+            // cleanup pre-existing database: drop foreign keys
+            foreach ($tables as $table) {
+                if ($existingSchema->hasTable($table->getName())) {
+                    foreach($this->db->getSchemaManager()->listTableForeignKeys($table->getName()) as $foreignKeyConstraint) {
+                        $statements[] = $databasePlatform->getDropForeignKeySQL($foreignKeyConstraint->getName(), $table->getName());
+                    }
+                }
+            }
+        }
+        // cleanup pre-existing database: drop tables
         foreach ($tables as $table) {
             if ($existingSchema->hasTable($table->getName())) {
                 $statements[] = $databasePlatform->getDropTableSQL($table);

--- a/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
+++ b/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
@@ -98,7 +98,7 @@ class CoreInstaller extends DbBasedInstaller implements Installer
         AbstractPlatform $databasePlatform
     ): array {
         $existingSchema = $this->db->getSchemaManager()->createSchema();
-        $statements = [];
+        $statements = ['SET FOREIGN_KEY_CHECKS=0'];
         // reverse table order for clean-up (due to FKs)
         $tables = array_reverse($newSchema->getTables());
         // cleanup pre-existing database

--- a/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
+++ b/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
@@ -98,26 +98,24 @@ class CoreInstaller extends DbBasedInstaller implements Installer
         AbstractPlatform $databasePlatform
     ): array {
         $existingSchema = $this->db->getSchemaManager()->createSchema();
-        $statements = [];
+        $dropForeignKeyStatements = [];
+        $dropTableStatements =[];
         $tables = $newSchema->getTables();
-        if ($databasePlatform->supportsForeignKeyConstraints()) {
-            // cleanup pre-existing database: drop foreign keys
-            foreach ($tables as $table) {
-                if ($existingSchema->hasTable($table->getName())) {
-                    foreach ($this->db->getSchemaManager()->listTableForeignKeys($table->getName()) as $foreignKeyConstraint) {
-                        $statements[] = $databasePlatform->getDropForeignKeySQL($foreignKeyConstraint->getName(), $table->getName());
-                    }
-                }
-            }
-        }
-        // cleanup pre-existing database: drop tables
+        // cleanup pre-existing database
         foreach ($tables as $table) {
             if ($existingSchema->hasTable($table->getName())) {
-                $statements[] = $databasePlatform->getDropTableSQL($table);
+                if ($databasePlatform->supportsForeignKeyConstraints()) {
+                    // cleanup pre-existing database: drop foreign keys
+                    foreach ($this->db->getSchemaManager()->listTableForeignKeys($table->getName()) as $foreignKeyConstraint) {
+                        $dropForeignKeyStatements[] = $databasePlatform->getDropForeignKeySQL($foreignKeyConstraint->getName(), $table->getName());
+                    }
+                }
+                // cleanup pre-existing database: drop tables
+                $dropTableStatements[] = $databasePlatform->getDropTableSQL($table);
             }
         }
 
-        return $statements;
+        return array_merge($dropForeignKeyStatements, $dropTableStatements);
     }
 
     /**

--- a/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
+++ b/src/bundle/RepositoryInstaller/Installer/CoreInstaller.php
@@ -99,7 +99,7 @@ class CoreInstaller extends DbBasedInstaller implements Installer
     ): array {
         $existingSchema = $this->db->getSchemaManager()->createSchema();
         $dropForeignKeyStatements = [];
-        $dropTableStatements =[];
+        $dropTableStatements = [];
         $tables = $newSchema->getTables();
         // cleanup pre-existing database
         foreach ($tables as $table) {


### PR DESCRIPTION
| :ticket: Issue | IBX-9617 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Before:
````
% ddev php bin/console ibexa:install
Creating database db if it does not exist, using doctrine:database:create --if-not-exists
Database `db` for connection named default already exists. Skipped.


 Running this command will delete data in all Ibexa generated tables. Continue? (yes/no) [yes]:
 > 

Executing 374 queries on database db (mysql)
   0/374 [>---------------------------]   0%
In AbstractMySQLDriver.php line 68:
                                                                                                                              
  An exception occurred while executing 'DROP TABLE ibexa_order_item_product':                                                
                                                                                                                              
  SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails  
                                                                                                                              
````

Issues:
- If developer risk to lose all data, default confirmation answer should be 'no', not 'yes'.
- Tables are not dropped in an order respecting foreign keys dependencies.

Fixes:
- Drop all the foreign keys before dropping the tables.
- Set 'no' as the default answer to the "Continue?" question.

After:
````
% ddev php bin/console ibexa:install
Creating database db if it does not exist, using doctrine:database:create --if-not-exists
Database `db` for connection named default already exists. Skipped.


 Running this command will delete data in all Ibexa generated tables. Continue? (yes/no) [no]:
 > 

% ddev php bin/console ibexa:install
Creating database db if it does not exist, using doctrine:database:create --if-not-exists
Database `db` for connection named default already exists. Skipped.


 Running this command will delete data in all Ibexa generated tables. Continue? (yes/no) [no]:
 > y

Executing 375 queries on database db (mysql)
 375/375 [============================] 100%

Executing 30 queries from /var/www/html/vendor/ibexa/core/data/mysql/cleandata.sql on database db
Executing 1 queries from /var/www/html/vendor/ibexa/installer/src/bundle/Resources/install/sql/mysql/user_settings.sql on database db
Executing 18 queries from /var/www/html/vendor/ibexa/installer/src/bundle/Resources/install/sql/mysql/content_data.sql on database db
Executing 3 queries from /var/www/html/vendor/ibexa/installer/src/bundle/Resources/install/sql/mysql/landing_pages.sql on database db
Executing 1 queries from /var/www/html/vendor/ibexa/installer/src/bundle/Resources/install/sql/mysql/permissions.sql on database db

                                                                                                                        
 [WARNING] Not passing the "--complete" option to "doctrine:schema:update" is deprecated and will not be supported when 
           using doctrine/dbal 4                                                                                        
                                                                                                                        

                                                                                                                        
 [OK] Nothing to update - your database is already in sync with the current entity metadata.                            
                                                                                                                        


In MigrationExecutor.php line 68:
                                                                                                                                                                                                          
  Executing migration "002_taxonomy_content.yml" failed. Exception: An exception occurred while executing 'INSERT INTO ibexa_taxonomy_entries (identifier, name, names, mainLanguageCode, content_id, `l  
  eft`, `right`, root, lvl, taxonomy, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params ["root", "Root", "a:1:{s:6:\"eng-GB\";s:4:\"Root\";}", "eng-GB", 58, 0, 0, 0, 0, "tags", null]:    
                                                                                                                                                                                                          
  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'tags-root' for key 'ibexa_taxonomy_entries_identifier_idx'.                                                                                                                                                                                                                                                                                
````

Remaining issue I'm not able to fix by myself:
- 3 tables aren't dropped (Commerce 4.6.x-dev with ibexa/core 1efa3ef33fd988a8e31c9d9904b03be476a81100): `ibexa_payment_token`, `ibexa_taxonomy_assignments`, and `ibexa_taxonomy_entries`.
- As those tables weren't dropped, the error `SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'tags-root' for key 'ibexa_taxonomy_entries_identifier_idx'` is thrown, and probably other errors of this kind are waiting behind it.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
