### PR TITLE
IBX-9060: Added mark as unread functionality for notifications

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24883,12 +24883,6 @@ parameters:
 			path: src/lib/Repository/NameSchema/NameSchemaService.php
 
 		-
-			message: '#^Parameter \#1 \$module of class Ibexa\\Core\\Base\\Exceptions\\UnauthorizedException constructor expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/lib/Repository/NotificationService.php
-
-		-
 			message: '#^Parameter \#2 \$whatIsWrong of class Ibexa\\Core\\Base\\Exceptions\\InvalidArgumentException constructor expects string, int given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/contracts/Repository/Decorator/NotificationServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/NotificationServiceDecorator.php
@@ -40,6 +40,11 @@ abstract class NotificationServiceDecorator implements NotificationService
         $this->innerService->markNotificationAsRead($notification);
     }
 
+    public function markNotificationAsUnread(Notification $notification): void
+    {
+        $this->innerService->markNotificationAsUnread($notification);
+    }
+
     public function getPendingNotificationCount(): int
     {
         return $this->innerService->getPendingNotificationCount();

--- a/src/contracts/Repository/Events/Notification/BeforeMarkNotificationAsUnreadEvent.php
+++ b/src/contracts/Repository/Events/Notification/BeforeMarkNotificationAsUnreadEvent.php
@@ -13,8 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Notification\Notification;
 
 final class BeforeMarkNotificationAsUnreadEvent extends BeforeEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Notification\Notification */
-    private $notification;
+    private Notification $notification;
 
     public function __construct(Notification $notification)
     {

--- a/src/contracts/Repository/Events/Notification/BeforeMarkNotificationAsUnreadEvent.php
+++ b/src/contracts/Repository/Events/Notification/BeforeMarkNotificationAsUnreadEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Events\Notification;
+
+use Ibexa\Contracts\Core\Repository\Event\BeforeEvent;
+use Ibexa\Contracts\Core\Repository\Values\Notification\Notification;
+
+final class BeforeMarkNotificationAsUnreadEvent extends BeforeEvent
+{
+    /** @var \Ibexa\Contracts\Core\Repository\Values\Notification\Notification */
+    private $notification;
+
+    public function __construct(Notification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function getNotification(): Notification
+    {
+        return $this->notification;
+    }
+}

--- a/src/contracts/Repository/Events/Notification/MarkNotificationAsUnreadEvent.php
+++ b/src/contracts/Repository/Events/Notification/MarkNotificationAsUnreadEvent.php
@@ -13,8 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Notification\Notification;
 
 final class MarkNotificationAsUnreadEvent extends AfterEvent
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Notification\Notification */
-    private $notification;
+    private Notification $notification;
 
     public function __construct(Notification $notification)
     {

--- a/src/contracts/Repository/Events/Notification/MarkNotificationAsUnreadEvent.php
+++ b/src/contracts/Repository/Events/Notification/MarkNotificationAsUnreadEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Events\Notification;
+
+use Ibexa\Contracts\Core\Repository\Event\AfterEvent;
+use Ibexa\Contracts\Core\Repository\Values\Notification\Notification;
+
+final class MarkNotificationAsUnreadEvent extends AfterEvent
+{
+    /** @var \Ibexa\Contracts\Core\Repository\Values\Notification\Notification */
+    private $notification;
+
+    public function __construct(Notification $notification)
+    {
+        $this->notification = $notification;
+    }
+
+    public function getNotification(): Notification
+    {
+        return $this->notification;
+    }
+}

--- a/src/contracts/Repository/NotificationService.php
+++ b/src/contracts/Repository/NotificationService.php
@@ -50,9 +50,7 @@ interface NotificationService
     public function markNotificationAsRead(Notification $notification): void;
 
     /**
-     * Mark notification as unread so it no longer bother the user.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Notification\Notification $notification
+     * Marks the given notification as unread so it is shown again as new to the user.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException

--- a/src/contracts/Repository/NotificationService.php
+++ b/src/contracts/Repository/NotificationService.php
@@ -50,6 +50,16 @@ interface NotificationService
     public function markNotificationAsRead(Notification $notification): void;
 
     /**
+     * Mark notification as unread so it no longer bother the user.
+     *
+     * @param \Ibexa\Contracts\Core\Repository\Values\Notification\Notification $notification
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     */
+    public function markNotificationAsUnread(Notification $notification): void;
+
+    /**
      * Get count of unread users notifications.
      *
      * @return int

--- a/src/lib/Event/NotificationService.php
+++ b/src/lib/Event/NotificationService.php
@@ -12,9 +12,11 @@ use Ibexa\Contracts\Core\Repository\Decorator\NotificationServiceDecorator;
 use Ibexa\Contracts\Core\Repository\Events\Notification\BeforeCreateNotificationEvent;
 use Ibexa\Contracts\Core\Repository\Events\Notification\BeforeDeleteNotificationEvent;
 use Ibexa\Contracts\Core\Repository\Events\Notification\BeforeMarkNotificationAsReadEvent;
+use Ibexa\Contracts\Core\Repository\Events\Notification\BeforeMarkNotificationAsUnreadEvent;
 use Ibexa\Contracts\Core\Repository\Events\Notification\CreateNotificationEvent;
 use Ibexa\Contracts\Core\Repository\Events\Notification\DeleteNotificationEvent;
 use Ibexa\Contracts\Core\Repository\Events\Notification\MarkNotificationAsReadEvent;
+use Ibexa\Contracts\Core\Repository\Events\Notification\MarkNotificationAsUnreadEvent;
 use Ibexa\Contracts\Core\Repository\NotificationService as NotificationServiceInterface;
 use Ibexa\Contracts\Core\Repository\Values\Notification\CreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Notification\Notification;
@@ -49,6 +51,24 @@ class NotificationService extends NotificationServiceDecorator
 
         $this->eventDispatcher->dispatch(
             new MarkNotificationAsReadEvent(...$eventData)
+        );
+    }
+
+    public function markNotificationAsUnread(Notification $notification): void
+    {
+        $eventData = [$notification];
+
+        $beforeEvent = new BeforeMarkNotificationAsUnreadEvent(...$eventData);
+
+        $this->eventDispatcher->dispatch($beforeEvent);
+        if ($beforeEvent->isPropagationStopped()) {
+            return;
+        }
+
+        $this->innerService->markNotificationAsUnread($notification);
+
+        $this->eventDispatcher->dispatch(
+            new MarkNotificationAsUnreadEvent(...$eventData)
         );
     }
 

--- a/src/lib/Repository/Helper/RelationProcessor.php
+++ b/src/lib/Repository/Helper/RelationProcessor.php
@@ -123,7 +123,7 @@ class RelationProcessor
                 }
             }
 
-            if ($relation->type & Relation::ASSET) {
+            if ($relation->type & Relation::ASSET && null !== $relation->sourceFieldDefinitionIdentifier) {
                 $fieldDefinition = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier);
                 if ($fieldDefinition !== null) {
                     $mappedRelations[Relation::ASSET][$fieldDefinition->id][$relation->destinationContentInfo->id] = $relation;

--- a/src/lib/Repository/NotificationService.php
+++ b/src/lib/Repository/NotificationService.php
@@ -112,7 +112,7 @@ class NotificationService implements NotificationServiceInterface
         }
 
         if ($notification->ownerId !== $currentUserId) {
-            throw new UnauthorizedException($notification->id, 'Notification');
+            throw new UnauthorizedException('notification', 'update', ['id' => $notification->id]);
         }
 
         if (!$notification->isPending) {
@@ -134,7 +134,7 @@ class NotificationService implements NotificationServiceInterface
         }
 
         if ($notification->ownerId !== $currentUserId) {
-            throw new UnauthorizedException($notification->id, 'Notification');
+            throw new UnauthorizedException('notification', 'update', ['id' => $notification->id]);
         }
 
         if ($notification->isPending) {

--- a/src/lib/Repository/NotificationService.php
+++ b/src/lib/Repository/NotificationService.php
@@ -128,6 +128,31 @@ class NotificationService implements NotificationServiceInterface
     /**
      * {@inheritdoc}
      */
+    public function markNotificationAsUnread(APINotification $notification): void
+    {
+        $currentUserId = $this->getCurrentUserId();
+
+        if (!$notification->id) {
+            throw new NotFoundException('Notification', $notification->id);
+        }
+
+        if ($notification->ownerId !== $currentUserId) {
+            throw new UnauthorizedException($notification->id, 'Notification');
+        }
+
+        if ($notification->isPending) {
+            return;
+        }
+
+        $updateStruct = new UpdateStruct();
+        $updateStruct->isPending = true;
+
+        $this->persistenceHandler->updateNotification($notification, $updateStruct);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getPendingNotificationCount(): int
     {
         return $this->persistenceHandler->countPendingNotifications(

--- a/src/lib/Repository/NotificationService.php
+++ b/src/lib/Repository/NotificationService.php
@@ -125,9 +125,6 @@ class NotificationService implements NotificationServiceInterface
         $this->persistenceHandler->updateNotification($notification, $updateStruct);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function markNotificationAsUnread(APINotification $notification): void
     {
         $currentUserId = $this->getCurrentUserId();

--- a/src/lib/Repository/SiteAccessAware/NotificationService.php
+++ b/src/lib/Repository/SiteAccessAware/NotificationService.php
@@ -63,6 +63,16 @@ class NotificationService implements NotificationServiceInterface
     }
 
     /**
+     * Mark notification as unread so it no longer bother the user.
+     *
+     * @param \Ibexa\Contracts\Core\Repository\Values\Notification\Notification $notification
+     */
+    public function markNotificationAsUnread(Notification $notification): void
+    {
+        $this->service->markNotificationAsUnread($notification);
+    }
+
+    /**
      * Get count of unread users notifications.
      *
      * @return int

--- a/src/lib/Repository/SiteAccessAware/NotificationService.php
+++ b/src/lib/Repository/SiteAccessAware/NotificationService.php
@@ -62,11 +62,6 @@ class NotificationService implements NotificationServiceInterface
         $this->service->markNotificationAsRead($notification);
     }
 
-    /**
-     * Mark notification as unread so it no longer bother the user.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Notification\Notification $notification
-     */
     public function markNotificationAsUnread(Notification $notification): void
     {
         $this->service->markNotificationAsUnread($notification);

--- a/tests/integration/Core/Repository/NotificationServiceTest.php
+++ b/tests/integration/Core/Repository/NotificationServiceTest.php
@@ -78,6 +78,25 @@ class NotificationServiceTest extends BaseTest
     }
 
     /**
+     * @covers \Ibexa\Contracts\Core\Repository\NotificationService::markNotificationAsUnread()
+     */
+    public function testMarkNotificationAsUnread()
+    {
+        $repository = $this->getRepository();
+
+        $notificationId = $this->generateId('notification', 5);
+        /* BEGIN: Use Case */
+        $notificationService = $repository->getNotificationService();
+
+        $notification = $notificationService->getNotification($notificationId);
+        $notificationService->markNotificationAsUnread($notification);
+        $notification = $notificationService->getNotification($notificationId);
+        /* END: Use Case */
+
+        self::assertTrue($notification->isPending);
+    }
+
+    /**
      * @covers \Ibexa\Contracts\Core\Repository\NotificationService::getPendingNotificationCount()
      */
     public function testGetPendingNotificationCount()

--- a/tests/integration/Core/Repository/NotificationServiceTest.php
+++ b/tests/integration/Core/Repository/NotificationServiceTest.php
@@ -88,6 +88,11 @@ class NotificationServiceTest extends BaseTest
         $notificationService = $repository->getNotificationService();
 
         $notification = $notificationService->getNotification($notificationId);
+        $notificationService->markNotificationAsRead($notification);
+
+        $notification = $notificationService->getNotification($notificationId);
+        self::assertFalse($notification->isPending);
+
         $notificationService->markNotificationAsUnread($notification);
         $notification = $notificationService->getNotification($notificationId);
 

--- a/tests/integration/Core/Repository/NotificationServiceTest.php
+++ b/tests/integration/Core/Repository/NotificationServiceTest.php
@@ -80,18 +80,16 @@ class NotificationServiceTest extends BaseTest
     /**
      * @covers \Ibexa\Contracts\Core\Repository\NotificationService::markNotificationAsUnread()
      */
-    public function testMarkNotificationAsUnread()
+    public function testMarkNotificationAsUnread(): void
     {
         $repository = $this->getRepository();
 
         $notificationId = $this->generateId('notification', 5);
-        /* BEGIN: Use Case */
         $notificationService = $repository->getNotificationService();
 
         $notification = $notificationService->getNotification($notificationId);
         $notificationService->markNotificationAsUnread($notification);
         $notification = $notificationService->getNotification($notificationId);
-        /* END: Use Case */
 
         self::assertTrue($notification->isPending);
     }

--- a/tests/lib/Event/NotificationServiceTest.php
+++ b/tests/lib/Event/NotificationServiceTest.php
@@ -202,7 +202,7 @@ class NotificationServiceTest extends AbstractServiceTest
         $this->assertSame([], $traceableEventDispatcher->getNotCalledListeners());
     }
 
-    public function testMarkNotificationAsUnreadEvents()
+    public function testMarkNotificationAsUnreadEvents(): void
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
             BeforeMarkNotificationAsUnreadEvent::class,
@@ -259,7 +259,7 @@ class NotificationServiceTest extends AbstractServiceTest
         ]);
     }
 
-    public function testMarkNotificationAsUnreadStopPropagationInBeforeEvents()
+    public function testMarkNotificationAsUnreadStopPropagationInBeforeEvents(): void
     {
         $traceableEventDispatcher = $this->getEventDispatcher(
             BeforeMarkNotificationAsUnreadEvent::class,

--- a/tests/lib/Event/NotificationServiceTest.php
+++ b/tests/lib/Event/NotificationServiceTest.php
@@ -65,9 +65,13 @@ class NotificationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
         $innerServiceMock->method('createNotification')->willReturn($notification);
 
-        $traceableEventDispatcher->addListener(BeforeCreateNotificationEvent::class, static function (BeforeCreateNotificationEvent $event) use ($eventNotification) {
-            $event->setNotification($eventNotification);
-        }, 10);
+        $traceableEventDispatcher->addListener(
+            BeforeCreateNotificationEvent::class,
+            static function (BeforeCreateNotificationEvent $event) use ($eventNotification): void {
+                $event->setNotification($eventNotification);
+            },
+            10
+        );
 
         $service = new NotificationService($innerServiceMock, $traceableEventDispatcher);
         $result = $service->createNotification(...$parameters);
@@ -99,10 +103,14 @@ class NotificationServiceTest extends AbstractServiceTest
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
         $innerServiceMock->method('createNotification')->willReturn($notification);
 
-        $traceableEventDispatcher->addListener(BeforeCreateNotificationEvent::class, static function (BeforeCreateNotificationEvent $event) use ($eventNotification) {
-            $event->setNotification($eventNotification);
-            $event->stopPropagation();
-        }, 10);
+        $traceableEventDispatcher->addListener(
+            BeforeCreateNotificationEvent::class,
+            static function (BeforeCreateNotificationEvent $event) use ($eventNotification): void {
+                $event->setNotification($eventNotification);
+                $event->stopPropagation();
+            },
+            10
+        );
 
         $service = new NotificationService($innerServiceMock, $traceableEventDispatcher);
         $result = $service->createNotification(...$parameters);
@@ -158,9 +166,13 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeDeleteNotificationEvent::class, static function (BeforeDeleteNotificationEvent $event) {
-            $event->stopPropagation();
-        }, 10);
+        $traceableEventDispatcher->addListener(
+            BeforeDeleteNotificationEvent::class,
+            static function (BeforeDeleteNotificationEvent $event): void {
+                $event->stopPropagation();
+            },
+            10
+        );
 
         $service = new NotificationService($innerServiceMock, $traceableEventDispatcher);
         $service->deleteNotification(...$parameters);
@@ -240,9 +252,13 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeMarkNotificationAsReadEvent::class, static function (BeforeMarkNotificationAsReadEvent $event) {
-            $event->stopPropagation();
-        }, 10);
+        $traceableEventDispatcher->addListener(
+            BeforeMarkNotificationAsReadEvent::class,
+            static function (BeforeMarkNotificationAsReadEvent $event): void {
+                $event->stopPropagation();
+            },
+            10
+        );
 
         $service = new NotificationService($innerServiceMock, $traceableEventDispatcher);
         $service->markNotificationAsRead(...$parameters);
@@ -272,9 +288,13 @@ class NotificationServiceTest extends AbstractServiceTest
 
         $innerServiceMock = $this->createMock(NotificationServiceInterface::class);
 
-        $traceableEventDispatcher->addListener(BeforeMarkNotificationAsUnreadEvent::class, static function (BeforeMarkNotificationAsUnreadEvent $event) {
-            $event->stopPropagation();
-        }, 10);
+        $traceableEventDispatcher->addListener(
+            BeforeMarkNotificationAsUnreadEvent::class,
+            static function (BeforeMarkNotificationAsUnreadEvent $event): void {
+                $event->stopPropagation();
+            },
+            10
+        );
 
         $service = new NotificationService($innerServiceMock, $traceableEventDispatcher);
         $service->markNotificationAsUnread(...$parameters);

--- a/tests/lib/Repository/Decorator/NotificationServiceDecoratorTest.php
+++ b/tests/lib/Repository/Decorator/NotificationServiceDecoratorTest.php
@@ -67,6 +67,18 @@ class NotificationServiceDecoratorTest extends TestCase
         $decoratedService->markNotificationAsRead(...$parameters);
     }
 
+    public function testMarkNotificationAsUnreadDecorator()
+    {
+        $serviceMock = $this->createServiceMock();
+        $decoratedService = $this->createDecorator($serviceMock);
+
+        $parameters = [$this->createMock(Notification::class)];
+
+        $serviceMock->expects(self::once())->method('markNotificationAsunread')->with(...$parameters);
+
+        $decoratedService->markNotificationAsunread(...$parameters);
+    }
+
     public function testGetPendingNotificationCountDecorator()
     {
         $serviceMock = $this->createServiceMock();

--- a/tests/lib/Repository/Decorator/NotificationServiceDecoratorTest.php
+++ b/tests/lib/Repository/Decorator/NotificationServiceDecoratorTest.php
@@ -67,16 +67,16 @@ class NotificationServiceDecoratorTest extends TestCase
         $decoratedService->markNotificationAsRead(...$parameters);
     }
 
-    public function testMarkNotificationAsUnreadDecorator()
+    public function testMarkNotificationAsUnreadDecorator(): void
     {
         $serviceMock = $this->createServiceMock();
         $decoratedService = $this->createDecorator($serviceMock);
 
         $parameters = [$this->createMock(Notification::class)];
 
-        $serviceMock->expects(self::once())->method('markNotificationAsunread')->with(...$parameters);
+        $serviceMock->expects(self::once())->method('markNotificationAsUnread')->with(...$parameters);
 
-        $decoratedService->markNotificationAsunread(...$parameters);
+        $decoratedService->markNotificationAsUnread(...$parameters);
     }
 
     public function testGetPendingNotificationCountDecorator()


### PR DESCRIPTION
| :ticket: Issue | IBX-9060 |
|----------------|----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR introduces support for marking notifications as unread. This completes the "mark as unread" feature as part of the notification system improvements.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
