### PR TITLE
[Doc] Dropped obsolete doc about upgrade scripts location

### DIFF
--- a/data/update/README.md
+++ b/data/update/README.md
@@ -1,4 +1,0 @@
-# Legacy Storage upgrade scripts
-
-Database (a.k.a Legacy Storage) upgrade scripts were moved to eZ Platform meta repository, to
-[`upgrade/db/`](https://github.com/ezsystems/ezplatform/tree/master/upgrade/db) directory.


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

Found it by accident. We still reference old `ezplatform` meta repo for upgrade scripts. The scripts for OSS were moved to the official documentation. 

We could mention this instead of deleting the doc, but we agreed quite some time ago that we prefer to avoid keeping any docs outside the official one (due to maintenance reasons). Open to change if you prefer some doc here anyway.

#### For QA:
No QA required

#### Documentation:

Already covered by the Documentation.