### PR TITLE
Added missing `void` return types and minor refactoring

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -289,18 +289,6 @@ parameters:
 			path: src/bundle/Core/Command/VirtualFieldDuplicateFixCommand.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Compiler\\BinaryContentDownloadPass\:\:addCall\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Compiler/BinaryContentDownloadPass.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Compiler\\BinaryContentDownloadPass\:\:addCall\(\) has parameter \$targetServiceName with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Compiler/BinaryContentDownloadPass.php
-
-		-
 			message: '#^Argument of an invalid type array\|bool\|float\|int\|string\|null supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
@@ -311,30 +299,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/Core/DependencyInjection/Compiler/EntityManagerFactoryServiceLocatorPass.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Compiler\\ImaginePass\:\:processReduceNoiseFilter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Compiler\\ImaginePass\:\:processReduceNoiseFilter\(\) has parameter \$driver with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Compiler\\ImaginePass\:\:processSwirlFilter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Compiler\\ImaginePass\:\:processSwirlFilter\(\) has parameter \$driver with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
 
 		-
 			message: '#^Argument of an invalid type array\|bool\|float\|int\|string\|null supplied for foreach, only iterables are supported\.$#'
@@ -425,12 +389,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPass.php
-
-		-
-			message: '#^Constant Ibexa\\Bundle\\Core\\DependencyInjection\\Compiler\\TranslationCollectorPass\:\:LOCALES_MAP type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Compiler/TranslationCollectorPass.php
 
 		-
 			message: '#^Parameter \#1 \$kernelRootDir of class Ibexa\\Bundle\\Core\\Translation\\GlobCollector constructor expects string, array\|bool\|float\|int\|string\|null given\.$#'
@@ -8033,30 +7991,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Base/Container/Compiler/GenericFieldTypeConverterPass.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriteriaConverterPass\:\:addHandlers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriteriaConverterPass\:\:addHandlers\(\) has parameter \$handlers with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\SortClauseConverterPass\:\:addHandlers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\SortClauseConverterPass\:\:addHandlers\(\) has parameter \$handlers with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
 
 		-
 			message: '#^Class Ibexa\\Core\\Base\\Container\\Compiler\\TaggedServiceIdsIterator\\BackwardCompatibleIterator implements generic interface IteratorAggregate but does not specify its types\: TKey, TValue$#'

--- a/src/bundle/Core/DependencyInjection/Compiler/BinaryContentDownloadPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/BinaryContentDownloadPass.php
@@ -14,12 +14,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * Injects the downloadUrlGenerator into the binary fieldtype external storage services.
- */
 class BinaryContentDownloadPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(ContentDownloadUrlGenerator::class)) {
             return;
@@ -31,7 +28,7 @@ class BinaryContentDownloadPass implements CompilerPassInterface
         $this->addCall($container, $downloadUrlReference, BinaryFileStorage::class);
     }
 
-    private function addCall(ContainerBuilder $container, Reference $reference, $targetServiceName)
+    private function addCall(ContainerBuilder $container, Reference $reference, string $targetServiceName): void
     {
         if (!$container->has($targetServiceName)) {
             return;

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
@@ -12,16 +12,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * The ChainConfigResolverPass will register all services tagged as "ibexa.site.config.resolver"
- * to the chain config resolver.
- */
 class ChainConfigResolverPass implements CompilerPassInterface
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(ChainConfigResolver::class)) {
             return;
@@ -31,7 +24,6 @@ class ChainConfigResolverPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('ibexa.site.config.resolver') as $id => $attributes) {
             $priority = isset($attributes[0]['priority']) ? (int)$attributes[0]['priority'] : 0;
-            // Priority range is between -255 (the lowest) and 255 (the highest)
             if ($priority > 255) {
                 $priority = 255;
             }

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
@@ -14,15 +14,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * The ChainRoutingPass will register all services tagged as "router" to the chain router.
- */
 class ChainRoutingPass implements CompilerPassInterface
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(ChainRouter::class)) {
             return;
@@ -54,7 +48,6 @@ class ChainRoutingPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('router') as $id => $attributes) {
             $priority = isset($attributes[0]['priority']) ? (int)$attributes[0]['priority'] : 0;
-            // Priority range is between -255 (the lowest) and 255 (the highest)
             if ($priority > 255) {
                 $priority = 255;
             }

--- a/src/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class ConsoleCommandPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         foreach ($container->findTaggedServiceIds('console.command') as $id => $attributes) {
             $definition = $container->getDefinition($id);

--- a/src/bundle/Core/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
@@ -8,23 +8,16 @@
 namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
 
 use Ibexa\Core\MVC\Symfony\FieldType\View\ParameterProviderRegistry;
+use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Ibexa field type parameter providers.
- */
 class FieldTypeParameterProviderRegistryPass implements CompilerPassInterface
 {
-    public const FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG = 'ibexa.field_type.view.parameter.provider';
+    public const string FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG = 'ibexa.field_type.view.parameter.provider';
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @throws \LogicException
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(ParameterProviderRegistry::class)) {
             return;
@@ -38,7 +31,7 @@ class FieldTypeParameterProviderRegistryPass implements CompilerPassInterface
         foreach ($serviceTags as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
-                    throw new \LogicException(
+                    throw new LogicException(
                         sprintf(
                             'Service "%s" tagged with "%s" service tag needs an "alias" attribute to identify the Field Type.',
                             $serviceId,

--- a/src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ImaginePass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ImaginePass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('liip_imagine.filter.configuration')) {
             return;
@@ -38,7 +38,7 @@ class ImaginePass implements CompilerPassInterface
         }
     }
 
-    private function processReduceNoiseFilter(ContainerBuilder $container, $driver)
+    private function processReduceNoiseFilter(ContainerBuilder $container, string $driver): void
     {
         if ($driver === 'imagick') {
             $container->setAlias('ibexa.image_alias.imagine.filter.reduce_noise', new Alias(ImagickReduceNoiseFilter::class));
@@ -47,7 +47,7 @@ class ImaginePass implements CompilerPassInterface
         }
     }
 
-    private function processSwirlFilter(ContainerBuilder $container, $driver)
+    private function processSwirlFilter(ContainerBuilder $container, string $driver): void
     {
         if ($driver === 'imagick') {
             $container->setAlias('ibexa.image_alias.imagine.filter.swirl', new Alias(ImagickSwirlFilter::class));

--- a/src/bundle/Core/DependencyInjection/Compiler/NotificationRendererPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/NotificationRendererPass.php
@@ -15,10 +15,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class NotificationRendererPass implements CompilerPassInterface
 {
-    public const TAG_NAME = 'ibexa.notification.renderer';
-    public const REGISTRY_DEFINITION_ID = 'notification.renderer.registry';
+    public const string TAG_NAME = 'ibexa.notification.renderer';
+    public const string REGISTRY_DEFINITION_ID = 'notification.renderer.registry';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(self::REGISTRY_DEFINITION_ID)) {
             return;

--- a/src/bundle/Core/DependencyInjection/Compiler/PlaceholderProviderPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/PlaceholderProviderPass.php
@@ -15,10 +15,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class PlaceholderProviderPass implements CompilerPassInterface
 {
-    public const TAG_NAME = 'ibexa.media.images.placeholder.provider';
-    public const REGISTRY_DEFINITION_ID = PlaceholderProviderRegistry::class;
+    public const string TAG_NAME = 'ibexa.media.images.placeholder.provider';
+    public const string REGISTRY_DEFINITION_ID = PlaceholderProviderRegistry::class;
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::REGISTRY_DEFINITION_ID)) {
             return;

--- a/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
@@ -13,30 +13,13 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass registers Ibexa search engines indexers.
- */
 class RegisterSearchEngineIndexerPass implements CompilerPassInterface
 {
-    public const SEARCH_ENGINE_INDEXER_SERVICE_TAG = 'ibexa.search.engine.indexer';
+    public const string SEARCH_ENGINE_INDEXER_SERVICE_TAG = 'ibexa.search.engine.indexer';
 
-    /**
-     * Container service id of the SearchEngineIndexerFactory.
-     *
-     * @see \Ibexa\Bundle\Core\ApiLoader\SearchEngineIndexerFactory
-     *
-     * @var string
-     */
-    protected $factoryId = SearchEngineIndexerFactory::class;
+    protected string $factoryId = SearchEngineIndexerFactory::class;
 
-    /**
-     * Register all found search engine indexers to the SearchEngineIndexerFactory.
-     *
-     * @throws \LogicException
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition($this->factoryId)) {
             return;
@@ -57,7 +40,6 @@ class RegisterSearchEngineIndexerPass implements CompilerPassInterface
                     );
                 }
 
-                // Register the search engine with the search engine factory
                 $searchEngineIndexerFactoryDefinition->addMethodCall(
                     'registerSearchEngineIndexer',
                     [

--- a/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEnginePass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/RegisterSearchEnginePass.php
@@ -13,30 +13,13 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Ibexa search engines.
- */
 class RegisterSearchEnginePass implements CompilerPassInterface
 {
-    public const SEARCH_ENGINE_SERVICE_TAG = 'ibexa.search.engine';
+    public const string SEARCH_ENGINE_SERVICE_TAG = 'ibexa.search.engine';
 
-    /**
-     * Container service id of the SearchEngineFactory.
-     *
-     * @see \Ibexa\Bundle\Core\ApiLoader\SearchEngineFactory
-     *
-     * @var string
-     */
-    protected $factoryId = SearchEngineFactory::class;
+    protected string $factoryId = SearchEngineFactory::class;
 
-    /**
-     * Registers all found search engines to the SearchEngineFactory.
-     *
-     * @throws \LogicException
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition($this->factoryId)) {
             return;
@@ -57,7 +40,6 @@ class RegisterSearchEnginePass implements CompilerPassInterface
                     );
                 }
 
-                // Register the search engine with the search engine factory
                 $searchEngineFactoryDefinition->addMethodCall(
                     'registerSearchEngine',
                     [

--- a/src/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/RegisterStorageEnginePass.php
@@ -13,24 +13,11 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Ibexa storage engines.
- */
 class RegisterStorageEnginePass implements CompilerPassInterface
 {
-    public const STORAGE_ENGINE_TAG = 'ibexa.storage';
+    public const string STORAGE_ENGINE_TAG = 'ibexa.storage';
 
-    /**
-     * Performs compiler passes for persistence factories.
-     *
-     * Does:
-     * - Registers all storage engines to ezpublish.api.storage_engine.factory
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @throws \LogicException
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(StorageEngineFactory::class)) {
             return;
@@ -50,7 +37,6 @@ class RegisterStorageEnginePass implements CompilerPassInterface
                     );
                 }
 
-                // Register the storage engine on the main storage engine factory
                 $storageEngineFactoryDef->addMethodCall(
                     'registerStorageEngine',
                     [

--- a/src/bundle/Core/DependencyInjection/Compiler/RouterPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/RouterPass.php
@@ -11,15 +11,9 @@ use Ibexa\Bundle\Core\Routing\DefaultRouter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Routing related compiler pass.
- *
- * Manipulates Symfony default router services to adapt them to eZ routing needs,
- * specifically to implement the RequestMatcherInterface.
- */
 class RouterPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('router.default')) {
             return;

--- a/src/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SessionConfigurationPass.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class SessionConfigurationPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $handlerId = $container->hasParameter('ibexa.session.handler_id')
             ? $container->getParameter('ibexa.session.handler_id')

--- a/src/bundle/Core/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
@@ -12,20 +12,14 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * This compiler pass will create configuration injected into SlugConverter responsible for url pattern creation.
- */
 class SlugConverterConfigurationPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
-        if (!$container->has(\Ibexa\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter::class)) {
+        if (!$container->has(SlugConverter::class)) {
             return;
         }
-        $slugConverterDefinition = $container->getDefinition(\Ibexa\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter::class);
+        $slugConverterDefinition = $container->getDefinition(SlugConverter::class);
 
         $parameterConfiguration = $slugConverterDefinition->getArgument(1);
         $semanticConfiguration = $container->getParameter('ibexa.url_alias.slug_converter');
@@ -62,7 +56,9 @@ class SlugConverterConfigurationPass implements CompilerPassInterface
                 $mergedConfiguration['transformation'],
                 implode(', ', array_keys($mergedConfiguration['transformationGroups']))
             ));
-        } elseif (empty($mergedConfiguration['transformation'])) {
+        }
+
+        if (empty($mergedConfiguration['transformation'])) {
             @trigger_error(
                 sprintf(
                     'Relying on default url_alias.slug_converter.transformation setting ("%s") is deprecated and might change in the next major. Set it explicitly to one of the following: %s',

--- a/src/bundle/Core/DependencyInjection/Compiler/StorageConnectionPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/StorageConnectionPass.php
@@ -11,13 +11,9 @@ use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * This compiler pass will create aliases for storage engine database handler connections
- * to the storage connection factory.
- */
 class StorageConnectionPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $taggedServiceIds = $container->findTaggedServiceIds(
             RegisterStorageEnginePass::STORAGE_ENGINE_TAG

--- a/src/bundle/Core/DependencyInjection/Compiler/TranslationCollectorPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/TranslationCollectorPass.php
@@ -11,15 +11,11 @@ use Ibexa\Bundle\Core\Translation\GlobCollector;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * This compilation pass loads every ezplatform available translations into symfony translator.
- */
 class TranslationCollectorPass implements CompilerPassInterface
 {
-    public const ORIGINAL_TRANSLATION = 'en';
+    public const string ORIGINAL_TRANSLATION = 'en';
 
-    /** @var array */
-    public const LOCALES_MAP = [
+    public const array LOCALES_MAP = [
         'de_DE' => 'de',
         'el_GR' => 'el',
         'es_ES' => 'es',
@@ -36,7 +32,7 @@ class TranslationCollectorPass implements CompilerPassInterface
         'ru_RU' => 'ru',
     ];
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('translator.default')) {
             return;

--- a/src/bundle/Core/DependencyInjection/Compiler/URLHandlerPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/URLHandlerPass.php
@@ -13,15 +13,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register URL handlers.
- */
 class URLHandlerPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(URLHandlerRegistry::class)) {
             return;

--- a/src/bundle/Core/DependencyInjection/Compiler/ViewProvidersPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ViewProvidersPass.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
 
 use Ibexa\Bundle\Core\EventListener\ConfigScopeListener;
+use Ibexa\Core\MVC\Symfony\View\ContentView;
 use Ibexa\Core\MVC\Symfony\View\CustomLocationControllerChecker;
 use Ibexa\Core\MVC\Symfony\View\Provider\Registry;
 use LogicException;
@@ -15,22 +16,15 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * Registers services tagged as "ibexa.view.provider" into the view_provider registry.
- */
 class ViewProvidersPass implements CompilerPassInterface
 {
-    private const VIEW_PROVIDER_TAG = 'ibexa.view.provider';
+    private const string VIEW_PROVIDER_TAG = 'ibexa.view.provider';
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $rawViewProviders = [];
         foreach ($container->findTaggedServiceIds(self::VIEW_PROVIDER_TAG) as $serviceId => $tags) {
             foreach ($tags as $attributes) {
-                // Priority range is between -255 (the lowest) and 255 (the highest)
                 $priority = isset($attributes['priority']) ? max(min((int)$attributes['priority'], 255), -255) : 0;
 
                 if (!isset($attributes['type'])) {
@@ -84,7 +78,7 @@ class ViewProvidersPass implements CompilerPassInterface
         if ($container->hasDefinition(CustomLocationControllerChecker::class)) {
             $container->getDefinition(CustomLocationControllerChecker::class)->addMethodCall(
                 'addViewProviders',
-                [$viewProviders['Ibexa\Core\MVC\Symfony\View\ContentView']]
+                [$viewProviders[ContentView::class]]
             );
         }
     }

--- a/src/lib/Base/Container/Compiler/AbstractFieldTypeBasedPass.php
+++ b/src/lib/Base/Container/Compiler/AbstractFieldTypeBasedPass.php
@@ -13,19 +13,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 abstract class AbstractFieldTypeBasedPass implements CompilerPassInterface
 {
-    public const FIELD_TYPE_SERVICE_TAG = 'ibexa.field_type';
+    public const string FIELD_TYPE_SERVICE_TAG = 'ibexa.field_type';
 
-    public const FIELD_TYPE_SERVICE_TAGS = [
+    public const array FIELD_TYPE_SERVICE_TAGS = [
         self::FIELD_TYPE_SERVICE_TAG,
     ];
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @return array
-     *
-     * @throws \LogicException
-     */
     public function getFieldTypeServiceIds(ContainerBuilder $container): iterable
     {
         $serviceTags = $container->findTaggedServiceIds(self::FIELD_TYPE_SERVICE_TAG);
@@ -46,5 +39,5 @@ abstract class AbstractFieldTypeBasedPass implements CompilerPassInterface
         return $serviceTags;
     }
 
-    abstract public function process(ContainerBuilder $container);
+    abstract public function process(ContainerBuilder $container): void;
 }

--- a/src/lib/Base/Container/Compiler/Persistence/FieldTypeRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Persistence/FieldTypeRegistryPass.php
@@ -14,12 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class FieldTypeRegistryPass extends AbstractFieldTypeBasedPass
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @throws \LogicException
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(FieldTypeRegistry::class)) {
             return;

--- a/src/lib/Base/Container/Compiler/Search/FieldRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Search/FieldRegistryPass.php
@@ -13,19 +13,11 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Ibexa indexable field types.
- */
 class FieldRegistryPass implements CompilerPassInterface
 {
-    public const FIELD_TYPE_INDEXABLE_SERVICE_TAG = 'ibexa.field_type.indexable';
+    public const string FIELD_TYPE_INDEXABLE_SERVICE_TAG = 'ibexa.field_type.indexable';
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @throws \LogicException
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(FieldRegistry::class)) {
             return;

--- a/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
@@ -13,15 +13,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Legacy Search Engine criterion handlers.
- */
 class CriteriaConverterPass implements CompilerPassInterface
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (
             !$container->hasDefinition('ibexa.search.legacy.gateway.criteria_converter.content') &&
@@ -63,7 +57,10 @@ class CriteriaConverterPass implements CompilerPassInterface
         }
     }
 
-    protected function addHandlers(Definition $definition, $handlers)
+    /**
+     * @param array<string, array<array<string, mixed>>> $handlers
+     */
+    protected function addHandlers(Definition $definition, array $handlers): void
     {
         foreach ($handlers as $id => $attributes) {
             $definition->addMethodCall('addHandler', [new Reference($id)]);

--- a/src/lib/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPass.php
@@ -13,17 +13,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Legacy Search Engine criterion field value handlers.
- */
 class CriterionFieldValueHandlerRegistryPass implements CompilerPassInterface
 {
-    private const SEARCH_LEGACY_GATEWAY_CRITERION_HANDLER_FIELD_VALUE_TAG = 'ibexa.search.legacy.gateway.criterion_handler.field_value';
+    private const string SEARCH_LEGACY_GATEWAY_CRITERION_HANDLER_FIELD_VALUE_TAG = 'ibexa.search.legacy.gateway.criterion_handler.field_value';
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(HandlerRegistry::class)) {
             return;

--- a/src/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
@@ -12,15 +12,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Legacy Storage sort clause handlers.
- */
 class SortClauseConverterPass implements CompilerPassInterface
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (
             !$container->hasDefinition('ibexa.search.legacy.gateway.sort_clause_converter.content') &&
@@ -55,7 +49,10 @@ class SortClauseConverterPass implements CompilerPassInterface
         }
     }
 
-    protected function addHandlers(Definition $definition, $handlers)
+    /**
+     * @param array<string, array<array<string, mixed>>> $handlers
+     */
+    protected function addHandlers(Definition $definition, array $handlers): void
     {
         foreach ($handlers as $id => $attributes) {
             $definition->addMethodCall('addHandler', [new Reference($id)]);

--- a/src/lib/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
+++ b/src/lib/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
@@ -13,20 +13,12 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Ibexa external storage handlers and gateways.
- */
 class ExternalStorageRegistryPass implements CompilerPassInterface
 {
-    public const EXTERNAL_STORAGE_HANDLER_SERVICE_TAG = 'ibexa.field_type.storage.external.handler';
-    public const EXTERNAL_STORAGE_HANDLER_GATEWAY_SERVICE_TAG = 'ibexa.field_type.storage.external.handler.gateway';
+    public const string EXTERNAL_STORAGE_HANDLER_SERVICE_TAG = 'ibexa.field_type.storage.external.handler';
+    public const string EXTERNAL_STORAGE_HANDLER_GATEWAY_SERVICE_TAG = 'ibexa.field_type.storage.external.handler.gateway';
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @throws \LogicException
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(StorageRegistry::class)) {
             return;

--- a/src/lib/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPass.php
@@ -12,17 +12,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * This compiler pass will register Legacy Storage role limitation converters.
- */
 class RoleLimitationConverterPass implements CompilerPassInterface
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @throws \LogicException
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(LimitationConverter::class)) {
             return;


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
Added missing `void` return types across multiple classes (e.g. CompilerPass implementations) to align with future PHP compatibility and static analysis expectations.

Also included small refactors such as:
- Improving method signatures
- Removing redundant comments or unused parameters
- Fixing PHPStan warnings (e.g. iterable type hints)

This improves code clarity, consistency, and compatibility.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
