### PR TITLE
[Tests] Fixed precision in `ParameterProviderTest::testGetViewParameters`

### DIFF
--- a/tests/lib/MVC/Symfony/FieldType/User/ParameterProviderTest.php
+++ b/tests/lib/MVC/Symfony/FieldType/User/ParameterProviderTest.php
@@ -44,12 +44,8 @@ class ParameterProviderTest extends TestCase
         $this->parameterProvider = new ParameterProvider($this->userService);
     }
 
-    /**
-     * @requires PHP < 8.1
-     */
     public function testGetViewParameters(): void
     {
-        $passwordExpiresIn = 14;
         $passwordExpiresAt = (new DateTimeImmutable())->add(new DateInterval('P14D'));
 
         $this->userService
@@ -63,7 +59,9 @@ class ParameterProviderTest extends TestCase
 
         self::assertFalse($parameters['is_password_expired']);
         self::assertEquals($passwordExpiresAt, $parameters['password_expires_at']);
-        self::assertEquals($passwordExpiresIn, $parameters['password_expires_in']->days);
+        // since PHP 8.1 computing date time includes microseconds, so the difference is not deterministic
+        self::assertGreaterThanOrEqual(13, $parameters['password_expires_in']->days);
+        self::assertLessThanOrEqual(14, $parameters['password_expires_in']->days);
     }
 
     public function testGetViewParametersWhenPasswordExpirationDateIsNull(): void


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

Follow up to changes done during Symfony 7 upgrade, but it's really a part of PHP 8.3 upgrade. It seems the date/time diff expressed in `days` is more precise.

The issue has been described here: https://github.com/php/php-src/issues/10822

I was gonna just drop this test initially, but Copilot had a better idea and I agree with that. The second pair of eyes appreciated.

#### For QA:
No QA required.