### PR TITLE
Added missing `void` return types to 'process'

### DIFF
--- a/src/bundle/Debug/DependencyInjection/Compiler/DataCollectorPass.php
+++ b/src/bundle/Debug/DependencyInjection/Compiler/DataCollectorPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class DataCollectorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(IbexaCoreCollector::class)) {
             return;

--- a/src/bundle/RepositoryInstaller/DependencyInjection/Compiler/InstallerTagPass.php
+++ b/src/bundle/RepositoryInstaller/DependencyInjection/Compiler/InstallerTagPass.php
@@ -19,9 +19,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class InstallerTagPass implements CompilerPassInterface
 {
-    public const INSTALLER_TAG = 'ibexa.installer';
+    public const string INSTALLER_TAG = 'ibexa.installer';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(InstallPlatformCommand::class)) {
             return;


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:
Added missing void return type declarations to process methods across the codebase to improve type safety and align with PHP 8.1+ best practices.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
