### PR TITLE
Fixed collection subtypes PHPStan declarations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5881,6 +5881,12 @@ parameters:
 			path: src/bundle/RepositoryInstaller/Installer/Installer.php
 
 		-
+			message: '#^Template type TValue is declared as covariant, but occurs in invariant position in property Ibexa\\Contracts\\Core\\Collection\\AbstractInMemoryCollection\:\:\$items\.$#'
+			identifier: generics.variance
+			count: 1
+			path: src/contracts/Collection/AbstractInMemoryCollection.php
+
+		-
 			message: '#^Parameter \#2 \$offset of function array_splice expects int, int\|string given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5881,22 +5881,10 @@ parameters:
 			path: src/bundle/RepositoryInstaller/Installer/Installer.php
 
 		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Collection\\MutableArrayList\:\:createFrom\(\) return type with generic class Ibexa\\Contracts\\Core\\Collection\\MutableArrayList does not specify its types\: TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/contracts/Collection/MutableArrayList.php
-
-		-
 			message: '#^Parameter \#2 \$offset of function array_splice expects int, int\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/contracts/Collection/MutableArrayList.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Collection\\MutableArrayMap\:\:createFrom\(\) return type with generic class Ibexa\\Contracts\\Core\\Collection\\MutableArrayMap does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/contracts/Collection/MutableArrayMap.php
 
 		-
 			message: '#^Binary operation "\." between array\|bool\|float\|int\|string\|null and ''/'' results in an error\.$#'

--- a/src/contracts/Collection/AbstractInMemoryCollection.php
+++ b/src/contracts/Collection/AbstractInMemoryCollection.php
@@ -14,7 +14,7 @@ use Iterator;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @template-implements \Ibexa\Contracts\Core\Collection\CollectionInterface<TValue>
  * @template-implements \Ibexa\Contracts\Core\Collection\StreamableInterface<TValue>
@@ -53,8 +53,6 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @phpstan-param \Closure(TValue, TKey=): bool $predicate
-     *
      * @phpstan-return static<TKey, TValue>
      */
     public function filter(Closure $predicate): self
@@ -63,8 +61,6 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @phpstan-param \Closure(TValue): mixed $function
-     *
      * @phpstan-return static<TKey, TValue>
      */
     public function map(Closure $function): self
@@ -72,9 +68,6 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
         return $this->createFrom(array_map($function, $this->items));
     }
 
-    /**
-     * @param \Closure(TValue, TKey): bool $predicate
-     */
     public function forAll(Closure $predicate): bool
     {
         foreach ($this->items as $i => $item) {

--- a/src/contracts/Collection/AbstractInMemoryCollection.php
+++ b/src/contracts/Collection/AbstractInMemoryCollection.php
@@ -13,7 +13,6 @@ use Closure;
 use Iterator;
 
 /**
- * @template TKey of array-key
  * @template-covariant TValue
  *
  * @template-implements \Ibexa\Contracts\Core\Collection\CollectionInterface<TValue>
@@ -21,11 +20,11 @@ use Iterator;
  */
 abstract class AbstractInMemoryCollection implements CollectionInterface, StreamableInterface
 {
-    /** @phpstan-var array<TKey, TValue> */
+    /** @phpstan-var TValue[] */
     protected array $items;
 
     /**
-     * @phpstan-param array<TKey, TValue> $items
+     * @phpstan-param TValue[] $items
      */
     public function __construct(array $items = [])
     {
@@ -53,7 +52,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @phpstan-return static<TKey, TValue>
+     * @phpstan-return static<TValue>
      */
     public function filter(Closure $predicate): self
     {
@@ -61,7 +60,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @phpstan-return static<TKey, TValue>
+     * @phpstan-return static<TValue>
      */
     public function map(Closure $function): self
     {
@@ -79,9 +78,6 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
         return true;
     }
 
-    /**
-     * @param \Closure(TValue, TKey): bool $predicate
-     */
     public function exists(Closure $predicate): bool
     {
         foreach ($this->items as $i => $item) {
@@ -96,9 +92,9 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     /**
      * @template TValueFrom
      *
-     * @param array<TKey, TValueFrom> $items
+     * @param array<TValueFrom> $items
      *
-     * @phpstan-return static<TKey, TValueFrom>
+     * @phpstan-return static<TValueFrom>
      */
     abstract protected function createFrom(array $items): self;
 }

--- a/src/contracts/Collection/AbstractInMemoryCollection.php
+++ b/src/contracts/Collection/AbstractInMemoryCollection.php
@@ -54,6 +54,8 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
 
     /**
      * @phpstan-param \Closure(TValue, TKey=): bool $predicate
+     *
+     * @phpstan-return static<TKey, TValue>
      */
     public function filter(Closure $predicate): self
     {

--- a/src/contracts/Collection/AbstractInMemoryCollection.php
+++ b/src/contracts/Collection/AbstractInMemoryCollection.php
@@ -13,6 +13,7 @@ use Closure;
 use Iterator;
 
 /**
+ * @template TKey of array-key
  * @template TValue
  *
  * @template-implements \Ibexa\Contracts\Core\Collection\CollectionInterface<TValue>
@@ -20,11 +21,11 @@ use Iterator;
  */
 abstract class AbstractInMemoryCollection implements CollectionInterface, StreamableInterface
 {
-    /** @phpstan-var TValue[] */
+    /** @phpstan-var array<TKey, TValue> */
     protected array $items;
 
     /**
-     * @phpstan-param TValue[] $items
+     * @phpstan-param array<TKey, TValue> $items
      */
     public function __construct(array $items = [])
     {
@@ -52,7 +53,7 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @phpstan-return static<TValue>
+     * @phpstan-param \Closure(TValue, TKey=): bool $predicate
      */
     public function filter(Closure $predicate): self
     {
@@ -60,13 +61,18 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @phpstan-return static<TValue>
+     * @phpstan-param \Closure(TValue): mixed $function
+     *
+     * @phpstan-return static<TKey, TValue>
      */
     public function map(Closure $function): self
     {
         return $this->createFrom(array_map($function, $this->items));
     }
 
+    /**
+     * @param \Closure(TValue, TKey): bool $predicate
+     */
     public function forAll(Closure $predicate): bool
     {
         foreach ($this->items as $i => $item) {
@@ -78,6 +84,9 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
         return true;
     }
 
+    /**
+     * @param \Closure(TValue, TKey): bool $predicate
+     */
     public function exists(Closure $predicate): bool
     {
         foreach ($this->items as $i => $item) {
@@ -90,9 +99,11 @@ abstract class AbstractInMemoryCollection implements CollectionInterface, Stream
     }
 
     /**
-     * @param TValue[] $items
+     * @template TValueFrom
      *
-     * @phpstan-return static<TValue>
+     * @param array<TKey, TValueFrom> $items
+     *
+     * @phpstan-return static<TKey, TValueFrom>
      */
     abstract protected function createFrom(array $items): self;
 }

--- a/src/contracts/Collection/ArrayList.php
+++ b/src/contracts/Collection/ArrayList.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Exception\OutOfBoundsException;
 /**
  * @template TValue
  *
- * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<array-key, TValue>
+ * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<TValue>
  * @template-implements \Ibexa\Contracts\Core\Collection\ListInterface<TValue>
  */
 class ArrayList extends AbstractInMemoryCollection implements ListInterface

--- a/src/contracts/Collection/ArrayList.php
+++ b/src/contracts/Collection/ArrayList.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Exception\OutOfBoundsException;
 /**
  * @template TValue
  *
- * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<TValue>
+ * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<array-key, TValue>
  * @template-implements \Ibexa\Contracts\Core\Collection\ListInterface<TValue>
  */
 class ArrayList extends AbstractInMemoryCollection implements ListInterface

--- a/src/contracts/Collection/ArrayMap.php
+++ b/src/contracts/Collection/ArrayMap.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Exception\OutOfBoundsException;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<TKey, TValue>
  * @template-implements \Ibexa\Contracts\Core\Collection\MapInterface<TKey, TValue>

--- a/src/contracts/Collection/ArrayMap.php
+++ b/src/contracts/Collection/ArrayMap.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Core\Exception\OutOfBoundsException;
  * @template TKey of array-key
  * @template-covariant TValue
  *
- * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<TKey, TValue>
+ * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<TValue>
  * @template-implements \Ibexa\Contracts\Core\Collection\MapInterface<TKey, TValue>
  */
 class ArrayMap extends AbstractInMemoryCollection implements MapInterface

--- a/src/contracts/Collection/ArrayMap.php
+++ b/src/contracts/Collection/ArrayMap.php
@@ -11,10 +11,10 @@ namespace Ibexa\Contracts\Core\Collection;
 use Ibexa\Contracts\Core\Exception\OutOfBoundsException;
 
 /**
- * @template TKey
+ * @template TKey of array-key
  * @template TValue
  *
- * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<TValue>
+ * @template-extends \Ibexa\Contracts\Core\Collection\AbstractInMemoryCollection<TKey, TValue>
  * @template-implements \Ibexa\Contracts\Core\Collection\MapInterface<TKey, TValue>
  */
 class ArrayMap extends AbstractInMemoryCollection implements MapInterface
@@ -34,9 +34,11 @@ class ArrayMap extends AbstractInMemoryCollection implements MapInterface
     }
 
     /**
-     * @phpstan-param TValue[] $items
+     * @template TValueFrom
      *
-     * @phpstan-return \Ibexa\Contracts\Core\Collection\ArrayMap<TKey,TValue>
+     * @phpstan-param TValueFrom[] $items
+     *
+     * @phpstan-return \Ibexa\Contracts\Core\Collection\ArrayMap<TKey,TValueFrom>
      */
     protected function createFrom(array $items): self
     {

--- a/src/contracts/Collection/CollectionInterface.php
+++ b/src/contracts/Collection/CollectionInterface.php
@@ -13,7 +13,7 @@ use Iterator;
 use IteratorAggregate;
 
 /**
- * @template TValue
+ * @template-covariant TValue
  *
  * @template-extends \IteratorAggregate<TValue>
  */

--- a/src/contracts/Collection/MapInterface.php
+++ b/src/contracts/Collection/MapInterface.php
@@ -10,7 +10,7 @@ namespace Ibexa\Contracts\Core\Collection;
 
 /**
  * @template TKey
- * @template TValue
+ * @template-covariant TValue
  *
  * @template-extends \Ibexa\Contracts\Core\Collection\CollectionInterface<TValue>
  */

--- a/src/contracts/Collection/MutableArrayList.php
+++ b/src/contracts/Collection/MutableArrayList.php
@@ -39,6 +39,13 @@ class MutableArrayList extends ArrayList implements MutableListInterface
         $this->items = [];
     }
 
+    /**
+     * @template TValueFrom
+     *
+     * @phpstan-param TValueFrom[] $items
+     *
+     * @phpstan-return \Ibexa\Contracts\Core\Collection\MutableArrayList<TValueFrom>
+     */
     protected function createFrom(array $items): MutableArrayList
     {
         return new MutableArrayList($items);

--- a/src/contracts/Collection/MutableArrayMap.php
+++ b/src/contracts/Collection/MutableArrayMap.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Core\Collection;
 
 /**
- * @template TKey
+ * @template TKey of array-key
  * @template TValue
  *
  * @template-extends \Ibexa\Contracts\Core\Collection\ArrayMap<TKey,TValue>
@@ -32,6 +32,13 @@ class MutableArrayMap extends ArrayMap implements MutableMapInterface
         $this->items = [];
     }
 
+    /**
+     * @template TValueFrom
+     *
+     * @phpstan-param TValueFrom[] $items
+     *
+     * @phpstan-return \Ibexa\Contracts\Core\Collection\MutableArrayMap<TKey,TValueFrom>
+     */
     protected function createFrom(array $items): MutableArrayMap
     {
         return new MutableArrayMap($items);

--- a/src/contracts/Collection/StreamableInterface.php
+++ b/src/contracts/Collection/StreamableInterface.php
@@ -11,13 +11,15 @@ namespace Ibexa\Contracts\Core\Collection;
 use Closure;
 
 /**
- * @template TValue
+ * @template-covariant TValue
  */
 interface StreamableInterface
 {
     /**
      * Returns all the elements of this collection that satisfy the predicate.
      * The order of the elements is preserved.
+     *
+     * @phpstan-param \Closure(TValue, array-key=): bool $predicate
      *
      * @phpstan-return static<TValue>
      */
@@ -27,17 +29,23 @@ interface StreamableInterface
      * Applies the given function to each element in the collection and returns
      * a new collection with the elements returned by the function.
      *
+     * @phpstan-param \Closure(TValue): mixed $function
+     *
      * @phpstan-return static<TValue>
      */
     public function map(Closure $function): self;
 
     /**
      * Tests whether the given predicate holds for all elements of this collection.
+     *
+     * @param \Closure(TValue, array-key=): bool $predicate
      */
     public function forAll(Closure $predicate): bool;
 
     /**
      * Tests the existence of an element that satisfies the given predicate.
+     *
+     * @param \Closure(TValue, array-key=): bool $predicate
      */
     public function exists(Closure $predicate): bool;
 }


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR fixes an issue with Collection types and their PHPStan declarations.

Using declarations before this change, following was reported as an error by PHPStan:
```php
    /**
     * @return iterable<array{
     *     \Ibexa\Contracts\Core\Collection\ArrayMap<array-key, scalar>,
     * }>
     */
    public function provideForBuiltInFunctionsFromConditions(): iterable
    {
        $context = new ArrayMap([
            'cart_discount_code' => '__code__',
        ]);
        
        yield [
            $context,
        ];
    }
```
with an error similar to this one:
```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/integration/ExpressionLanguage/ExpressionLanguageTest.php                                                                                                                                                            
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  132    Generator expects value type array{Ibexa\Contracts\Core\Collection\ArrayMap<(int|string), bool|float|int|string>}, array{string,  
         'Ibexa\Contracts\Core\Collection\ArrayMap<string, string>} given.                                                       
         🪪 generator.valueType                                                                                                                                                                                                     
         💡 Offset 1 (Ibexa\Contracts\Core\Collection\ArrayMap<(int|string), bool|float|int|string>) does not accept type Ibexa\Contracts\Core\Collection\ArrayMap<string, string>: Template type TValue on class                   
            Ibexa\Contracts\Core\Collection\ArrayMap is not covariant. Learn more: https://phpstan.org/blog/whats-up-with-template-covariant                                                                                        

```

This fix works by introducing `TKey` to descendants where applicable, and making `CollectionInterface::createFrom` use a **local** template type to ensure it properly resolves.

Missing declarations were added.

Additionally, closure declarations are added to ensure proper use across relevant codebase.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
