### PR TITLE
[CI] Fixed phpstan issues

### DIFF
--- a/src/bundle/Core/IbexaCoreBundle.php
+++ b/src/bundle/Core/IbexaCoreBundle.php
@@ -101,7 +101,7 @@ final class IbexaCoreBundle extends Bundle
         $container->registerForAutoconfiguration(VariableProvider::class)->addTag('ezplatform.view.variable_provider');
     }
 
-    public function getContainerExtension(): ?ExtensionInterface
+    public function getContainerExtension(): ExtensionInterface
     {
         if (!isset($this->extension)) {
             $this->extension = new IbexaCoreExtension(

--- a/src/lib/MVC/Symfony/Security/UserWrapped.php
+++ b/src/lib/MVC/Symfony/Security/UserWrapped.php
@@ -28,7 +28,7 @@ class UserWrapped implements ReferenceUserInterface, EquatableInterface
 {
     private UserInterface $wrappedUser;
 
-    private APIUser $apiUser;
+    private ?APIUser $apiUser = null;
 
     private APIUserReference $apiUserReference;
 
@@ -52,7 +52,7 @@ class UserWrapped implements ReferenceUserInterface, EquatableInterface
 
     public function getAPIUser(): APIUser
     {
-        if (!isset($this->apiUser)) {
+        if ($this->apiUser === null) {
             throw new LogicException(
                 'Attempted to get APIUser before it has been set by UserProvider, APIUser is not serialized to session'
             );


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

```
 ------ ------------------------------------------------------------------- 
  Line   src/bundle/Core/IbexaCoreBundle.php                                
 ------ ------------------------------------------------------------------- 
  104    Method Ibexa\Bundle\Core\IbexaCoreBundle::getContainerExtension()  
         never returns null so it can be removed from the return type.      
         🪪  return.unusedType                                              
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   src/lib/MVC/Symfony/Security/UserWrapped.php                       
 ------ ------------------------------------------------------------------- 
  55     Property Ibexa\Core\MVC\Symfony\Security\UserWrapped::$apiUser in  
         isset() is not nullable nor uninitialized.                         
         🪪  isset.initializedProperty                                      
 ------ ------------------------------------------------------------------- 
 ```

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
