### PR TITLE
IBX-8471: [Tests][DI] Replaced deprecated `!tagged` with `!tagged_iterator`

### DIFF
--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -86,7 +86,7 @@ services:
     Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider:
         class: Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider
         arguments:
-            $providers: !tagged ibexa.site_access.provider
+            $providers: !tagged_iterator ibexa.site_access.provider
 
     ibexa.siteaccess.provider:
         alias: Ibexa\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider

--- a/tests/integration/Core/Resources/settings/integration_legacy.yml
+++ b/tests/integration/Core/Resources/settings/integration_legacy.yml
@@ -51,7 +51,7 @@ services:
     Ibexa\Tests\Core\Persistence\DatabaseConnectionFactory:
         autowire: true
         arguments:
-            $databasePlatforms: !tagged ibexa.doctrine.db.platform
+            $databasePlatforms: !tagged_iterator ibexa.doctrine.db.platform
 
     # build ezpublish.api.storage_engine.legacy.connection for test purposes
     ibexa.api.storage_engine.legacy.connection:


### PR DESCRIPTION
| :ticket: Issue | Follow-up to IBX-8471 |
|----------------|-----------------------|

 
#### Related PRs: 
- https://github.com/ibexa/core/pull/530


#### Description:

Using `tagged` has been deprecated either in Symfony 6 or 7. It seems there are only two leftover cases in `tests/`.

#### For QA:
No QA required.