### PR TITLE
IBX-9727: Add missing type hints to PAPI decorators

### DIFF
--- a/src/contracts/Repository/Decorator/BookmarkServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/BookmarkServiceDecorator.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 
 abstract class BookmarkServiceDecorator implements BookmarkService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\BookmarkService */
-    protected $innerService;
+    protected BookmarkService $innerService;
 
     public function __construct(BookmarkService $innerService)
     {

--- a/src/contracts/Repository/Decorator/ContentServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/ContentServiceDecorator.php
@@ -29,8 +29,7 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 abstract class ContentServiceDecorator implements ContentService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService */
-    protected $innerService;
+    protected ContentService $innerService;
 
     public function __construct(ContentService $innerService)
     {

--- a/src/contracts/Repository/Decorator/ContentTypeServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/ContentTypeServiceDecorator.php
@@ -23,8 +23,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\User;
 
 abstract class ContentTypeServiceDecorator implements ContentTypeService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    protected $innerService;
+    protected ContentTypeService $innerService;
 
     public function __construct(ContentTypeService $innerService)
     {

--- a/src/contracts/Repository/Decorator/FieldTypeServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/FieldTypeServiceDecorator.php
@@ -13,8 +13,7 @@ use Ibexa\Contracts\Core\Repository\FieldTypeService;
 
 abstract class FieldTypeServiceDecorator implements FieldTypeService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\FieldTypeService */
-    protected $innerService;
+    protected FieldTypeService $innerService;
 
     public function __construct(FieldTypeService $innerService)
     {

--- a/src/contracts/Repository/Decorator/LanguageServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/LanguageServiceDecorator.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\LanguageCreateStruct;
 
 abstract class LanguageServiceDecorator implements LanguageService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\LanguageService */
-    protected $innerService;
+    protected LanguageService $innerService;
 
     public function __construct(LanguageService $innerService)
     {

--- a/src/contracts/Repository/Decorator/LocationServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/LocationServiceDecorator.php
@@ -19,8 +19,7 @@ use Ibexa\Contracts\Core\Repository\Values\Filter\Filter;
 
 abstract class LocationServiceDecorator implements LocationService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\LocationService */
-    protected $innerService;
+    protected LocationService $innerService;
 
     public function __construct(LocationService $innerService)
     {

--- a/src/contracts/Repository/Decorator/NotificationServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/NotificationServiceDecorator.php
@@ -15,8 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\Notification\NotificationList;
 
 abstract class NotificationServiceDecorator implements NotificationService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\NotificationService */
-    protected $innerService;
+    protected NotificationService $innerService;
 
     public function __construct(NotificationService $innerService)
     {

--- a/src/contracts/Repository/Decorator/ObjectStateServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/ObjectStateServiceDecorator.php
@@ -19,8 +19,7 @@ use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateUpdateStruct;
 
 abstract class ObjectStateServiceDecorator implements ObjectStateService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ObjectStateService */
-    protected $innerService;
+    protected ObjectStateService $innerService;
 
     public function __construct(ObjectStateService $innerService)
     {

--- a/src/contracts/Repository/Decorator/RoleServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/RoleServiceDecorator.php
@@ -4,10 +4,6 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-/**
- * @copyright Copyright (C) Ibexa AS. All rights reserved.
- * @license For full copyright and license information view LICENSE file distributed with this source code.
- */
 declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Decorator;
@@ -29,8 +25,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 
 abstract class RoleServiceDecorator implements RoleService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\RoleService */
-    protected $innerService;
+    protected RoleService $innerService;
 
     public function __construct(RoleService $innerService)
     {

--- a/src/contracts/Repository/Decorator/SearchServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/SearchServiceDecorator.php
@@ -17,8 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
 
 abstract class SearchServiceDecorator implements SearchService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\SearchService */
-    protected $innerService;
+    protected SearchService $innerService;
 
     public function __construct(SearchService $innerService)
     {

--- a/src/contracts/Repository/Decorator/SectionServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/SectionServiceDecorator.php
@@ -4,10 +4,6 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-/**
- * @copyright Copyright (C) Ibexa AS. All rights reserved.
- * @license For full copyright and license information view LICENSE file distributed with this source code.
- */
 declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Decorator;
@@ -21,8 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\SectionUpdateStruct;
 
 abstract class SectionServiceDecorator implements SectionService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\SectionService */
-    protected $innerService;
+    protected SectionService $innerService;
 
     public function __construct(SectionService $innerService)
     {

--- a/src/contracts/Repository/Decorator/SettingServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/SettingServiceDecorator.php
@@ -15,8 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\Setting\SettingUpdateStruct;
 
 abstract class SettingServiceDecorator implements SettingService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\SettingService */
-    protected $innerService;
+    protected SettingService $innerService;
 
     public function __construct(
         SettingService $innerService

--- a/src/contracts/Repository/Decorator/TranslationServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/TranslationServiceDecorator.php
@@ -13,8 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Translation;
 
 abstract class TranslationServiceDecorator implements TranslationService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\TranslationService */
-    protected $innerService;
+    protected TranslationService $innerService;
 
     public function __construct(TranslationService $innerService)
     {

--- a/src/contracts/Repository/Decorator/TrashServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/TrashServiceDecorator.php
@@ -18,8 +18,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\TrashItem;
 
 abstract class TrashServiceDecorator implements TrashService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\TrashService */
-    protected $innerService;
+    protected TrashService $innerService;
 
     public function __construct(TrashService $innerService)
     {

--- a/src/contracts/Repository/Decorator/URLAliasServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/URLAliasServiceDecorator.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\URLAlias;
 
 abstract class URLAliasServiceDecorator implements URLAliasService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\URLAliasService */
-    protected $innerService;
+    protected URLAliasService $innerService;
 
     public function __construct(URLAliasService $innerService)
     {

--- a/src/contracts/Repository/Decorator/URLServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/URLServiceDecorator.php
@@ -17,8 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\UsageSearchResult;
 
 abstract class URLServiceDecorator implements URLService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\URLService */
-    protected $innerService;
+    protected URLService $innerService;
 
     public function __construct(URLService $innerService)
     {

--- a/src/contracts/Repository/Decorator/URLWildcardServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/URLWildcardServiceDecorator.php
@@ -17,8 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\URLWildcardUpdateStruct;
 
 abstract class URLWildcardServiceDecorator implements URLWildcardService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\URLWildcardService */
-    protected $innerService;
+    protected URLWildcardService $innerService;
 
     public function __construct(URLWildcardService $innerService)
     {

--- a/src/contracts/Repository/Decorator/UserPreferenceServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/UserPreferenceServiceDecorator.php
@@ -14,8 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\UserPreference\UserPreferenceList;
 
 abstract class UserPreferenceServiceDecorator implements UserPreferenceService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserPreferenceService */
-    protected $innerService;
+    protected UserPreferenceService $innerService;
 
     public function __construct(UserPreferenceService $innerService)
     {

--- a/src/contracts/Repository/Decorator/UserServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/UserServiceDecorator.php
@@ -4,10 +4,6 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-/**
- * @copyright Copyright (C) Ibexa AS. All rights reserved.
- * @license For full copyright and license information view LICENSE file distributed with this source code.
- */
 declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Decorator;
@@ -27,8 +23,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
 
 abstract class UserServiceDecorator implements UserService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    protected $innerService;
+    protected UserService $innerService;
 
     public function __construct(UserService $innerService)
     {


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Add missing type hints to PAPI decorators

#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
