### PR TITLE
IBX-8125: Added *link* index to ezurlalias_ml

### DIFF
--- a/src/bundle/Core/Resources/config/storage/legacy/schema.yaml
+++ b/src/bundle/Core/Resources/config/storage/legacy/schema.yaml
@@ -581,6 +581,7 @@ tables:
             ezurlalias_ml_par_lnk_txt: { fields: [parent, text, link], options: { lengths: [null, '32', null] } }
             ezurlalias_ml_act_org: { fields: [action, is_original], options: { lengths: ['32', null] } }
             ezurlalias_ml_text: { fields: [text, id, link], options: { lengths: ['32', null, null] } }
+            ezurlalias_ml_link: { fields: [link] }
             ezurlalias_ml_id: { fields: [id] }
         id:
             parent: { type: integer, nullable: false, options: { default: '0' } }


### PR DESCRIPTION
| :ticket: Issue | IBX-8125|
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/installer/pull/161

#### Description:
LocationService::moveSubtree can result in such a query being executed:

```
SELECT parent, text_md5 FROM `ezurlalias_ml` WHERE
    (is_alias = ?) AND
    (is_original = ?) AND
    (action_type = ?)
    AND (link = ?)
```
Running:
```
EXPLAIN SELECT parent, text_md5 FROM `ezurlalias_ml` WHERE
    (is_alias = 0) AND
    (is_original = 0) AND
    (action_type = 'eznode')
    AND (link = 67);
```
shows that link column is not part of the index and number of checked rows is unnecessarily high.

