### PR TITLE
IBX-8054 Add extension point for doing cleanup during delete operation

### DIFF
--- a/src/lib/Resources/settings/storage_engines/legacy/content.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/content.yml
@@ -56,6 +56,7 @@ services:
             - '@ibexa.persistence.legacy.content.gateway'
             - '@Ibexa\Core\Persistence\Legacy\Content\Mapper'
             - '@Ibexa\Core\Persistence\Legacy\Content\FieldHandler'
+            - !tagged_iterator 'ibexa.core.delete.content.handler'
 
     Ibexa\Core\Persistence\Legacy\Content\Handler:
         class: Ibexa\Core\Persistence\Legacy\Content\Handler


### PR DESCRIPTION
| :ticket: Issue | IBX-8054 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/connector-dam/pull/59

#### Description:
Make an extension point for doing cleanup during delete operation.
For instance, field types may need to clean up data in `ezcontentobject_attribute` table for related content

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
