### PR TITLE
Removed deprecated getName method from GatewayFactory

### DIFF
--- a/src/lib/Persistence/Legacy/SharedGateway/GatewayFactory.php
+++ b/src/lib/Persistence/Legacy/SharedGateway/GatewayFactory.php
@@ -34,13 +34,10 @@ final class GatewayFactory
      */
     public function buildSharedGateway(Connection $connection): Gateway
     {
-        return $this->getGatewayForDatabasePlatform($connection->getDatabasePlatform()->getName());
-    }
+        $platform = $connection->getDatabasePlatform();
 
-    private function getGatewayForDatabasePlatform(string $currentDatabasePlatformName): Gateway
-    {
-        foreach ($this->gateways as $databasePlatformName => $gateway) {
-            if ($currentDatabasePlatformName === $databasePlatformName) {
+        foreach ($this->gateways as $platformClass => $gateway) {
+            if ($platform instanceof $platformClass) {
                 return $gateway;
             }
         }

--- a/src/lib/Resources/settings/storage_engines/legacy/shared_gateway.yaml
+++ b/src/lib/Resources/settings/storage_engines/legacy/shared_gateway.yaml
@@ -12,11 +12,11 @@ services:
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\DatabasePlatform\SqliteGateway:
         tags:
-            - { name: ibexa.storage.legacy.gateway.shared, platform: Doctrine\\DBAL\\Platforms\\SqlitePlatform }
+            - { name: ibexa.storage.legacy.gateway.shared, platform: Doctrine\DBAL\Platforms\SqlitePlatform }
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\DatabasePlatform\PostgresqlGateway:
         tags:
-            - { name: ibexa.storage.legacy.gateway.shared, platform: Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform }
+            - { name: ibexa.storage.legacy.gateway.shared, platform: Doctrine\DBAL\Platforms\PostgreSQLPlatform }
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\GatewayFactory:
         arguments:

--- a/src/lib/Resources/settings/storage_engines/legacy/shared_gateway.yaml
+++ b/src/lib/Resources/settings/storage_engines/legacy/shared_gateway.yaml
@@ -12,11 +12,11 @@ services:
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\DatabasePlatform\SqliteGateway:
         tags:
-            - { name: ibexa.storage.legacy.gateway.shared, platform: sqlite }
+            - { name: ibexa.storage.legacy.gateway.shared, platform: Doctrine\\DBAL\\Platforms\\SqlitePlatform }
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\DatabasePlatform\PostgresqlGateway:
         tags:
-            - { name: ibexa.storage.legacy.gateway.shared, platform: postgresql }
+            - { name: ibexa.storage.legacy.gateway.shared, platform: Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform }
 
     Ibexa\Core\Persistence\Legacy\SharedGateway\GatewayFactory:
         arguments:

--- a/tests/lib/Persistence/Legacy/SharedGateway/GatewayFactoryTest.php
+++ b/tests/lib/Persistence/Legacy/SharedGateway/GatewayFactoryTest.php
@@ -30,7 +30,7 @@ final class GatewayFactoryTest extends TestCase
     public function setUp(): void
     {
         $gateways = [
-            'Doctrine\DBAL\Platforms\SqlitePlatform' => new SqliteGateway($this->createMock(Connection::class)),
+            Platforms\SqlitePlatform::class => new SqliteGateway($this->createMock(Connection::class)),
         ];
 
         $this->factory = new GatewayFactory(

--- a/tests/lib/Persistence/Legacy/SharedGateway/GatewayFactoryTest.php
+++ b/tests/lib/Persistence/Legacy/SharedGateway/GatewayFactoryTest.php
@@ -30,7 +30,7 @@ final class GatewayFactoryTest extends TestCase
     public function setUp(): void
     {
         $gateways = [
-            'sqlite' => new SqliteGateway($this->createMock(Connection::class)),
+            'Doctrine\DBAL\Platforms\SqlitePlatform' => new SqliteGateway($this->createMock(Connection::class)),
         ];
 
         $this->factory = new GatewayFactory(

--- a/tests/lib/Persistence/Legacy/TestCase.php
+++ b/tests/lib/Persistence/Legacy/TestCase.php
@@ -114,7 +114,7 @@ abstract class TestCase extends BaseTestCase
             $factory = new SharedGateway\GatewayFactory(
                 new SharedGateway\DatabasePlatform\FallbackGateway($connection),
                 [
-                    'sqlite' => new SharedGateway\DatabasePlatform\SqliteGateway($connection),
+                    'Doctrine\DBAL\Platforms\SqlitePlatform' => new SharedGateway\DatabasePlatform\SqliteGateway($connection),
                 ]
             );
 

--- a/tests/lib/Persistence/Legacy/TestCase.php
+++ b/tests/lib/Persistence/Legacy/TestCase.php
@@ -11,6 +11,7 @@ use Doctrine\Common\EventManager as DoctrineEventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Ibexa\Contracts\Core\Test\Persistence\Fixture\FileFixtureFactory;
 use Ibexa\Contracts\Core\Test\Persistence\Fixture\FixtureImporter;
@@ -114,7 +115,7 @@ abstract class TestCase extends BaseTestCase
             $factory = new SharedGateway\GatewayFactory(
                 new SharedGateway\DatabasePlatform\FallbackGateway($connection),
                 [
-                    'Doctrine\DBAL\Platforms\SqlitePlatform' => new SharedGateway\DatabasePlatform\SqliteGateway($connection),
+                    SqlitePlatform::class => new SharedGateway\DatabasePlatform\SqliteGateway($connection),
                 ]
             );
 


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|


#### Description:
Removed deprecated getName method from GatewayFactory

Deprecation:
`User Deprecated: PostgreSQLPlatform::getName() is deprecated. Identify platforms by their class. (PostgreSQLPlatform.php:1154 called by GatewayFactory.php:37, https://github.com/doctrine/dbal/issues/4749, package doctrine/dbal)`
