### PR TITLE
IBX-9810: Fixed inner `validateProperty*()` calls of StructWrapperValidator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-24.04"
         strategy:
             matrix:
                 php:
@@ -35,7 +35,7 @@ jobs:
 
     tests:
         name: Unit tests & SQLite integration tests
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-24.04"
         timeout-minutes: 15
 
         strategy:
@@ -90,7 +90,7 @@ jobs:
                     --health-timeout 5s
                     --health-retries 5
                     --tmpfs /var/lib/postgres
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-24.04"
         timeout-minutes: 60
 
         strategy:
@@ -145,7 +145,7 @@ jobs:
                     --health-timeout=5s
                     --health-retries=5
                     --tmpfs=/var/lib/mysql
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-24.04"
         timeout-minutes: 60
 
         strategy:
@@ -182,7 +182,7 @@ jobs:
 
     solr-integration:
         name: "Solr integration tests"
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-24.04"
         timeout-minutes: 30
         permissions:
             packages: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         strategy:
             matrix:
                 php:
@@ -35,7 +35,7 @@ jobs:
 
     tests:
         name: Unit tests & SQLite integration tests
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 15
 
         strategy:
@@ -90,7 +90,7 @@ jobs:
                     --health-timeout 5s
                     --health-retries 5
                     --tmpfs /var/lib/postgres
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 60
 
         strategy:
@@ -145,7 +145,7 @@ jobs:
                     --health-timeout=5s
                     --health-retries=5
                     --tmpfs=/var/lib/mysql
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 60
 
         strategy:
@@ -182,7 +182,7 @@ jobs:
 
     solr-integration:
         name: "Solr integration tests"
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 30
         permissions:
             packages: read

--- a/src/contracts/Validation/StructWrapperValidator.php
+++ b/src/contracts/Validation/StructWrapperValidator.php
@@ -74,12 +74,12 @@ final class StructWrapperValidator implements ValidatorInterface
 
     public function validateProperty(object $object, string $propertyName, $groups = null): ConstraintViolationListInterface
     {
-        return $this->inner->validatePropertyValue($object, $propertyName, $groups);
+        return $this->inner->validateProperty($object, $propertyName, $groups);
     }
 
     public function validatePropertyValue($objectOrClass, string $propertyName, $value, $groups = null): ConstraintViolationListInterface
     {
-        return $this->inner->validatePropertyValue($objectOrClass, $propertyName, $groups);
+        return $this->inner->validatePropertyValue($objectOrClass, $propertyName, $value, $groups);
     }
 
     public function startContext(): ContextualValidatorInterface

--- a/tests/lib/Validation/StructWrapperValidatorTest.php
+++ b/tests/lib/Validation/StructWrapperValidatorTest.php
@@ -108,6 +108,39 @@ final class StructWrapperValidatorTest extends TestCase
         self::assertSame('property', $error->getPropertyPath());
     }
 
+    public function testValidateProperty(): void
+    {
+        $initialError = $this->createExampleConstraintViolation();
+        $initialErrors = $this->createExampleConstraintViolationList($initialError);
+
+        $object = new stdClass();
+        $propertyName = 'foobar';
+        $group = ['Default', 'group'];
+        $this->validator->expects(self::exactly(1))
+            ->method('validateProperty')
+            ->with($object, $propertyName, $group)
+            ->willReturn($initialErrors);
+
+        $this->structValidator->validateProperty($object, $propertyName, $group);
+    }
+
+    public function testValidatePropertyValue(): void
+    {
+        $initialError = $this->createExampleConstraintViolation();
+        $initialErrors = $this->createExampleConstraintViolationList($initialError);
+
+        $object = new stdClass();
+        $propertyName = 'foobar';
+        $value = 'someValue';
+        $group = ['Default', 'group'];
+        $this->validator->expects(self::exactly(1))
+            ->method('validatePropertyValue')
+            ->with($object, $propertyName, $value, $group)
+            ->willReturn($initialErrors);
+
+        $this->structValidator->validatePropertyValue($object, $propertyName, $value, $group);
+    }
+
     private function createExampleConstraintViolation(): ConstraintViolationInterface
     {
         return new ConstraintViolation(

--- a/tests/lib/Validation/StructWrapperValidatorTest.php
+++ b/tests/lib/Validation/StructWrapperValidatorTest.php
@@ -116,7 +116,7 @@ final class StructWrapperValidatorTest extends TestCase
         $object = new stdClass();
         $propertyName = 'foobar';
         $group = ['Default', 'group'];
-        $this->validator->expects(self::exactly(1))
+        $this->validator->expects(self::once())
             ->method('validateProperty')
             ->with($object, $propertyName, $group)
             ->willReturn($initialErrors);
@@ -133,7 +133,7 @@ final class StructWrapperValidatorTest extends TestCase
         $propertyName = 'foobar';
         $value = 'someValue';
         $group = ['Default', 'group'];
-        $this->validator->expects(self::exactly(1))
+        $this->validator->expects(self::once())
             ->method('validatePropertyValue')
             ->with($object, $propertyName, $value, $group)
             ->willReturn($initialErrors);


### PR DESCRIPTION

| :ticket: Issue | IBX-9810 |
|----------------|-----------|

#### Description:
Looks like a a cut&paste mistake when implementing the `validateProperty()` and `validatePropertyValue()` methods.
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
