### PR TITLE
Mark ContentName as also being a Trash Criterion

### DIFF
--- a/src/contracts/Repository/Values/Content/Query/Criterion/ContentName.php
+++ b/src/contracts/Repository/Values/Content/Query/Criterion/ContentName.php
@@ -10,8 +10,9 @@ namespace Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+use Ibexa\Contracts\Core\Repository\Values\Trash\Query\Criterion as TrashCriterion;
 
-final class ContentName extends Criterion
+final class ContentName extends Criterion implements TrashCriterion
 {
     public function __construct(string $value)
     {


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

`\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\ContentName` can be used with `\Ibexa\Core\Repository\TrashService::findTrashItems()`.
Its `Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentName` is tagged `ibexa.search.legacy.trash.gateway.criterion.handler`.
Not having it marked as a trash criterion is probably an oversight.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:

It was discovered during ibexa/documentation-developer#2540

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
