### PR TITLE
IBX-9262: Fixed Relation::Asset not being cleaned up on content deletion

### DIFF
--- a/src/lib/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1141,7 +1141,7 @@ final class DoctrineDatabase extends Gateway
                 )
             )
             ->setParameter('content_id', $contentId, ParameterType::INTEGER)
-            ->setParameter('relation_type', Relation::FIELD, ParameterType::INTEGER);
+            ->setParameter('relation_type', Relation::FIELD | Relation::ASSET, ParameterType::INTEGER);
 
         $statement = $query->execute();
 
@@ -1152,6 +1152,10 @@ final class DoctrineDatabase extends Gateway
 
             if ($row['data_type_string'] === 'ezobjectrelationlist') {
                 $this->removeRelationFromRelationListField($contentId, $row);
+            }
+
+            if ($row['data_type_string'] === 'ezimageasset') {
+                $this->removeRelationFromAssetField($row);
             }
         }
     }
@@ -1211,6 +1215,33 @@ final class DoctrineDatabase extends Gateway
             ->update(self::CONTENT_FIELD_TABLE)
             ->set('data_int', ':data_int')
             ->set('sort_key_int', ':sort_key_int')
+            ->setParameter('data_int', null, ParameterType::NULL)
+            ->setParameter('sort_key_int', 0, ParameterType::INTEGER)
+            ->where('id = :attribute_id')
+            ->andWhere('version = :version_no')
+            ->setParameter('attribute_id', (int)$row['id'], ParameterType::INTEGER)
+            ->setParameter('version_no', (int)$row['version'], ParameterType::INTEGER);
+
+        $query->execute();
+    }
+
+    /**
+     * @param array{
+     *     id: int|string,
+     *     version: int|string,
+     *     data_type_string: string,
+     *     data_text: string|null
+     * } $row
+     */
+    private function removeRelationFromAssetField(array $row): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->update(self::CONTENT_FIELD_TABLE)
+            ->set('data_text', ':data_text')
+            ->set('data_int', ':data_int')
+            ->set('sort_key_int', ':sort_key_int')
+            ->setParameter('data_text', null, ParameterType::NULL)
             ->setParameter('data_int', null, ParameterType::NULL)
             ->setParameter('sort_key_int', 0, ParameterType::INTEGER)
             ->where('id = :attribute_id')

--- a/tests/integration/Core/Repository/ContentService/ImageAssetTest.php
+++ b/tests/integration/Core/Repository/ContentService/ImageAssetTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\ContentService;
+
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Core\FieldType\Image\Value;
+use Ibexa\Tests\Integration\Core\RepositoryTestCase;
+
+final class ImageAssetTest extends RepositoryTestCase
+{
+    private ContentService $contentService;
+
+    private ContentTypeService $contentTypeService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contentService = self::getContentService();
+        $this->contentTypeService = self::getContentTypeService();
+    }
+
+    public function testAssetRelationIsRemoved(): void
+    {
+        $contentType = $this->createContentTypeWithImageAsset();
+        $destinationContent = $this->createImageContent();
+
+        $struct = $this->contentService->newContentCreateStruct($contentType, 'eng-US');
+        $struct->setField('asset', new \Ibexa\Core\FieldType\ImageAsset\Value(
+            $destinationContent->getId(),
+        ));
+        $assetContent = $this->contentService->publishVersion(
+            $this->contentService->createContent($struct)->getVersionInfo()
+        );
+
+        self::assertEquals(1, $this->contentService->countRelations($assetContent->getVersionInfo()));
+        self::assertEquals(1, $this->contentService->countReverseRelations($destinationContent->getContentInfo()));
+
+        $this->contentService->deleteContent($destinationContent->getContentInfo());
+
+        self::assertEquals(0, $this->contentService->countRelations($assetContent->getVersionInfo()));
+        self::assertEquals(0, $this->contentService->countReverseRelations($destinationContent->getContentInfo()));
+
+        $assetContent = $this->contentService->loadContentByContentInfo($assetContent->getContentInfo());
+
+        /** @var \Ibexa\Core\FieldType\ImageAsset\Value $value */
+        $value = $assetContent->getFieldValue('asset');
+        self::assertNull($value->destinationContentId);
+    }
+
+    private function createContentTypeWithImageAsset(): ContentType
+    {
+        $struct = $this->contentTypeService->newContentTypeCreateStruct('content_type_with_image_asset');
+        $struct->names = ['eng-US' => 'Content Type with Image Asset'];
+
+        $struct->addFieldDefinition(
+            $this->contentTypeService->newFieldDefinitionCreateStruct('asset', 'ezimageasset')
+        );
+        $struct->mainLanguageCode = 'eng-US';
+        $contentType = $this->contentTypeService->createContentType(
+            $struct,
+            [$this->contentTypeService->loadContentTypeGroupByIdentifier('Content')],
+        );
+        $this->contentTypeService->publishContentTypeDraft($contentType);
+
+        return $this->contentTypeService->loadContentType($contentType->id);
+    }
+
+    private function createImageContent(): Content
+    {
+        $path = __DIR__ . '/../_fixtures/image/square.png';
+
+        $imageContentType = $this->contentTypeService->loadContentTypeByIdentifier('image');
+        $struct = $this->contentService->newContentCreateStruct($imageContentType, 'eng-US');
+        $struct->setField('name', 'Image Name');
+        $struct->setField('image', new Value(
+            [
+                'fileName' => 'square.jpg',
+                'inputUri' => $path,
+                'fileSize' => filesize($path),
+            ],
+        ));
+        $content = $this->contentService->createContent(
+            $struct
+        );
+
+        return $this->contentService->publishVersion($content->getVersionInfo());
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-9262 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
We were missing image asset cleanup when asset content was deleted.

#### For QA:
Check also if that change did not affect normal relation field type cleanup in any way.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
