### PR TITLE
Remove usage of deprecated ContainerAwareTrait

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Cannot call method get\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/bundle/Core/ApiLoader/CacheFactory.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\Core\\ApiLoader\\RepositoryFactory\:\:__construct\(\) has parameter \$policyMap with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -655,24 +649,6 @@ parameters:
 			path: src/bundle/Core/DependencyInjection/Configuration/ConfigParser.php
 
 		-
-			message: '#^Cannot call method getParameter\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 7
-			path: src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
-
-		-
-			message: '#^Cannot call method has\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
-
-		-
-			message: '#^Cannot call method hasParameter\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 8
-			path: src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver\:\:__construct\(\) has parameter \$groupsBySiteAccess with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -749,18 +725,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
-
-		-
-			message: '#^Cannot call method getParameter\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
-
-		-
-			message: '#^Cannot call method hasParameter\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver\\ContainerConfigResolver\:\:resolveNamespaceAndScope\(\) return type has no value type specified in iterable type array\.$#'
@@ -4585,12 +4549,6 @@ parameters:
 			path: src/bundle/IO/DependencyInjection/ConfigurationFactory/Flysystem.php
 
 		-
-			message: '#^Parameter \#1 \$container of method Ibexa\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\Flysystem\:\:createFilesystem\(\) expects Symfony\\Component\\DependencyInjection\\ContainerBuilder, Symfony\\Component\\DependencyInjection\\ContainerInterface\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/bundle/IO/DependencyInjection/ConfigurationFactory/Flysystem.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\MetadataHandler\\LegacyDFSCluster\:\:addConfiguration\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -4793,24 +4751,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: src/bundle/IO/Migration/MigrationHandler.php
-
-		-
-			message: '#^Cannot call method get\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
-
-		-
-			message: '#^Cannot call method getParameter\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
-
-		-
-			message: '#^Cannot call method has\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\LegacySearchEngine\\ApiLoader\\ConnectionFactory\:\:getConnection\(\) should return Doctrine\\DBAL\\Connection but returns object\.$#'
@@ -12163,12 +12103,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Controller/Content/ViewController.php
 
 		-
-			message: '#^Property Ibexa\\Core\\MVC\\Symfony\\Controller\\Content\\ViewController\:\:\$authorizationChecker is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/lib/MVC/Symfony/Controller/Content/ViewController.php
-
-		-
 			message: '#^Call to an undefined method object\:\:getCurrentRequest\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -12178,12 +12112,6 @@ parameters:
 			message: '#^Call to an undefined method object\:\:isGranted\(\)\.$#'
 			identifier: method.notFound
 			count: 1
-			path: src/lib/MVC/Symfony/Controller/Controller.php
-
-		-
-			message: '#^Cannot call method get\(\) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 7
 			path: src/lib/MVC/Symfony/Controller/Controller.php
 
 		-
@@ -25027,18 +24955,6 @@ parameters:
 			path: src/lib/Token/RandomBytesGenerator.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ApiLoader\\CacheFactoryTest\:\:providerGetService\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/Core/ApiLoader/CacheFactoryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ApiLoader\\CacheFactoryTest\:\:testGetService\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ApiLoader/CacheFactoryTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ApiLoader\\CacheFactoryTest\:\:testGetService\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -25047,18 +24963,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ApiLoader\\CacheFactoryTest\:\:testGetService\(\) has parameter \$name with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: tests/bundle/Core/ApiLoader/CacheFactoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$configResolver of method Ibexa\\Bundle\\Core\\ApiLoader\\CacheFactory\:\:getCachePool\(\) expects Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/bundle/Core/ApiLoader/CacheFactoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$container of method Ibexa\\Bundle\\Core\\ApiLoader\\CacheFactory\:\:setContainer\(\) expects Symfony\\Component\\DependencyInjection\\ContainerInterface\|null, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
 			count: 1
 			path: tests/bundle/Core/ApiLoader/CacheFactoryTest.php
 
@@ -25345,7 +25249,7 @@ parameters:
 			path: tests/bundle/Core/ConfigResolverTest.php
 
 		-
-			message: '#^Parameter \#1 \$container of method Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver\:\:setContainer\(\) expects Symfony\\Component\\DependencyInjection\\ContainerInterface\|null, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
+			message: '#^Parameter \#1 \$container of class Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver constructor expects Symfony\\Component\\DependencyInjection\\ContainerInterface, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/bundle/Core/ConfigResolverTest.php
@@ -28689,12 +28593,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:provideHandlerConfiguration\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:provideHandlerConfiguration\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
 

--- a/src/bundle/Core/ApiLoader/CacheFactory.php
+++ b/src/bundle/Core/ApiLoader/CacheFactory.php
@@ -10,8 +10,6 @@ namespace Ibexa\Bundle\Core\ApiLoader;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/src/bundle/Core/ApiLoader/CacheFactory.php
+++ b/src/bundle/Core/ApiLoader/CacheFactory.php
@@ -12,15 +12,21 @@ use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class CacheFactory.
  *
  * Service "ibexa.cache_pool", selects a Symfony cache service based on siteaccess[-group] setting "cache_service_name"
  */
-class CacheFactory implements ContainerAwareInterface
+class CacheFactory
 {
-    use ContainerAwareTrait;
+    private ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
 
     /**
      * @param \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface $configResolver

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
@@ -13,9 +13,8 @@ use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * This class will help you get settings for a specific scope.
@@ -34,15 +33,15 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * 2. SiteAccess name
  * 3. "default"
  */
-class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, ContainerAwareInterface
+class ConfigResolver implements VersatileScopeInterface, SiteAccessAware
 {
-    use ContainerAwareTrait;
-
     public const SCOPE_GLOBAL = 'global';
     public const SCOPE_DEFAULT = 'default';
 
     public const UNDEFINED_STRATEGY_EXCEPTION = 1;
     public const UNDEFINED_STRATEGY_NULL = 2;
+
+    protected ContainerInterface $container;
 
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     protected $siteAccess;
@@ -75,11 +74,13 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
      *                                  - ConfigResolver::UNDEFINED_STRATEGY_NULL (return null)
      */
     public function __construct(
+        ContainerInterface $container,
         ?LoggerInterface $logger,
         array $groupsBySiteAccess,
         $defaultNamespace,
         $undefinedStrategy = self::UNDEFINED_STRATEGY_EXCEPTION
     ) {
+        $this->container = $container;
         $this->logger = $logger ?? new NullLogger();
         $this->groupsBySiteAccess = $groupsBySiteAccess;
         $this->defaultNamespace = $defaultNamespace;

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
@@ -10,12 +10,11 @@ namespace Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-abstract class ContainerConfigResolver implements ConfigResolverInterface, ContainerAwareInterface
+abstract class ContainerConfigResolver implements ConfigResolverInterface
 {
-    use ContainerAwareTrait;
+    protected ContainerInterface $container;
 
     /** @var string */
     private $scope;
@@ -23,8 +22,9 @@ abstract class ContainerConfigResolver implements ConfigResolverInterface, Conta
     /** @var string */
     private $defaultNamespace;
 
-    public function __construct(string $scope, string $defaultNamespace)
+    public function __construct(ContainerInterface $container, string $scope, string $defaultNamespace)
     {
+        $this->container = $container;
         $this->scope = $scope;
         $this->defaultNamespace = $defaultNamespace;
     }

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 /**
  * @internal
  */
@@ -15,9 +17,9 @@ class DefaultScopeConfigResolver extends ContainerConfigResolver
 {
     private const SCOPE_NAME = 'default';
 
-    public function __construct(string $defaultNamespace)
+    public function __construct(ContainerInterface $container, string $defaultNamespace)
     {
-        parent::__construct(self::SCOPE_NAME, $defaultNamespace);
+        parent::__construct($container, self::SCOPE_NAME, $defaultNamespace);
     }
 
     public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 /**
  * @internal
  */
@@ -15,9 +17,9 @@ class GlobalScopeConfigResolver extends ContainerConfigResolver
 {
     private const SCOPE_NAME = 'global';
 
-    public function __construct(string $defaultNamespace)
+    public function __construct(ContainerInterface $container, string $defaultNamespace)
     {
-        parent::__construct(self::SCOPE_NAME, $defaultNamespace);
+        parent::__construct($container, self::SCOPE_NAME, $defaultNamespace);
     }
 
     public function hasParameter(string $paramName, ?string $namespace = null, ?string $scope = null): bool

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -11,26 +11,27 @@ namespace Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver;
 use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccessGroup;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
- *
  * @internal
  */
 class SiteAccessGroupConfigResolver extends SiteAccessConfigResolver
 {
-    use ContainerAwareTrait;
+    protected ContainerInterface $container;
 
     /** @var string[][] */
     protected $siteAccessGroups;
 
     public function __construct(
+        ContainerInterface $container,
         SiteAccess\SiteAccessProviderInterface $siteAccessProvider,
         string $defaultNamespace,
         array $siteAccessGroups
     ) {
         parent::__construct($siteAccessProvider, $defaultNamespace);
+
+        $this->container = $container;
         $this->siteAccessGroups = $siteAccessGroups;
     }
 

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
@@ -11,16 +11,24 @@ namespace Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver;
 use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @property-read \Symfony\Component\DependencyInjection\ContainerInterface $container
- *
  * @internal
  */
 class StaticSiteAccessConfigResolver extends SiteAccessConfigResolver
 {
-    use ContainerAwareTrait;
+    protected ContainerInterface $container;
+
+    public function __construct(
+        ContainerInterface $container,
+        SiteAccess\SiteAccessProviderInterface $siteAccessProvider,
+        string $defaultNamespace
+    ) {
+        parent::__construct($siteAccessProvider, $defaultNamespace);
+
+        $this->container = $container;
+    }
 
     protected function resolverHasParameter(SiteAccess $siteAccess, string $paramName, string $namespace): bool
     {

--- a/src/bundle/Core/Resources/config/cache.yml
+++ b/src/bundle/Core/Resources/config/cache.yml
@@ -7,8 +7,8 @@ services:
 
     Ibexa\Bundle\Core\ApiLoader\CacheFactory:
         class: Ibexa\Bundle\Core\ApiLoader\CacheFactory
-        calls:
-            - [setContainer, ["@service_container"]]
+        arguments:
+            $container: '@service_container'
 
     Ibexa\Bundle\Core\Cache\Warmer\ProxyCacheWarmer:
         arguments:

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -89,8 +89,7 @@ services:
     Ibexa\Core\MVC\Symfony\Controller\Content\ViewController:
         class: Ibexa\Core\MVC\Symfony\Controller\Content\ViewController
         arguments:
-            - '@Ibexa\Core\MVC\Symfony\View\ViewManagerInterface'
-            - "@security.authorization_checker"
+            $viewManager: '@Ibexa\Core\MVC\Symfony\View\ViewManagerInterface'
         parent: Ibexa\Core\MVC\Symfony\Controller\Controller
         tags:
             - { name: controller.service_arguments }
@@ -117,11 +116,9 @@ services:
     Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController:
         class: Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController
         arguments:
-            - '@ibexa.api.service.content'
-            - '@ibexa.field_type.ezbinaryfile.io_service'
-            - '@Ibexa\Core\Helper\TranslationHelper'
-            - "@router"
-            - '@Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator'
+            $contentService: '@ibexa.api.service.content'
+            $ioService: '@ibexa.field_type.ezbinaryfile.io_service'
+            $translationHelper: '@Ibexa\Core\Helper\TranslationHelper'
         parent: Ibexa\Core\MVC\Symfony\Controller\Controller
         tags:
               - { name: controller.service_arguments }
@@ -129,9 +126,9 @@ services:
     Ibexa\Core\MVC\Symfony\Controller\Content\DownloadRedirectionController:
         class: Ibexa\Core\MVC\Symfony\Controller\Content\DownloadRedirectionController
         arguments:
-            - '@ibexa.api.service.content'
-            - "@router"
-            - '@Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator'
+            $contentService: '@ibexa.api.service.content'
+            $router: "@router"
+            $routeReferenceGenerator: '@Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator'
         parent: Ibexa\Core\MVC\Symfony\Controller\Controller
         tags:
               - { name: controller.service_arguments }

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -83,8 +83,8 @@ services:
     Ibexa\Core\MVC\Symfony\Controller\Controller:
         class: Ibexa\Core\MVC\Symfony\Controller\Controller
         abstract: true
-        calls:
-            - [ setContainer, ["@service_container"] ]
+        arguments:
+            $container: '@service_container'
 
     Ibexa\Core\MVC\Symfony\Controller\Content\ViewController:
         class: Ibexa\Core\MVC\Symfony\Controller\Content\ViewController

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -14,41 +14,39 @@ services:
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver:
         arguments:
+            - '@service_container'
             - '%ibexa.config.default_scope%'
-        calls:
-            - [setContainer, ['@service_container']]
         lazy: true
         tags:
             - { name: ibexa.site.config.resolver, priority: 0 }
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\SiteAccessGroupConfigResolver:
         arguments:
+            - '@service_container'
             - '@ibexa.siteaccess.provider'
             - '%ibexa.config.default_scope%'
             - '%ibexa.site_access.groups%'
         calls:
             - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
-            - [setContainer, ['@service_container']]
         lazy: true
         tags:
             - { name: ibexa.site.config.resolver, priority: 50 }
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\StaticSiteAccessConfigResolver:
         arguments:
+            - '@service_container'
             - '@ibexa.siteaccess.provider'
             - '%ibexa.config.default_scope%'
         calls:
             - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
-            - [setContainer, ['@service_container']]
         lazy: true
         tags:
             - { name: ibexa.site.config.resolver, priority: 100 }
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver:
         arguments:
+            - '@service_container'
             - '%ibexa.config.default_scope%'
-        calls:
-            - [setContainer, ['@service_container']]
         lazy: true
         tags:
             - { name: ibexa.site.config.resolver, priority: 255 }

--- a/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
+++ b/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
@@ -93,7 +93,7 @@ class IOConfigurationPass implements CompilerPassInterface
             $handlerServiceDefinition = new ChildDefinition($parentHandlerId);
             $definition = $container->setDefinition($handlerId, $handlerServiceDefinition);
 
-            $configurationFactory->configureHandler($definition, $config);
+            $configurationFactory->configureHandler($container, $definition, $config);
 
             $handlers[$name] = new Reference($handlerId);
         }

--- a/src/bundle/IO/DependencyInjection/ConfigurationFactory.php
+++ b/src/bundle/IO/DependencyInjection/ConfigurationFactory.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Bundle\IO\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition as ServiceDefinition;
 
 /**
@@ -56,5 +57,5 @@ interface ConfigurationFactory
      * @param \Symfony\Component\DependencyInjection\Definition $serviceDefinition
      * @param array $config
      */
-    public function configureHandler(ServiceDefinition $serviceDefinition, array $config);
+    public function configureHandler(ContainerBuilder $container, ServiceDefinition $serviceDefinition, array $config);
 }

--- a/src/bundle/IO/DependencyInjection/ConfigurationFactory/Flysystem.php
+++ b/src/bundle/IO/DependencyInjection/ConfigurationFactory/Flysystem.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory;
 
@@ -11,8 +12,6 @@ use Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition as ServiceDefinition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -22,10 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * Binarydata & metadata are identical, except for the parent service.
  */
-abstract class Flysystem implements ConfigurationFactory, ContainerAwareInterface
+abstract class Flysystem implements ConfigurationFactory
 {
-    use ContainerAwareTrait;
-
     public function addConfiguration(ArrayNodeDefinition $node)
     {
         $node
@@ -45,9 +42,9 @@ abstract class Flysystem implements ConfigurationFactory, ContainerAwareInterfac
             ->end();
     }
 
-    public function configureHandler(ServiceDefinition $definition, array $config)
+    public function configureHandler(ContainerBuilder $container, ServiceDefinition $definition, array $config)
     {
-        $filesystemId = $this->createFilesystem($this->container, $config['name'], $config['adapter']);
+        $filesystemId = $this->createFilesystem($container, $config['name'], $config['adapter']);
         $definition->replaceArgument(0, new Reference($filesystemId));
     }
 

--- a/src/bundle/IO/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSCluster.php
+++ b/src/bundle/IO/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSCluster.php
@@ -9,6 +9,7 @@ namespace Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory\MetadataHandl
 
 use Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition as ServiceDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -19,7 +20,7 @@ class LegacyDFSCluster implements ConfigurationFactory
         return \Ibexa\Core\IO\IOMetadataHandler\LegacyDFSCluster::class;
     }
 
-    public function configureHandler(ServiceDefinition $definition, array $config)
+    public function configureHandler(ContainerBuilder $container, ServiceDefinition $definition, array $config)
     {
         $definition->replaceArgument(0, new Reference($config['connection']));
     }

--- a/src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
+++ b/src/bundle/LegacySearchEngine/ApiLoader/ConnectionFactory.php
@@ -4,22 +4,26 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Bundle\LegacySearchEngine\ApiLoader;
 
+use Doctrine\DBAL\Connection;
 use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use InvalidArgumentException;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ConnectionFactory implements ContainerAwareInterface
+class ConnectionFactory
 {
-    use ContainerAwareTrait;
+    protected ContainerInterface $container;
 
     protected RepositoryConfigurationProviderInterface $repositoryConfigurationProvider;
 
-    public function __construct(RepositoryConfigurationProviderInterface $repositoryConfigurationProvider)
-    {
+    public function __construct(
+        ContainerInterface $container,
+        RepositoryConfigurationProviderInterface $repositoryConfigurationProvider
+    ) {
+        $this->container = $container;
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
     }
 
@@ -27,10 +31,8 @@ class ConnectionFactory implements ContainerAwareInterface
      * Returns database connection used by database handler.
      *
      * @throws \InvalidArgumentException
-     *
-     * @return \Doctrine\DBAL\Connection
      */
-    public function getConnection()
+    public function getConnection(): Connection
     {
         $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
         // Taking provided connection name if any.

--- a/src/bundle/LegacySearchEngine/Resources/config/services.yml
+++ b/src/bundle/LegacySearchEngine/Resources/config/services.yml
@@ -1,9 +1,8 @@
 services:
     Ibexa\Bundle\LegacySearchEngine\ApiLoader\ConnectionFactory:
         arguments:
+            $container: '@service_container'
             $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
-        calls:
-            - [setContainer, ['@service_container']]
 
     ibexa.api.search_engine.legacy.connection:
         class: Doctrine\DBAL\Connection

--- a/src/lib/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/DownloadController.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\MVC\Symfony\Controller\Content;
 
@@ -16,22 +17,26 @@ use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Helper\TranslationHelper;
 use Ibexa\Core\IO\IOServiceInterface;
 use Ibexa\Core\MVC\Symfony\Controller\Controller;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class DownloadController extends Controller
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Ibexa\Core\IO\IOServiceInterface */
-    private $ioService;
+    private IOServiceInterface $ioService;
 
-    /** @var \Ibexa\Core\Helper\TranslationHelper */
-    private $translationHelper;
+    private TranslationHelper $translationHelper;
 
-    public function __construct(ContentService $contentService, IOServiceInterface $ioService, TranslationHelper $translationHelper)
-    {
+    public function __construct(
+        ContainerInterface $container,
+        ContentService $contentService,
+        IOServiceInterface $ioService,
+        TranslationHelper $translationHelper
+    ) {
+        parent::__construct($container);
+
         $this->contentService = $contentService;
         $this->ioService = $ioService;
         $this->translationHelper = $translationHelper;

--- a/src/lib/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\MVC\Symfony\Controller\Content;
 
@@ -13,6 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Core\MVC\Symfony\Controller\Controller;
 use Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
 use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,17 +22,20 @@ use Symfony\Component\Routing\RouterInterface;
 
 class DownloadRedirectionController extends Controller
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    private $contentService;
+    private ContentService $contentService;
 
-    /** @var \Symfony\Component\Routing\RouterInterface */
-    private $router;
+    private RouterInterface $router;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator */
-    private $routeReferenceGenerator;
+    private RouteReferenceGenerator $routeReferenceGenerator;
 
-    public function __construct(ContentService $contentService, RouterInterface $router, RouteReferenceGenerator $routeReferenceGenerator)
-    {
+    public function __construct(
+        ContainerInterface $container,
+        ContentService $contentService,
+        RouterInterface $router,
+        RouteReferenceGenerator $routeReferenceGenerator
+    ) {
+        parent::__construct($container);
+
         $this->contentService = $contentService;
         $this->router = $router;
         $this->routeReferenceGenerator = $routeReferenceGenerator;
@@ -40,14 +45,8 @@ class DownloadRedirectionController extends Controller
      * Used by the REST API to reference downloadable files.
      * It redirects (permanently) to the standard ez_content_download route, based on the language of the field
      * passed as an argument, using the language switcher.
-     *
-     * @param mixed $contentId
-     * @param int $fieldId
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function redirectToContentDownloadAction($contentId, $fieldId, Request $request)
+    public function redirectToContentDownloadAction(int $contentId, int $fieldId, Request $request): RedirectResponse
     {
         $content = $this->contentService->loadContent($contentId);
         $field = $this->findFieldInContent($fieldId, $content);
@@ -77,13 +76,8 @@ class DownloadRedirectionController extends Controller
 
     /**
      * Finds the field with id $fieldId in $content.
-     *
-     * @param int $fieldId
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Field
      */
-    protected function findFieldInContent($fieldId, Content $content)
+    protected function findFieldInContent(int $fieldId, Content $content): Field
     {
         foreach ($content->getFields() as $field) {
             if ($field->id == $fieldId) {

--- a/src/lib/MVC/Symfony/Controller/Content/ViewController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/ViewController.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\MVC\Symfony\Controller\Content;
 
@@ -17,8 +18,8 @@ use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use Ibexa\Core\MVC\Symfony\View\ContentView;
 use Ibexa\Core\MVC\Symfony\View\ViewManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
@@ -28,16 +29,15 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 class ViewController extends Controller
 {
-    /** @var \Ibexa\Core\MVC\Symfony\View\ViewManagerInterface */
-    protected $viewManager;
+    protected ViewManagerInterface $viewManager;
 
-    /** @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface */
-    private $authorizationChecker;
+    public function __construct(
+        ContainerInterface $container,
+        ViewManagerInterface $viewManager,
+    ) {
+        parent::__construct($container);
 
-    public function __construct(ViewManagerInterface $viewManager, AuthorizationCheckerInterface $authorizationChecker)
-    {
         $this->viewManager = $viewManager;
-        $this->authorizationChecker = $authorizationChecker;
     }
 
     /**

--- a/tests/bundle/Core/ApiLoader/CacheFactoryTest.php
+++ b/tests/bundle/Core/ApiLoader/CacheFactoryTest.php
@@ -4,23 +4,23 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\Core\ApiLoader;
 
 use Ibexa\Bundle\Core\ApiLoader\CacheFactory;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class CacheFactoryTest extends TestCase
+final class CacheFactoryTest extends TestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private $configResolver;
+    private ConfigResolverInterface&MockObject $configResolver;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private $container;
+    private ContainerInterface&MockObject $container;
 
     protected function setUp(): void
     {
@@ -30,9 +30,9 @@ class CacheFactoryTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<array{string, string}>
      */
-    public function providerGetService()
+    public function providerGetService(): array
     {
         return [
             ['default', 'default'],
@@ -44,7 +44,7 @@ class CacheFactoryTest extends TestCase
     /**
      * @dataProvider providerGetService
      */
-    public function testGetService($name, $expected)
+    public function testGetService($name, $expected): void
     {
         $this->configResolver
             ->expects(self::once())
@@ -58,8 +58,7 @@ class CacheFactoryTest extends TestCase
             ->with($expected)
             ->will(self::returnValue($this->createMock(AdapterInterface::class)));
 
-        $factory = new CacheFactory();
-        $factory->setContainer($this->container);
+        $factory = new CacheFactory($this->container);
 
         self::assertInstanceOf(TagAwareAdapter::class, $factory->getCachePool($this->configResolver));
     }

--- a/tests/bundle/Core/ConfigResolverTest.php
+++ b/tests/bundle/Core/ConfigResolverTest.php
@@ -38,13 +38,13 @@ class ConfigResolverTest extends TestCase
     private function getResolver($defaultNS = 'ibexa.site_access.config', $undefinedStrategy = ConfigResolver::UNDEFINED_STRATEGY_EXCEPTION, array $groupsBySiteAccess = [])
     {
         $configResolver = new ConfigResolver(
+            $this->containerMock,
             null,
             $groupsBySiteAccess,
             $defaultNS,
             $undefinedStrategy
         );
         $configResolver->setSiteAccess($this->siteAccess);
-        $configResolver->setContainer($this->containerMock);
 
         return $configResolver;
     }

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
@@ -215,22 +215,18 @@ class ChainConfigResolverTest extends TestCase
 
     private function getGlobalConfigResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {
-        $configResolver = new GlobalScopeConfigResolver(
+        return new GlobalScopeConfigResolver(
+            $this->containerMock,
             $defaultNamespace
         );
-        $configResolver->setContainer($this->containerMock);
-
-        return $configResolver;
     }
 
     private function getDefaultConfigResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {
-        $configResolver = new DefaultScopeConfigResolver(
+        return new DefaultScopeConfigResolver(
+            $this->containerMock,
             $defaultNamespace
         );
-        $configResolver->setContainer($this->containerMock);
-
-        return $configResolver;
     }
 
     protected function getSiteAccessGroupConfigResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
@@ -239,11 +235,11 @@ class ChainConfigResolverTest extends TestCase
             self::FIRST_SA_NAME,
         );
         $configResolver = new SiteAccessGroupConfigResolver(
+            $this->containerMock,
             $this->getStaticSiteAccessProvider(),
             $defaultNamespace,
             []
         );
-        $configResolver->setContainer($this->containerMock);
         $configResolver->setSiteAccess($siteAccess);
 
         return $configResolver;
@@ -255,10 +251,10 @@ class ChainConfigResolverTest extends TestCase
             self::FIRST_SA_NAME,
         );
         $configResolver = new StaticSiteAccessConfigResolver(
+            $this->containerMock,
             $this->getStaticSiteAccessProvider(),
             $defaultNamespace
         );
-        $configResolver->setContainer($this->containerMock);
         $configResolver->setSiteAccess($siteAccess);
 
         return $configResolver;

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolverTest.php
@@ -15,12 +15,10 @@ class DefaultScopeConfigResolverTest extends ConfigResolverTest
 {
     protected function getResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {
-        $configResolver = new DefaultScopeConfigResolver(
+        return new DefaultScopeConfigResolver(
+            $this->containerMock,
             $defaultNamespace
         );
-        $configResolver->setContainer($this->containerMock);
-
-        return $configResolver;
     }
 
     protected function getScope(): string

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolverTest.php
@@ -15,12 +15,10 @@ class GlobalScopeConfigResolverTest extends ConfigResolverTest
 {
     protected function getResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {
-        $configResolver = new GlobalScopeConfigResolver(
+        return new GlobalScopeConfigResolver(
+            $this->containerMock,
             $defaultNamespace
         );
-        $configResolver->setContainer($this->containerMock);
-
-        return $configResolver;
     }
 
     protected function getScope(): string

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
@@ -28,11 +28,11 @@ class SiteAccessGroupConfigResolverTest extends ConfigResolverTest
             $this->createMock(Matcher::class)
         );
         $configResolver = new SiteAccessGroupConfigResolver(
+            $this->containerMock,
             $staticSiteAccessProvider,
             $defaultNamespace,
             []
         );
-        $configResolver->setContainer($this->containerMock);
         $configResolver->setSiteAccess($siteAccess);
 
         return $configResolver;

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolverTest.php
@@ -28,10 +28,10 @@ class StaticSiteAccessConfigResolverTest extends ConfigResolverTest
             $this->createMock(Matcher::class)
         );
         $configResolver = new StaticSiteAccessConfigResolver(
+            $this->containerMock,
             $staticSiteAccessProvider,
             $defaultNamespace
         );
-        $configResolver->setContainer($this->containerMock);
         $configResolver->setSiteAccess($siteAccess);
 
         return $configResolver;

--- a/tests/bundle/Core/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Configuration\Parser;
 
@@ -58,14 +59,13 @@ abstract class AbstractParserTestCase extends AbstractExtensionTestCase
         $siteAccessProvider = $this->getSiteAccessProviderMock();
 
         $configResolvers = [
-            new DefaultScopeConfigResolver('default'),
-            new SiteAccessGroupConfigResolver($siteAccessProvider, 'default', [self::EMPTY_SA_GROUP => []]),
-            new StaticSiteAccessConfigResolver($siteAccessProvider, 'default'),
-            new GlobalScopeConfigResolver('default'),
+            new DefaultScopeConfigResolver($this->container, 'default'),
+            new SiteAccessGroupConfigResolver($this->container, $siteAccessProvider, 'default', [self::EMPTY_SA_GROUP => []]),
+            new StaticSiteAccessConfigResolver($this->container, $siteAccessProvider, 'default'),
+            new GlobalScopeConfigResolver($this->container, 'default'),
         ];
 
         foreach ($configResolvers as $priority => $configResolver) {
-            $configResolver->setContainer($this->container);
             $chainConfigResolver->addResolver($configResolver, $priority);
         }
 

--- a/tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+++ b/tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
@@ -10,7 +10,6 @@ namespace Ibexa\Tests\Bundle\IO\DependencyInjection;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractContainerBuilderTestCase;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**
@@ -28,11 +27,6 @@ abstract class ConfigurationFactoryTest extends AbstractContainerBuilderTestCase
         parent::setUp();
 
         $this->factory = $this->provideTestedFactory();
-
-        if ($this->factory instanceof ContainerAwareInterface) {
-            $this->container = new ContainerBuilder();
-            $this->factory->setContainer($this->container);
-        }
     }
 
     public function testGetParentServiceId()
@@ -55,12 +49,12 @@ abstract class ConfigurationFactoryTest extends AbstractContainerBuilderTestCase
     public function testConfigureHandler()
     {
         $handlerConfiguration =
-            $this->provideHandlerConfiguration($this->container) +
+            $this->provideHandlerConfiguration() +
             ['name' => 'my_test_handler', 'type' => 'test_handler'];
 
         $handlerServiceId = $this->registerHandler($handlerConfiguration['name']);
 
-        $this->factory->configureHandler($this->container->getDefinition($handlerServiceId), $handlerConfiguration);
+        $this->factory->configureHandler($this->container, $this->container->getDefinition($handlerServiceId), $handlerConfiguration);
 
         $this->validateConfiguredHandler($handlerServiceId);
 

--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -60,12 +60,12 @@ services:
     ibexa.config.resolver:
         class: Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver
         arguments:
+            - '@service_container'
             - '@logger'
             - []
             - 'ibexa.site_access.config'
         calls:
             - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
-            - [setContainer, ['@service_container']]
             - [setDefaultScope, ['default']]
 
     Ibexa\Core\MVC\Symfony\SiteAccess:

--- a/tests/lib/MVC/Symfony/Controller/ControllerTest.php
+++ b/tests/lib/MVC/Symfony/Controller/ControllerTest.php
@@ -33,8 +33,7 @@ class ControllerTest extends TestCase
     {
         $this->templateEngineMock = $this->createMock(EngineInterface::class);
         $this->containerMock = $this->createMock(ContainerInterface::class);
-        $this->controller = $this->getMockForAbstractClass(Controller::class);
-        $this->controller->setContainer($this->containerMock);
+        $this->controller = $this->getMockForAbstractClass(Controller::class, [$this->containerMock]);
         $this->containerMock
             ->expects(self::any())
             ->method('get')


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Remove usage of deprecated `Symfony\Component\DependencyInjection\ContainerAwareTrait` from the following code units:

* `Ibexa\Bundle\Core\ApiLoader\CacheFactory`
* `Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver` and related classes 
* `Ibexa\Bundle\LegacySearchEngine\ApiLoader\ConnectionFactory`
* `Ibexa\Core\MVC\Symfony\Controller\Controller` and related classes 
* `Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory\Flysystem` and related classes 

This PR unblocks upgrade to Symfony 7. 

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
