### PR TITLE
Fixed an issue reported by PHPStan

### DIFF
--- a/src/bundle/IO/BinaryStreamResponse.php
+++ b/src/bundle/IO/BinaryStreamResponse.php
@@ -9,6 +9,7 @@ namespace Ibexa\Bundle\IO;
 use DateTime;
 use Ibexa\Core\IO\IOServiceInterface;
 use Ibexa\Core\IO\Values\BinaryFile;
+use InvalidArgumentException;
 use LogicException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -118,6 +119,13 @@ class BinaryStreamResponse extends Response
 
         if (empty($filenameFallback)) {
             $filenameFallback = mb_convert_encoding($filename, 'ASCII');
+
+            if ($filenameFallback === false) {
+                throw new InvalidArgumentException(sprintf(
+                    'Could not convert filename "%s" to ASCII. It contains invalid or non-ASCII byte sequences.',
+                    $filename
+                ));
+            }
         }
 
         $dispositionHeader = $this->headers->makeDisposition($disposition, $filename, $filenameFallback);


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fixes
```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/bundle/IO/BinaryStreamResponse.php                                                                                                              
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------- 
  123    Parameter #3 $filenameFallback of method Symfony\Component\HttpFoundation\ResponseHeaderBag::makeDisposition() expects string, string|false given.  
         🪪 argument.type                                                                                                                                     
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------- 
```

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
