### PR TITLE
IBX-9446: [BO] Fatal error after non-translatable field added to Content Type

### DIFF
--- a/src/lib/Persistence/Legacy/Content/FieldHandler.php
+++ b/src/lib/Persistence/Legacy/Content/FieldHandler.php
@@ -334,10 +334,10 @@ class FieldHandler
                     $field->versionNo = $content->versionInfo->versionNo;
                     if (isset($field->id) && array_key_exists($field->languageCode, $existingLanguageCodes)) {
                         $this->updateField($field, $content);
-                        $updatedFields[$fieldDefinition->id][$languageCode] = $field;
                     } else {
                         $this->createNewField($field, $content);
                     }
+                    $updatedFields[$fieldDefinition->id][$languageCode] = $field;
                 } elseif (!isset($existingLanguageCodes[$languageCode])) {
                     // If field is not set for new language
                     if ($fieldDefinition->isTranslatable) {


### PR DESCRIPTION

| :ticket: Issue | IBX-9446 |
|----------------|-----------|

#### Description:
This is a fix for a regression caused by the "virtual fields" introduced in 98b7b50e601

#### For QA:
See ticket for step-by-step on how to reproduce the problem


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
