### PR TITLE
Added support for ContentAwareInterface in ibexa_render function

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15925,12 +15925,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
 
 		-
-			message: '#^Method Ibexa\\Core\\MVC\\Symfony\\Templating\\Twig\\Extension\\RenderExtension\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/MVC/Symfony/Templating/Twig/Extension/RenderExtension.php
-
-		-
 			message: '#^Method Ibexa\\Core\\MVC\\Symfony\\Templating\\Twig\\Extension\\RenderLocationExtension\:\:renderLocation\(\) has parameter \$options with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderExtension.php
+++ b/src/lib/MVC/Symfony/Templating/Twig/Extension/RenderExtension.php
@@ -61,7 +61,8 @@ final class RenderExtension extends AbstractExtension
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $object
+     * @phpstan-param \Ibexa\Contracts\Core\Repository\Values\ValueObject|\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface $object
+     *
      * @param array<string, mixed> $options
      */
     public function render(object $object, array $options = []): string

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/RenderExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/RenderExtensionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use Ibexa\Contracts\Core\MVC\Templating\RenderStrategy;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
+use Ibexa\Core\MVC\Symfony\Event\ResolveRenderOptionsEvent;
+use Ibexa\Core\MVC\Symfony\Templating\RenderOptions;
+use Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\RenderExtension;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Test\IntegrationTestCase;
+
+final class RenderExtensionTest extends IntegrationTestCase
+{
+    /** @var \Ibexa\Contracts\Core\MVC\Templating\RenderStrategy&\PHPUnit\Framework\MockObject\MockObject */
+    private RenderStrategy $renderStrategy;
+
+    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private EventDispatcherInterface $eventDispatcher;
+
+    protected function setUp(): void
+    {
+        $this->renderStrategy = $this->createMock(RenderStrategy::class);
+        $this->renderStrategy->method('supports')->willReturn(true);
+        $this->renderStrategy->method('render')->willReturnCallback(
+            static function (Content $valueObject): ?string {
+                return $valueObject->getName();
+            }
+        );
+
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->eventDispatcher->method('dispatch')->willReturn(
+            new ResolveRenderOptionsEvent(new RenderOptions())
+        );
+    }
+
+    protected function getExtensions(): array
+    {
+        return [
+            new RenderExtension(
+                $this->renderStrategy,
+                $this->eventDispatcher
+            ),
+        ];
+    }
+
+    protected function getFixturesDir(): string
+    {
+        return __DIR__ . '/_fixtures/render';
+    }
+
+    public function getExampleContent(string $name): Content
+    {
+        $content = $this->createMock(Content::class);
+        $content->method('getName')->willReturn($name);
+
+        return $content;
+    }
+
+    public function getExampleContentAware(string $name): ContentAwareInterface
+    {
+        $contentAware = $this->createMock(ContentAwareInterface::class);
+        $contentAware->method('getContent')->willReturn($this->getExampleContent($name));
+
+        return $contentAware;
+    }
+}

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/RenderExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/RenderExtensionTest.php
@@ -11,9 +11,12 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Templating\Twig\Extension;
 use Ibexa\Contracts\Core\MVC\Templating\RenderStrategy;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface;
+use Ibexa\Contracts\Core\Repository\Values\Setting\Setting;
+use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\MVC\Symfony\Event\ResolveRenderOptionsEvent;
 use Ibexa\Core\MVC\Symfony\Templating\RenderOptions;
 use Ibexa\Core\MVC\Symfony\Templating\Twig\Extension\RenderExtension;
+use stdClass;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Test\IntegrationTestCase;
 
@@ -28,7 +31,9 @@ final class RenderExtensionTest extends IntegrationTestCase
     protected function setUp(): void
     {
         $this->renderStrategy = $this->createMock(RenderStrategy::class);
-        $this->renderStrategy->method('supports')->willReturn(true);
+        $this->renderStrategy->method('supports')->willReturnCallback(
+            static fn (ValueObject $vo): bool => !$vo instanceof Setting
+        );
         $this->renderStrategy->method('render')->willReturnCallback(
             static function (Content $valueObject): ?string {
                 return $valueObject->getName();
@@ -70,5 +75,15 @@ final class RenderExtensionTest extends IntegrationTestCase
         $contentAware->method('getContent')->willReturn($this->getExampleContent($name));
 
         return $contentAware;
+    }
+
+    public function getExampleNonValueObject(): object
+    {
+        return new stdClass();
+    }
+
+    public function getExampleUnsupportedValueObject(): Setting
+    {
+        return new Setting();
     }
 }

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/render/ibexa_render.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/render/ibexa_render.test
@@ -1,0 +1,13 @@
+--TEST--
+"ibexa_render" function
+--TEMPLATE--
+{{ ibexa_render(content) }}
+{{ ibexa_render(content_aware) }}
+--DATA--
+return [
+    'content' => $this->getExampleContent('Example content'),
+    'content_aware' => $this->getExampleContentAware('Example content aware'),
+];
+--EXPECT--
+Example content
+Example content aware

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/render/ibexa_render_with_non_vo.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/render/ibexa_render_with_non_vo.test
@@ -1,0 +1,10 @@
+--TEST--
+ "ibexa_render" function
+--TEMPLATE--
+{{ ibexa_render(non_vo) }}
+--DATA--
+return [
+    'non_vo' => $this->getExampleNonValueObject(),
+];
+--EXPECT--
+Twig\Error\Error: Twig\Error\RuntimeError: An exception has been thrown during the rendering of a template ("Argument 'valueObject' is invalid: stdClass is not a valid value object.") in "index.twig" at line 2.

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/render/ibexa_render_with_unsupported_vo.test
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/_fixtures/render/ibexa_render_with_unsupported_vo.test
@@ -1,0 +1,10 @@
+--TEST--
+"ibexa_render" function with unsupported value object
+--TEMPLATE--
+{{ ibexa_render(unsupported_vo) }}
+--DATA--
+return [
+    'unsupported_vo' => $this->getExampleUnsupportedValueObject(),
+];
+--EXPECT--
+Twig\Error\Error: Twig\Error\RuntimeError: An exception has been thrown during the rendering of a template ("Argument 'valueObject' is invalid: Ibexa\Contracts\Core\Repository\Values\Setting\Setting is not supported.") in "index.twig" at line 2.


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Added support for `\Ibexa\Contracts\Core\Repository\Values\Content\ContentAwareInterface` in `ibexa_render` Twig function 
#### For QA:
`ibexa_render` Twig function with e.g. Product
 
#### Documentation:

Yes, please. 


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
