### PR TITLE
IBX-9060: Added $query parameter for filtering notifications count and loading

### DIFF
--- a/src/contracts/Persistence/Notification/Handler.php
+++ b/src/contracts/Persistence/Notification/Handler.php
@@ -51,20 +51,11 @@ interface Handler
     public function getNotificationById(int $notificationId): Notification;
 
     /**
-     * @param int $userId
-     * @param int $offset
-     * @param int $limit
-     *
      * @return \Ibexa\Contracts\Core\Persistence\Notification\Notification[]
      */
-    public function loadUserNotifications(int $userId, int $offset, int $limit): array;
+    public function loadUserNotifications(int $userId, int $offset, int $limit, ?string $query = null): array;
 
-    /**
-     * @param int $currentUserId
-     *
-     * @return int
-     */
-    public function countNotifications(int $currentUserId): int;
+    public function countNotifications(int $currentUserId, ?string $query = null): int;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Notification\Notification $notification

--- a/src/contracts/Repository/Decorator/NotificationServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/NotificationServiceDecorator.php
@@ -25,9 +25,10 @@ abstract class NotificationServiceDecorator implements NotificationService
 
     public function loadNotifications(
         int $offset,
-        int $limit
+        int $limit,
+        ?string $query = null
     ): NotificationList {
-        return $this->innerService->loadNotifications($offset, $limit);
+        return $this->innerService->loadNotifications($offset, $limit, $query);
     }
 
     public function getNotification(int $notificationId): Notification
@@ -50,9 +51,9 @@ abstract class NotificationServiceDecorator implements NotificationService
         return $this->innerService->getPendingNotificationCount();
     }
 
-    public function getNotificationCount(): int
+    public function getNotificationCount(?string $query = null): int
     {
-        return $this->innerService->getNotificationCount();
+        return $this->innerService->getNotificationCount($query);
     }
 
     public function createNotification(CreateStruct $createStruct): Notification

--- a/src/contracts/Repository/NotificationService.php
+++ b/src/contracts/Repository/NotificationService.php
@@ -18,15 +18,7 @@ use Ibexa\Contracts\Core\Repository\Values\Notification\NotificationList;
  */
 interface NotificationService
 {
-    /**
-     * Get currently logged user notifications.
-     *
-     * @param int $offset the start offset for paging
-     * @param int $limit  the number of notifications returned
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Notification\NotificationList
-     */
-    public function loadNotifications(int $offset, int $limit): NotificationList;
+    public function loadNotifications(int $offset, int $limit, ?string $query = null): NotificationList;
 
     /**
      * Load single notification (by ID).
@@ -64,12 +56,7 @@ interface NotificationService
      */
     public function getPendingNotificationCount(): int;
 
-    /**
-     * Get count of total users notifications.
-     *
-     * @return int
-     */
-    public function getNotificationCount(): int;
+    public function getNotificationCount(?string $query = null): int;
 
     /**
      * Creates a new notification.

--- a/src/lib/Persistence/Cache/NotificationHandler.php
+++ b/src/lib/Persistence/Cache/NotificationHandler.php
@@ -98,13 +98,15 @@ class NotificationHandler extends AbstractHandler implements Handler
         return $count;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countNotifications(int $ownerId): int
+    public function countNotifications(int $ownerId, ?string $query = null): int
     {
+        $cacheKeyParams = [$ownerId];
+        if ($query !== null) {
+            $cacheKeyParams[] = $query;
+        }
+
         $cacheItem = $this->cache->getItem(
-            $this->cacheIdentifierGenerator->generateKey(self::NOTIFICATION_COUNT_IDENTIFIER, [$ownerId], true)
+            $this->cacheIdentifierGenerator->generateKey(self::NOTIFICATION_COUNT_IDENTIFIER, $cacheKeyParams, true)
         );
 
         $count = $cacheItem->get();
@@ -114,9 +116,10 @@ class NotificationHandler extends AbstractHandler implements Handler
 
         $this->logger->logCall(__METHOD__, [
             'ownerId' => $ownerId,
+            'query' => $query,
         ]);
 
-        $count = $this->persistenceHandler->notificationHandler()->countNotifications($ownerId);
+        $count = $this->persistenceHandler->notificationHandler()->countNotifications($ownerId, $query);
 
         $cacheItem->set($count);
         $this->cache->save($cacheItem);
@@ -150,18 +153,16 @@ class NotificationHandler extends AbstractHandler implements Handler
         return $notification;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function loadUserNotifications(int $userId, int $offset, int $limit): array
+    public function loadUserNotifications(int $userId, int $offset, int $limit, ?string $query = null): array
     {
         $this->logger->logCall(__METHOD__, [
             'ownerId' => $userId,
             'offset' => $offset,
             'limit' => $limit,
+            'query' => $query,
         ]);
 
-        return $this->persistenceHandler->notificationHandler()->loadUserNotifications($userId, $offset, $limit);
+        return $this->persistenceHandler->notificationHandler()->loadUserNotifications($userId, $offset, $limit, $query);
     }
 }
 

--- a/src/lib/Persistence/Legacy/Notification/Gateway.php
+++ b/src/lib/Persistence/Legacy/Notification/Gateway.php
@@ -41,12 +41,7 @@ abstract class Gateway
      */
     abstract public function updateNotification(Notification $notification): void;
 
-    /**
-     * @param int $userId
-     *
-     * @return int
-     */
-    abstract public function countUserNotifications(int $userId): int;
+    abstract public function countUserNotifications(int $userId, ?string $query = null): int;
 
     /**
      * Count users unread Notifications.
@@ -57,14 +52,12 @@ abstract class Gateway
      */
     abstract public function countUserPendingNotifications(int $userId): int;
 
-    /**
-     * @param int $userId
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return array
-     */
-    abstract public function loadUserNotifications(int $userId, int $offset = 0, int $limit = -1): array;
+    abstract public function loadUserNotifications(
+        int $userId,
+        int $offset = 0,
+        int $limit = -1,
+        ?string $query = null
+    ): array;
 
     /**
      * @param int $notificationId

--- a/src/lib/Persistence/Legacy/Notification/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Notification/Gateway/DoctrineDatabase.php
@@ -25,20 +25,13 @@ class DoctrineDatabase extends Gateway
     public const COLUMN_CREATED = 'created';
     public const COLUMN_DATA = 'data';
 
-    /** @var \Doctrine\DBAL\Connection */
-    private $connection;
+    private Connection $connection;
 
-    /**
-     * @param \Doctrine\DBAL\Connection $connection
-     */
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function insert(CreateStruct $createStruct): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -62,9 +55,6 @@ class DoctrineDatabase extends Gateway
         return (int) $this->connection->lastInsertId();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNotificationById(int $notificationId): array
     {
         $query = $this->connection->createQueryBuilder();
@@ -78,9 +68,6 @@ class DoctrineDatabase extends Gateway
         return $query->execute()->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function updateNotification(Notification $notification): void
     {
         if (!isset($notification->id) || !is_numeric($notification->id)) {
@@ -99,24 +86,29 @@ class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countUserNotifications(int $userId): int
+    public function countUserNotifications(int $userId, ?string $query = null): int
     {
-        $query = $this->connection->createQueryBuilder();
-        $query
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
             ->select('COUNT(' . self::COLUMN_ID . ')')
             ->from(self::TABLE_NOTIFICATION)
-            ->where($query->expr()->eq(self::COLUMN_OWNER_ID, ':user_id'))
+            ->where($queryBuilder->expr()->eq(self::COLUMN_OWNER_ID, ':user_id'))
             ->setParameter(':user_id', $userId, PDO::PARAM_INT);
 
-        return (int)$query->execute()->fetchColumn();
+        if ($query !== null) {
+            $queryBuilder
+                ->andWhere(
+                    $queryBuilder->expr()->or(
+                        $queryBuilder->expr()->like(self::COLUMN_TYPE, ':query'),
+                        $queryBuilder->expr()->like(self::COLUMN_DATA, ':query')
+                    )
+                )
+                ->setParameter(':query', '%' . $query . '%');
+        }
+
+        return (int)$queryBuilder->execute()->fetchColumn();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function countUserPendingNotifications(int $userId): int
     {
         $query = $this->connection->createQueryBuilder();
@@ -132,31 +124,36 @@ class DoctrineDatabase extends Gateway
         return (int)$query->execute()->fetchColumn();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function loadUserNotifications(int $userId, int $offset = 0, int $limit = -1): array
+    public function loadUserNotifications(int $userId, int $offset = 0, int $limit = -1, ?string $query = null): array
     {
-        $query = $this->connection->createQueryBuilder();
-        $query
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder
             ->select(...$this->getColumns())
             ->from(self::TABLE_NOTIFICATION)
-            ->where($query->expr()->eq(self::COLUMN_OWNER_ID, ':user_id'))
+            ->where($queryBuilder->expr()->eq(self::COLUMN_OWNER_ID, ':user_id'))
             ->setFirstResult($offset);
 
-        if ($limit > 0) {
-            $query->setMaxResults($limit);
+        if ($query !== null) {
+            $queryBuilder
+                ->andWhere(
+                    $queryBuilder->expr()->or(
+                        $queryBuilder->expr()->like(self::COLUMN_TYPE, ':query'),
+                        $queryBuilder->expr()->like(self::COLUMN_DATA, ':query')
+                    )
+                )
+                ->setParameter(':query', '%' . $query . '%');
         }
 
-        $query->orderBy(self::COLUMN_ID, 'DESC');
-        $query->setParameter(':user_id', $userId, PDO::PARAM_INT);
+        if ($limit > 0) {
+            $queryBuilder->setMaxResults($limit);
+        }
 
-        return $query->execute()->fetchAll(PDO::FETCH_ASSOC);
+        $queryBuilder->orderBy(self::COLUMN_ID, 'DESC');
+        $queryBuilder->setParameter(':user_id', $userId, PDO::PARAM_INT);
+
+        return $queryBuilder->execute()->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function delete(int $notificationId): void
     {
         $query = $this->connection->createQueryBuilder();
@@ -168,9 +165,6 @@ class DoctrineDatabase extends Gateway
         $query->execute();
     }
 
-    /**
-     * @return array
-     */
     private function getColumns(): array
     {
         return [

--- a/src/lib/Persistence/Legacy/Notification/Gateway/ExceptionConversion.php
+++ b/src/lib/Persistence/Legacy/Notification/Gateway/ExceptionConversion.php
@@ -52,10 +52,10 @@ class ExceptionConversion extends Gateway
         }
     }
 
-    public function countUserNotifications(int $userId): int
+    public function countUserNotifications(int $userId, ?string $query = null): int
     {
         try {
-            return $this->innerGateway->countUserNotifications($userId);
+            return $this->innerGateway->countUserNotifications($userId, $query);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }
@@ -70,10 +70,10 @@ class ExceptionConversion extends Gateway
         }
     }
 
-    public function loadUserNotifications(int $userId, int $offset = 0, int $limit = -1): array
+    public function loadUserNotifications(int $userId, int $offset = 0, int $limit = -1, ?string $query = null): array
     {
         try {
-            return $this->innerGateway->loadUserNotifications($userId, $offset, $limit);
+            return $this->innerGateway->loadUserNotifications($userId, $offset, $limit, $query);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/src/lib/Persistence/Legacy/Notification/Handler.php
+++ b/src/lib/Persistence/Legacy/Notification/Handler.php
@@ -89,21 +89,18 @@ class Handler implements HandlerInterface
         return $this->getNotificationById($notification->id);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countNotifications(int $userId): int
+    public function countNotifications(int $userId, ?string $query = null): int
     {
-        return $this->gateway->countUserNotifications($userId);
+        return $this->gateway->countUserNotifications($userId, $query);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function loadUserNotifications(int $userId, int $offset, int $limit): array
+    public function loadUserNotifications(int $userId, int $offset, int $limit, ?string $query = null): array
     {
         return $this->mapper->extractNotificationsFromRows(
-            $this->gateway->loadUserNotifications($userId, $offset, $limit)
+            $this->gateway->loadUserNotifications($userId, $offset, $limit, $query)
         );
     }
 

--- a/src/lib/Repository/NotificationService.php
+++ b/src/lib/Repository/NotificationService.php
@@ -40,27 +40,22 @@ class NotificationService implements NotificationServiceInterface
         $this->permissionResolver = $permissionResolver;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function loadNotifications(int $offset = 0, int $limit = 25): NotificationList
+    public function loadNotifications(int $offset = 0, int $limit = 25, ?string $query = null): NotificationList
     {
         $currentUserId = $this->getCurrentUserId();
 
         $list = new NotificationList();
-        $list->totalCount = $this->persistenceHandler->countNotifications($currentUserId);
+        $list->totalCount = $this->persistenceHandler->countNotifications($currentUserId, $query);
+
         if ($list->totalCount > 0) {
             $list->items = array_map(function (Notification $spiNotification) {
                 return $this->buildDomainObject($spiNotification);
-            }, $this->persistenceHandler->loadUserNotifications($currentUserId, $offset, $limit));
+            }, $this->persistenceHandler->loadUserNotifications($currentUserId, $offset, $limit, $query));
         }
 
         return $list;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function createNotification(APICreateStruct $createStruct): APINotification
     {
         $spiCreateStruct = new CreateStruct();
@@ -85,9 +80,6 @@ class NotificationService implements NotificationServiceInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNotification(int $notificationId): APINotification
     {
         $notification = $this->persistenceHandler->getNotificationById($notificationId);
@@ -100,9 +92,6 @@ class NotificationService implements NotificationServiceInterface
         return $this->buildDomainObject($notification);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function markNotificationAsRead(APINotification $notification): void
     {
         $currentUserId = $this->getCurrentUserId();
@@ -147,9 +136,6 @@ class NotificationService implements NotificationServiceInterface
         $this->persistenceHandler->updateNotification($notification, $updateStruct);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPendingNotificationCount(): int
     {
         return $this->persistenceHandler->countPendingNotifications(
@@ -157,19 +143,14 @@ class NotificationService implements NotificationServiceInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNotificationCount(): int
+    public function getNotificationCount(?string $query = null): int
     {
         return $this->persistenceHandler->countNotifications(
-            $this->getCurrentUserId()
+            $this->getCurrentUserId(),
+            $query
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function deleteNotification(APINotification $notification): void
     {
         $this->persistenceHandler->delete($notification);

--- a/src/lib/Repository/SiteAccessAware/NotificationService.php
+++ b/src/lib/Repository/SiteAccessAware/NotificationService.php
@@ -29,17 +29,9 @@ class NotificationService implements NotificationServiceInterface
         $this->service = $service;
     }
 
-    /**
-     * Get currently logged user notifications.
-     *
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Notification\NotificationList
-     */
-    public function loadNotifications(int $offset, int $limit): NotificationList
+    public function loadNotifications(int $offset, int $limit, ?string $query = null): NotificationList
     {
-        return $this->service->loadNotifications($offset, $limit);
+        return $this->service->loadNotifications($offset, $limit, $query);
     }
 
     /**
@@ -77,14 +69,9 @@ class NotificationService implements NotificationServiceInterface
         return $this->service->getPendingNotificationCount();
     }
 
-    /**
-     * Get count of total users notifications.
-     *
-     * @return int
-     */
-    public function getNotificationCount(): int
+    public function getNotificationCount(?string $query = null): int
     {
-        return $this->service->getNotificationCount();
+        return $this->service->getNotificationCount($query);
     }
 
     /**

--- a/tests/integration/Core/Repository/NotificationServiceTest.php
+++ b/tests/integration/Core/Repository/NotificationServiceTest.php
@@ -28,15 +28,16 @@ class NotificationServiceTest extends BaseTest
     {
         $repository = $this->getRepository();
 
-        /* BEGIN: Use Case */
         $notificationService = $repository->getNotificationService();
-        $notificationList = $notificationService->loadNotifications(0, 25);
-        /* END: Use Case */
+        $query = 'Workflow:Review';
+        $notificationList = $notificationService->loadNotifications(0, 25, $query);
 
         $this->assertInstanceOf(NotificationList::class, $notificationList);
         $this->assertIsArray($notificationList->items);
         $this->assertIsInt($notificationList->totalCount);
-        $this->assertEquals(5, $notificationList->totalCount);
+
+        $expectedCount = 3;
+        $this->assertEquals($expectedCount, $notificationList->totalCount);
     }
 
     /**

--- a/tests/lib/Persistence/Legacy/Notification/Gateway/DoctrineDatabaseTest.php
+++ b/tests/lib/Persistence/Legacy/Notification/Gateway/DoctrineDatabaseTest.php
@@ -115,7 +115,7 @@ class DoctrineDatabaseTest extends TestCase
         $offset = 1;
         $limit = 3;
 
-        $results = $this->getGateway()->loadUserNotifications($userId, $offset, $limit);
+        $resultsWithoutQuery = $this->getGateway()->loadUserNotifications($userId, $offset, $limit);
 
         $this->assertEquals([
             [
@@ -142,7 +142,34 @@ class DoctrineDatabaseTest extends TestCase
                 'created' => '1529998652',
                 'data' => null,
             ],
-        ], $results);
+        ], $resultsWithoutQuery);
+
+        $query = 'Workflow:Review';
+        $resultsWithQuery = $this->getGateway()->loadUserNotifications($userId, $offset, $limit, $query);
+
+        $this->assertEquals([
+            [
+                'id' => '4',
+                'owner_id' => '14',
+                'is_pending' => 1,
+                'type' => 'Workflow:Review',
+                'created' => '1530005852',
+                'data' => null,
+            ],
+            [
+                'id' => '1',
+                'owner_id' => '14',
+                'is_pending' => 1,
+                'type' => 'Workflow:Review',
+                'created' => '1529995052',
+                'data' => null,
+            ],
+        ], $resultsWithQuery);
+
+        $queryNoResults = 'NonExistingType';
+        $resultsWithNoResults = $this->getGateway()->loadUserNotifications($userId, $offset, $limit, $queryNoResults);
+
+        $this->assertEquals([], $resultsWithNoResults);
     }
 
     public function testDelete()

--- a/tests/lib/Persistence/Legacy/Notification/HandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Notification/HandlerTest.php
@@ -167,32 +167,42 @@ class HandlerTest extends TestCase
         $ownerId = 9;
         $limit = 5;
         $offset = 0;
+        $query = 'Workflow:Review';
 
         $rows = [
-            ['id' => 1/* ... */],
-            ['id' => 2/* ... */],
-            ['id' => 3/* ... */],
+            ['id' => 1, 'owner_id' => 9, 'is_pending' => 1, 'type' => 'Workflow:Review', 'created' => '1530005852', 'data' => null],
+            ['id' => 2, 'owner_id' => 9, 'is_pending' => 0, 'type' => 'Workflow:Reject', 'created' => '1530002252', 'data' => null],
+            ['id' => 3, 'owner_id' => 9, 'is_pending' => 0, 'type' => 'Workflow:Approve', 'created' => '1529998652', 'data' => null],
         ];
 
         $objects = [
-            new Notification(['id' => 1/* ... */]),
-            new Notification(['id' => 2/* ... */]),
-            new Notification(['id' => 3/* ... */]),
+            new Notification(['id' => 1, 'ownerId' => 9, 'isPending' => 1, 'type' => 'Workflow:Review', 'created' => 1530005852, 'data' => null]),
+            new Notification(['id' => 2, 'ownerId' => 9, 'isPending' => 0, 'type' => 'Workflow:Reject', 'created' => 1530002252, 'data' => null]),
+            new Notification(['id' => 3, 'ownerId' => 9, 'isPending' => 0, 'type' => 'Workflow:Approve', 'created' => 1529998652, 'data' => null]),
         ];
 
         $this->gateway
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('loadUserNotifications')
-            ->with($ownerId, $offset, $limit)
+            ->with(
+                $this->logicalOr(
+                    $this->equalTo($ownerId),
+                    $this->equalTo($query)
+                ),
+                $offset,
+                $limit
+            )
             ->willReturn($rows);
 
         $this->mapper
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('extractNotificationsFromRows')
             ->with($rows)
             ->willReturn($objects);
 
         $this->assertEquals($objects, $this->handler->loadUserNotifications($ownerId, $offset, $limit));
+
+        $this->assertEquals($objects, $this->handler->loadUserNotifications($ownerId, $offset, $limit, $query));
     }
 
     public function testDelete()

--- a/tests/lib/Repository/Decorator/NotificationServiceDecoratorTest.php
+++ b/tests/lib/Repository/Decorator/NotificationServiceDecoratorTest.php
@@ -36,9 +36,12 @@ class NotificationServiceDecoratorTest extends TestCase
         $parameters = [
             264,
             959,
+            'some search query',
         ];
 
-        $serviceMock->expects($this->once())->method('loadNotifications')->with(...$parameters);
+        $serviceMock->expects($this->once())
+            ->method('loadNotifications')
+            ->with(...$parameters);
 
         $decoratedService->loadNotifications(...$parameters);
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-9060 |
|----------------|----------|

#### Description:
- Introduced an optional $query parameter to getNotificationCount, loadNotifications, and related methods to enable filtering by notification type or data.
- Adjusted query logic to apply filtering when $query is provided.
- Updated related tests to cover the new filtering behavior.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
