### PR TITLE
IBX-9898: Added mandatory admin user password altering on `ibexa:install`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3499,6 +3499,12 @@ parameters:
 			path: src/bundle/Core/Fragment/SiteAccessSerializationTrait.php
 
 		-
+			message: '#^Method Ibexa\\Bundle\\Core\\IbexaCoreBundle\:\:getContainerExtension\(\) never returns null so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: src/bundle/Core/IbexaCoreBundle.php
+
+		-
 			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\AliasCleaner\:\:removeAliases\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -12827,6 +12833,12 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: src/lib/MVC/Symfony/Security/UserInterface.php
+
+		-
+			message: '#^Property Ibexa\\Core\\MVC\\Symfony\\Security\\UserWrapped\:\:\$apiUser in isset\(\) is not nullable nor uninitialized\.$#'
+			identifier: isset.initializedProperty
+			count: 1
+			path: src/lib/MVC/Symfony/Security/UserWrapped.php
 
 		-
 			message: '#^Method Ibexa\\Core\\MVC\\Symfony\\SiteAccess\:\:__construct\(\) has parameter \$groups with no value type specified in iterable type array\.$#'

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -112,13 +112,15 @@ final class InstallPlatformCommand extends Command
         $installer->importData();
         $installer->importBinaries();
 
-        $io->warning(
-            'For security reasons, you\'re required to change the default admin password. Remember to follow currently set password validation rules.'
-        );
+        if ($input->isInteractive()) {
+            $io->warning(
+                'For security reasons, you\'re required to change the default admin password. Remember to follow currently set password validation rules.'
+            );
 
-        do {
-            $exitCode = $this->changeDefaultAdminPassword($input);
-        } while ($exitCode !== self::SUCCESS);
+            do {
+                $exitCode = $this->changeDefaultAdminPassword($input);
+            } while ($exitCode !== self::SUCCESS);
+        }
 
         $this->cacheClear($output);
 
@@ -295,10 +297,6 @@ final class InstallPlatformCommand extends Command
             'user' => 'admin',
             '--password' => $password,
         ]);
-
-        $commandInput->setInteractive(
-            $input->isInteractive()
-        );
 
         $application = $this->getApplication();
 

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -108,6 +108,9 @@ final class InstallPlatformCommand extends Command
         $installer->importSchema();
         $installer->importData();
         $installer->importBinaries();
+
+        $this->changeDefaultAdminPassword($input);
+
         $this->cacheClear($output);
 
         if (!$input->getOption('skip-indexing')) {
@@ -271,5 +274,24 @@ final class InstallPlatformCommand extends Command
         if (!$process->getExitCode() === 1) {
             throw new \RuntimeException(sprintf('An error occurred when executing the "%s" command.', escapeshellarg($cmd)));
         }
+    }
+
+    private function changeDefaultAdminPassword(InputInterface $input): void
+    {
+        $io = new SymfonyStyle($input, $this->output);
+        $io->warning(<<<EOT
+        As per safety measure, please change the default admin password. Remember to follow currently configured password validation rules as there will be no do-overs!
+        
+        If password is not accepted now you can still update it after the installation using the following command:
+        
+        ibexa:user:update-user admin --password.
+        EOT);
+
+        $password = $io->askHidden('Password (your input will be hidden)');
+
+        $this->executeCommand(
+            $this->output,
+            'ibexa:user:update-user admin --password=' . $password
+        );
     }
 }

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -296,7 +296,7 @@ final class InstallPlatformCommand extends Command
         ]);
 
         $commandInput->setInteractive(
-            $commandInput->isInteractive()
+            $input->isInteractive()
         );
 
         $application = $this->getApplication();

--- a/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
+++ b/src/bundle/RepositoryInstaller/Command/InstallPlatformCommand.php
@@ -10,6 +10,7 @@ namespace Ibexa\Bundle\RepositoryInstaller\Command;
 use Doctrine\DBAL\Connection;
 use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException;
+use LogicException;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -302,9 +303,7 @@ final class InstallPlatformCommand extends Command
         $application = $this->getApplication();
 
         if ($application === null) {
-            $io->error('Command application not found');
-
-            return self::FAILURE;
+            throw new LogicException('Command application not found');
         }
 
         try {


### PR DESCRIPTION
| :ticket: Issue | [IBX-9898](https://issues.ibexa.co/browse/IBX-9898) |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
We don't want to risk having the default `admin:publish` scenario for the new installations so I added invocation of existing command for updating user password. ~Since there in no obvious way to perform retry, I added exhaustive explanation on how admin default password should be altered afterwards in case it does not go through validation. Wording can be probably better so I allow myself to ask @juskora for help here. 😉~

Retries are apparently possible as @Steveb-p nicely pointed out - added as below:

![Zrzut ekranu 2025-04-18 o 14 06 28](https://github.com/user-attachments/assets/ac0192e0-b89d-458c-9f20-8b534d15883a)

## Note:
There are two unrelated PHPStan reports. While there are easy to fix, I don't want to give you additional load of rebasing since you handle upgrading to Sf7 already @alongosz. However, if it ticks one of the issues from the list I can do that on this very occasion with a little hassle.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
