### PR TITLE
[Twig] Removed usage of deprecated spaceless filter

### DIFF
--- a/src/bundle/Core/Resources/views/content_fields.html.twig
+++ b/src/bundle/Core/Resources/views/content_fields.html.twig
@@ -13,21 +13,16 @@
 {% trans_default_domain 'ibexa_content_fields' %}
 
 {% block ezstring_field %}
-{% apply spaceless %}
     {% set field_value = field.value.text %}
     {{ block( 'simple_inline_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block eztext_field %}
-{% apply spaceless %}
     {% set field_value = field.value|nl2br %}
     {{ block( 'simple_block_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block ezauthor_field %}
-{% apply spaceless %}
     {% if field.value.authors|length() > 0 %}
         <ul {{ block( 'field_attributes' ) }}>
         {% for author in field.value.authors %}
@@ -35,11 +30,9 @@
         {% endfor %}
         </ul>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezcountry_field %}
-{% apply spaceless %}
     {% if fieldSettings.isMultiple and field.value.countries|length > 0 %}
         <ul {{ block( 'field_attributes' ) }}>
             {% for country in field.value.countries %}
@@ -53,19 +46,15 @@
         {% endfor %}
         </p>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {# @todo: add translate filter #}
 {% block ezboolean_field %}
-{% apply spaceless %}
     {% set field_value = field.value.bool ? 'Yes' : 'No' %}
     {{ block( 'simple_inline_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block ezdatetime_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% if fieldSettings.useSeconds %}
             {% set field_value = field.value.value|format_datetime( 'short', 'medium', locale=parameters.locale ) %}
@@ -74,20 +63,16 @@
         {% endif %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezdate_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.date|format_date( 'short', locale=parameters.locale, timezone='UTC' ) %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block eztime_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% if fieldSettings.useSeconds %}
             {% set field_value = field.value.time|format_time( 'medium', locale=parameters.locale, timezone='UTC' ) %}
@@ -96,55 +81,43 @@
         {% endif %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezemail_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.email %}
         <a href="mailto:{{ field.value.email|escape( 'url' ) }}" {{ block( 'field_attributes' ) }}>{{ field.value.email }}</a>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezinteger_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.value %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {# @todo: handle localization #}
 {% block ezfloat_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set field_value = field.value.value %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezurl_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         <a href="{{ field.value.link }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.text ? field.value.text : field.value.link }}</a>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezisbn_field %}
-{% apply spaceless %}
     {% set field_value = field.value.isbn %}
     {{ block( 'simple_inline_field' ) }}
-{% endapply %}
 {% endblock %}
 
 {% block ezkeyword_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         <ul {{ block( 'field_attributes' ) }}>
         {% for keyword in field.value.values %}
@@ -152,12 +125,9 @@
         {% endfor %}
         </ul>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezselection_field %}
-{% apply spaceless %}
-
     {% set options = fieldSettings.options %}
 
     {% if fieldSettings.multilingualOptions[field.languageCode] is defined %}
@@ -177,7 +147,6 @@
         {% set field_value = options[field.value.selection.0] %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {# @todo:
@@ -185,7 +154,6 @@
  # - legacy used to dump is_locked attribute
  #}
 {% block ezuser_field %}
-{% apply spaceless %}
 <dl {{ block( 'field_attributes' ) }}>
     <dt>User ID</dt>
     <dd>{{ field.value.contentId }}</dd>
@@ -196,11 +164,9 @@
     <dt>Account status</dt>
     <dd>{{ field.value.enabled ? 'enabled' : 'disabled' }}</dd>
 </dl>
-{% endapply %}
 {% endblock %}
 
 {% block ezbinaryfile_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
         {% set route_reference = ibexa_route( 'ibexa.content.download', {
             'content': content,
@@ -211,12 +177,10 @@
         <a href="{{ ibexa_path( route_reference ) }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.fileName }}</a>&nbsp;({{ field.value.fileSize|ibexa_file_size( 1 ) }})
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezmedia_field %}
 {% if not ibexa_field_is_empty( content, field ) %}
-{% apply spaceless %}
     {% set type = fieldSettings.mediaType %}
     {% set value = field.value %}
     {% set route_reference = ibexa_route( 'ibexa.content.download', {
@@ -271,12 +235,10 @@
     {% endif %}
     {% endautoescape %}
     </div>
-{% endapply %}
 {% endif %}
 {% endblock %}
 
 {% block ezobjectrelationlist_field %}
-{% apply spaceless %}
     {% if not ibexa_field_is_empty( content, field ) %}
     <ul {{ block( 'field_attributes' ) }}>
         {% for contentId in field.value.destinationContentIds %}
@@ -287,7 +249,6 @@
         {% endfor %}
     </ul>
     {% endif %}
-{% endapply %}
 {% endblock %}
 
 {# @todo:
@@ -310,7 +271,6 @@
  # - https://wiki.openstreetmap.org
  # - http://leafletjs.com/reference-1.3.0.html
  #}
-{% apply spaceless %}
 <div {{ block( 'field_attributes' ) }}>
     {% set defaultWidth = '500px' %}
     {% set defaultHeight = '200px' %}
@@ -420,7 +380,6 @@
         <div class="maplocation-map" id="{{ mapId }}" style="{{ mapStyle }}"></div>
     {% endif %}
 </div>
-{% endapply %}
 {% endblock %}
 
 {# This field accepts the following parameters:
@@ -430,7 +389,6 @@
  #   - parameters.class. Allows setting CSS custom class name for the image
  #}
 {% block ezimage_field %}
-{% apply spaceless %}
 {% if not ibexa_field_is_empty( content, field ) %}
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ibexa_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
@@ -454,11 +412,9 @@
     {% endif %}
 </figure>
 {% endif %}
-{% endapply %}
 {% endblock %}
 
 {% block ezimageasset_field %}
-    {% apply spaceless %}
         {% if not ibexa_field_is_empty(content, field) and parameters.available %}
             <div {{ block('field_attributes') }}>
                 {{ render(controller('ibexa_content::embedAction', {
@@ -471,45 +427,36 @@
                 }))}}
             </div>
         {% endif %}
-    {% endapply %}
 {% endblock %}
 
 {% block ezobjectrelation_field %}
-{% apply spaceless %}
 {% if not ibexa_field_is_empty( content, field ) and parameters.available %}
     <div {{ block( 'field_attributes' ) }}>
         {{ render( controller( "ibexa_content::viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
     </div>
 {% endif %}
-{% endapply %}
 {% endblock %}
 
 {# The simple_block_field block is a shorthand html block-based fields (like eztext) #}
 {# You can define a field_value variable before rendering this one if you need special operation for rendering content (i.e. nl2br) #}
 {% block simple_block_field %}
-{% apply spaceless %}
     {% if field_value is not defined %}
         {% set field_value = field.value %}
     {% endif %}
     <div {{ block( 'field_attributes' ) }}>
-        {% endapply %}{{ field_value|raw }}{% apply spaceless %}
+        {{ field_value|raw }}
     </div>
-{% endapply %}
 {% endblock %}
 
 {% block simple_inline_field %}
-{% apply spaceless %}
     {% if field_value is not defined %}
         {% set field_value = field.value %}
     {% endif %}
     <span {{ block( 'field_attributes' ) }}>{{ field_value }}</span>
-{% endapply %}
 {% endblock %}
 
 {# Block for field attributes rendering. Useful to add a custom class, id or whatever HTML attribute to the field markup #}
 {% block field_attributes %}
-{% apply spaceless %}
     {% set attr = attr|default( {} ) %}
     {% for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}
-{% endapply %}
 {% endblock %}


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

> The spaceless filter is deprecated as of Twig 3.12 and will be removed in Twig 4.0.

See https://twig.symfony.com/doc/3.x/deprecated.html 

#### For QA:
Limitations and field types rendering.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
