### PR TITLE
IBX-9968: Resolved Symfony 7.x deprecations

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,9 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_62,
         SymfonySetList::SYMFONY_63,
         SymfonySetList::SYMFONY_64,
+        SymfonySetList::SYMFONY_70,
+        SymfonySetList::SYMFONY_71,
+        SymfonySetList::SYMFONY_72,
         DoctrineSetList::DOCTRINE_DBAL_211,
     ])
     ->withSkip([

--- a/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
@@ -33,7 +33,7 @@ interface ContextualizerInterface
      * <?php
      * namespace Acme\DemoBundle\DependencyInjection;
      *
-     * use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+     * use Symfony\Component\DependencyInjection\Extension\Extension;
      * use Symfony\Component\DependencyInjection\ContainerBuilder;
      * use Symfony\Component\DependencyInjection\Loader;
      * use Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware;
@@ -120,7 +120,7 @@ interface ContextualizerInterface
      * ```php
      * namespace Acme\DemoBundle\DependencyInjection;
      *
-     * use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+     * use Symfony\Component\DependencyInjection\Extension\Extension;
      * use Symfony\Component\DependencyInjection\ContainerBuilder;
      * use Symfony\Component\DependencyInjection\Loader;
      * use Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware;

--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -32,11 +32,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Loader\FileLoader;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class IbexaCoreExtension extends Extension implements PrependExtensionInterface
 {

--- a/src/bundle/Core/Resources/config/helpers.yml
+++ b/src/bundle/Core/Resources/config/helpers.yml
@@ -22,7 +22,7 @@ services:
 
     Ibexa\Bundle\Core\EventListener\ConfigScopeListener:
         arguments:
-            $configResolvers: !tagged ibexa.site.config.resolver
+            $configResolvers: !tagged_iterator ibexa.site.config.resolver
             $viewManager: '@Ibexa\Core\MVC\Symfony\View\ViewManagerInterface'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -81,7 +81,7 @@ services:
     Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider:
         class: Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider
         arguments:
-            $providers: !tagged ibexa.site_access.provider
+            $providers: !tagged_iterator ibexa.site_access.provider
 
     ibexa.siteaccess.provider:
         alias: Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider

--- a/src/bundle/Core/Resources/config/templating.yml
+++ b/src/bundle/Core/Resources/config/templating.yml
@@ -293,7 +293,7 @@ services:
 
     Ibexa\Core\MVC\Symfony\View\GenericVariableProviderRegistry:
         arguments:
-            $twigVariableProviders: !tagged ezplatform.view.variable_provider
+            $twigVariableProviders: !tagged_iterator ezplatform.view.variable_provider
 
     Ibexa\Core\MVC\Symfony\View\VariableProviderRegistry: '@Ibexa\Core\MVC\Symfony\View\GenericVariableProviderRegistry'
 

--- a/src/bundle/Debug/DependencyInjection/IbexaDebugExtension.php
+++ b/src/bundle/Debug/DependencyInjection/IbexaDebugExtension.php
@@ -9,8 +9,8 @@ namespace Ibexa\Bundle\Debug\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @internal

--- a/src/bundle/IO/DependencyInjection/IbexaIOExtension.php
+++ b/src/bundle/IO/DependencyInjection/IbexaIOExtension.php
@@ -12,8 +12,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.

--- a/src/bundle/LegacySearchEngine/DependencyInjection/IbexaLegacySearchEngineExtension.php
+++ b/src/bundle/LegacySearchEngine/DependencyInjection/IbexaLegacySearchEngineExtension.php
@@ -9,8 +9,8 @@ namespace Ibexa\Bundle\LegacySearchEngine\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class IbexaLegacySearchEngineExtension extends Extension
 {

--- a/src/bundle/RepositoryInstaller/DependencyInjection/IbexaRepositoryInstallerExtension.php
+++ b/src/bundle/RepositoryInstaller/DependencyInjection/IbexaRepositoryInstallerExtension.php
@@ -9,8 +9,8 @@ namespace Ibexa\Bundle\RepositoryInstaller\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class IbexaRepositoryInstallerExtension extends Extension
 {

--- a/src/lib/Resources/settings/roles.yml
+++ b/src/lib/Resources/settings/roles.yml
@@ -17,7 +17,7 @@ services:
         arguments:
             $persistenceLanguageHandler: '@Ibexa\Contracts\Core\Persistence\Content\Language\Handler'
             $persistenceContentHandler: '@Ibexa\Contracts\Core\Persistence\Content\Handler'
-            $versionTargetEvaluators: !tagged ibexa.permissions.limitation_type.language_target_evaluator.version
+            $versionTargetEvaluators: !tagged_iterator ibexa.permissions.limitation_type.language_target_evaluator.version
         tags:
             - {name: ibexa.permissions.limitation_type, alias: Language}
 

--- a/src/lib/Resources/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/src/lib/Resources/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -67,7 +67,7 @@ services:
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory:
         arguments:
             - '@ibexa.persistence.connection'
-            - !tagged ibexa.search.legacy.gateway.sort_clause_handler.gateway.random
+            - !tagged_iterator ibexa.search.legacy.gateway.sort_clause_handler.gateway.random
 
     Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\AbstractRandom:
         class: Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\AbstractRandom

--- a/src/lib/Resources/settings/storage_engines/cache.yml
+++ b/src/lib/Resources/settings/storage_engines/cache.yml
@@ -207,7 +207,7 @@ services:
         lazy: true
         arguments:
             $sharedPool: '@Ibexa\Core\Persistence\Cache\Adapter\TransactionalInMemoryCacheAdapter.inner'
-            $inMemoryPools: !tagged ibexa.cache.persistence.inmemory
+            $inMemoryPools: !tagged_iterator ibexa.cache.persistence.inmemory
 
     ibexa.cache_pool:
         public: true

--- a/tests/bundle/Core/EventListener/LocaleListenerTest.php
+++ b/tests/bundle/Core/EventListener/LocaleListenerTest.php
@@ -31,17 +31,15 @@ class LocaleListenerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->localeConverter = $this->createMock(LocaleConverterInterface::class);
-        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
-
-        $this->requestStack = new RequestStack();
         $parameterBagMock = $this->createMock(ParameterBag::class);
         $parameterBagMock->expects(self::never())->method(self::anything());
 
         $requestMock = $this->createMock(Request::class);
         $requestMock->attributes = $parameterBagMock;
 
-        $this->requestStack->push($requestMock);
+        $this->localeConverter = $this->createMock(LocaleConverterInterface::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->requestStack = new RequestStack([$requestMock]);
     }
 
     /**

--- a/tests/bundle/Core/Fragment/FragmentListenerFactoryTest.php
+++ b/tests/bundle/Core/Fragment/FragmentListenerFactoryTest.php
@@ -26,8 +26,7 @@ class FragmentListenerFactoryTest extends TestCase
         $uriSigner = new UriSigner('my_precious_secret');
         $baseFragmentPath = '/_fragment';
         $request = Request::create($requestUri);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $factory = new FragmentListenerFactory();
         $factory->setRequestStack($requestStack);

--- a/tests/lib/MVC/Symfony/FieldType/View/ParameterProvider/LocaleParameterProviderTest.php
+++ b/tests/lib/MVC/Symfony/FieldType/View/ParameterProvider/LocaleParameterProviderTest.php
@@ -41,7 +41,6 @@ class LocaleParameterProviderTest extends TestCase
 
     protected function getRequestStackMock($hasLocale)
     {
-        $requestStack = new RequestStack();
         $parameterBagMock = $this->createMock(ParameterBag::class);
 
         $parameterBagMock->expects(self::any())
@@ -57,9 +56,7 @@ class LocaleParameterProviderTest extends TestCase
         $requestMock = $this->createMock(Request::class);
         $requestMock->attributes = $parameterBagMock;
 
-        $requestStack->push($requestMock);
-
-        return $requestStack;
+        return new RequestStack([$requestMock]);
     }
 
     protected function getLocaleConverterMock()

--- a/tests/lib/MVC/Symfony/Routing/RouteReferenceGeneratorTest.php
+++ b/tests/lib/MVC/Symfony/Routing/RouteReferenceGeneratorTest.php
@@ -36,8 +36,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $request = new Request();
         $request->attributes->set('_route', $currentRouteName);
         $request->attributes->set('_route_params', $currentRouteParams);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $event = new RouteReferenceGenerationEvent(new RouteReference($currentRouteName, $currentRouteParams), $request);
         $this->dispatcher
@@ -63,8 +62,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $request = new Request();
         $request->attributes->set('_route', $currentRouteName);
         $request->attributes->set('_route_params', $currentRouteParams);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $event = new RouteReferenceGenerationEvent(new RouteReference($currentRouteName, $expectedParams), $request);
         $this->dispatcher
@@ -91,8 +89,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $request = new Request();
         $request->attributes->set('_route', $currentRouteName);
         $request->attributes->set('_route_params', $currentRouteParams);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $event = new RouteReferenceGenerationEvent(new RouteReference($resource, $params), $request);
         $this->dispatcher
@@ -114,8 +111,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $currentRouteParams = ['foo' => 'bar'];
 
         $request = new Request();
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $event = new RouteReferenceGenerationEvent(new RouteReference(null, []), $request);
         $this->dispatcher

--- a/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
+++ b/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
@@ -39,8 +39,7 @@ abstract class BaseRenderStrategyTest extends TestCase
     ): RenderStrategy {
         $siteAccess = new SiteAccess($siteAccessName);
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request ?? new Request());
+        $requestStack = new RequestStack([$request ?? new Request()]);
 
         return new $typeClass(
             $fragmentRenderers,

--- a/tests/lib/MVC/Symfony/Templating/GlobalHelperTest.php
+++ b/tests/lib/MVC/Symfony/Templating/GlobalHelperTest.php
@@ -55,8 +55,7 @@ class GlobalHelperTest extends TestCase
     public function testGetSiteaccess()
     {
         $request = new Request();
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
         $siteAccess = $this->createMock(SiteAccess::class);
         $request->attributes->set('siteaccess', $siteAccess);
         $this->helper->setRequestStack($requestStack);
@@ -73,8 +72,7 @@ class GlobalHelperTest extends TestCase
             'somethingelse' => 'héhé-høhø',
         ];
         $request->attributes->set('viewParameters', $viewParameters);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
         $this->helper->setRequestStack($requestStack);
 
         self::assertSame($viewParameters, $this->helper->getViewParameters());
@@ -85,8 +83,7 @@ class GlobalHelperTest extends TestCase
         $request = Request::create('/foo');
         $viewParametersString = '/(foo)/bar/(toto)/tata/(somethingelse)/héhé-høhø';
         $request->attributes->set('viewParametersString', $viewParametersString);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
         $this->helper->setRequestStack($requestStack);
 
         self::assertSame($viewParametersString, $this->helper->getViewParametersString());
@@ -97,8 +94,7 @@ class GlobalHelperTest extends TestCase
         $request = Request::create('/ibexa_demo_site/foo/bar');
         $semanticPathinfo = '/foo/bar';
         $request->attributes->set('semanticPathinfo', $semanticPathinfo);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
         $this->helper->setRequestStack($requestStack);
 
         self::assertSame($semanticPathinfo, $this->helper->getRequestedUriString());
@@ -110,8 +106,7 @@ class GlobalHelperTest extends TestCase
         $semanticPathinfo = '/foo/bar';
         $request->attributes->set('semanticPathinfo', $semanticPathinfo);
         $request->attributes->set('_route', 'someRouteName');
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
         $this->helper->setRequestStack($requestStack);
         self::assertSame($semanticPathinfo, $this->helper->getSystemUriString());
     }
@@ -127,8 +122,7 @@ class GlobalHelperTest extends TestCase
         $request->attributes->set('contentId', $contentId);
         $request->attributes->set('locationId', $locationId);
         $request->attributes->set('viewType', $viewType);
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $this->router
             ->expects(self::once())

--- a/tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
+++ b/tests/lib/MVC/Symfony/Templating/Twig/Extension/RoutingExtensionTest.php
@@ -92,8 +92,7 @@ final class RoutingExtensionTest extends IntegrationTestCase
             $this->createMock(EventDispatcherInterface::class)
         );
         $request = new Request();
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
         $generator->setRequestStack($requestStack);
 
         return $generator;


### PR DESCRIPTION
| :ticket: Issue | IBX-9968  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled Rector Symfony 7.0, 7.1 and 7.2 sets. Resolved the following deprecations:

```
* [symfony/http-kernel] Replaced usage of internal Symfony\Component\HttpKernel\DependencyInjection\Extension class
* [symfony/dependency-injection] Replaced deprecated !tagged YAML tag to !tagged_iterator 
* [symfony/http-foundation] Use constructor to initialize RequestStack
```

#### For QA:

Sanities.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
