### PR TITLE
Added missing `void` return types to CompilerPass implementations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4387,12 +4387,6 @@ parameters:
 			path: src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\IO\\DependencyInjection\\Compiler\\IOConfigurationPass\:\:processHandlers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\IO\\DependencyInjection\\Compiler\\IOConfigurationPass\:\:processHandlers\(\) has parameter \$configuredHandlers with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
+++ b/src/bundle/IO/DependencyInjection/Compiler/IOConfigurationPass.php
@@ -8,6 +8,7 @@
 namespace Ibexa\Bundle\IO\DependencyInjection\Compiler;
 
 use ArrayObject;
+use Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -16,8 +17,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * This compiler pass will create the metadata and binarydata IO handlers depending on container configuration.
- *
  * @todo Refactor into two passes, since they're very very close.
  */
 class IOConfigurationPass implements CompilerPassInterface
@@ -36,12 +35,7 @@ class IOConfigurationPass implements CompilerPassInterface
         $this->binarydataHandlerFactories = $binarydataHandlerFactories;
     }
 
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @throws \LogicException
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $ioMetadataHandlers = $container->hasParameter('ibexa.io.metadata_handlers') ?
             $container->getParameter('ibexa.io.metadata_handlers') :
@@ -80,8 +74,8 @@ class IOConfigurationPass implements CompilerPassInterface
         Definition $factory,
         array $configuredHandlers,
         ArrayObject $factories,
-        $defaultHandler
-    ) {
+        string $defaultHandler
+    ): void {
         $handlers = ['default' => new Reference($defaultHandler)];
 
         foreach ($configuredHandlers as $name => $config) {
@@ -105,10 +99,8 @@ class IOConfigurationPass implements CompilerPassInterface
      *
      * @param \Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory[]|\ArrayObject $factories
      * @param string $type
-     *
-     * @return \Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory
      */
-    protected function getFactory(ArrayObject $factories, $type)
+    protected function getFactory(ArrayObject $factories, string $type): ConfigurationFactory
     {
         if (!isset($factories[$type])) {
             throw new InvalidConfigurationException("Unknown handler type $type");

--- a/src/bundle/IO/DependencyInjection/Compiler/MigrationFileListerPass.php
+++ b/src/bundle/IO/DependencyInjection/Compiler/MigrationFileListerPass.php
@@ -14,12 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class MigrationFileListerPass implements CompilerPassInterface
 {
-    /**
-     * Registers the FileListerInterface into the file lister registry.
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(ConfigurableRegistry::class)) {
             return;


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
This PR adds explicit `void` return types to `IOConfigurationPass` and `MigrationFileListerPass` classes, which implement Symfony's `CompilerPassInterface`.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
