### PR TITLE
IBX-9727: Add missing type hints to PAPI exceptions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6991,54 +6991,6 @@ parameters:
 			path: src/contracts/Repository/Events/UserPreference/SetUserPreferenceEvent.php
 
 		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\ContentFieldValidationException\:\:getFieldErrors\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Repository/Exceptions/ContentFieldValidationException.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\ContentTypeFieldDefinitionValidationException\:\:getFieldErrors\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Repository/Exceptions/ContentTypeFieldDefinitionValidationException.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\InvalidCriterionArgumentException\:\:__construct\(\) has parameter \$criterion with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/contracts/Repository/Exceptions/InvalidCriterionArgumentException.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\InvalidCriterionArgumentException\:\:__construct\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/contracts/Repository/Exceptions/InvalidCriterionArgumentException.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\InvalidVariationException\:\:__construct\(\) has parameter \$code with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/contracts/Repository/Exceptions/InvalidVariationException.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\InvalidVariationException\:\:__construct\(\) has parameter \$variationName with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/contracts/Repository/Exceptions/InvalidVariationException.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\InvalidVariationException\:\:__construct\(\) has parameter \$variationType with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/contracts/Repository/Exceptions/InvalidVariationException.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\Exceptions\\LimitationValidationException\:\:getLimitationErrors\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Repository/Exceptions/LimitationValidationException.php
-
-		-
 			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\FieldType\:\:fieldSettingsFromHash\(\) has parameter \$fieldSettingsHash with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -20851,12 +20803,6 @@ parameters:
 			path: src/lib/Repository/ContentTypeService.php
 
 		-
-			message: '#^Parameter \#1 \$errors of class Ibexa\\Core\\Base\\Exceptions\\ContentTypeFieldDefinitionValidationException constructor expects array\<Ibexa\\Core\\FieldType\\ValidationError\>, array\<string, array\<Ibexa\\Contracts\\Core\\FieldType\\ValidationError\>\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/lib/Repository/ContentTypeService.php
-
-		-
 			message: '#^Property Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentTypeCreateStruct\:\:\$descriptions \(array\) on left side of \?\? is not nullable\.$#'
 			identifier: nullCoalesce.property
 			count: 1
@@ -21214,12 +21160,6 @@ parameters:
 			message: '#^PHPDoc tag @var has invalid value \(\$fieldType \\Ibexa\\Contracts\\Core\\FieldType\\FieldType\)\: Unexpected token "\$fieldType", expected type at offset 9 on line 1$#'
 			identifier: phpDoc.parseError
 			count: 2
-			path: src/lib/Repository/Mapper/ContentTypeDomainMapper.php
-
-		-
-			message: '#^Parameter \#1 \$errors of class Ibexa\\Core\\Base\\Exceptions\\ContentTypeFieldDefinitionValidationException constructor expects array\<Ibexa\\Core\\FieldType\\ValidationError\>, array\<Ibexa\\Contracts\\Core\\FieldType\\ValidationError\> given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/lib/Repository/Mapper/ContentTypeDomainMapper.php
 
 		-

--- a/src/contracts/Repository/Exceptions/ContentFieldValidationException.php
+++ b/src/contracts/Repository/Exceptions/ContentFieldValidationException.php
@@ -18,7 +18,7 @@ abstract class ContentFieldValidationException extends ForbiddenException
      *
      * The array is indexed by field definition ID and language code.
      *
-     * @return array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>>
+     * @return array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]>>
      */
     abstract public function getFieldErrors(): array;
 }

--- a/src/contracts/Repository/Exceptions/ContentFieldValidationException.php
+++ b/src/contracts/Repository/Exceptions/ContentFieldValidationException.php
@@ -16,7 +16,9 @@ abstract class ContentFieldValidationException extends ForbiddenException
     /**
      * Returns an array of field validation error messages.
      *
-     * @return array
+     * The array is indexed by field definition ID and language code.
+     *
+     * @return array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>>
      */
-    abstract public function getFieldErrors();
+    abstract public function getFieldErrors(): array;
 }

--- a/src/contracts/Repository/Exceptions/ContentTypeFieldDefinitionValidationException.php
+++ b/src/contracts/Repository/Exceptions/ContentTypeFieldDefinitionValidationException.php
@@ -16,7 +16,9 @@ abstract class ContentTypeFieldDefinitionValidationException extends ForbiddenEx
     /**
      * Returns an array of field definition validation error messages.
      *
-     * @return array
+     * The array is indexed by field definition identifier.
+     *
+     * @return array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]>
      */
-    abstract public function getFieldErrors();
+    abstract public function getFieldErrors(): array;
 }

--- a/src/contracts/Repository/Exceptions/InvalidCriterionArgumentException.php
+++ b/src/contracts/Repository/Exceptions/InvalidCriterionArgumentException.php
@@ -10,7 +10,7 @@ namespace Ibexa\Contracts\Core\Repository\Exceptions;
 
 final class InvalidCriterionArgumentException extends InvalidArgumentException
 {
-    public function __construct($key, $criterion, string $expectedCriterionFQCN)
+    public function __construct(string|int $key, mixed $criterion, string $expectedCriterionFQCN)
     {
         if ($criterion === null) {
             $type = 'null';

--- a/src/contracts/Repository/Exceptions/InvalidVariationException.php
+++ b/src/contracts/Repository/Exceptions/InvalidVariationException.php
@@ -12,7 +12,7 @@ use Exception;
 
 class InvalidVariationException extends InvalidArgumentException
 {
-    public function __construct($variationName, $variationType, $code = 0, Exception $previous = null)
+    public function __construct(string $variationName, string $variationType, int $code = 0, ?Exception $previous = null)
     {
         parent::__construct("Invalid variation '$variationName' for $variationType", $code, $previous);
     }

--- a/src/contracts/Repository/Exceptions/InvalidVariationException.php
+++ b/src/contracts/Repository/Exceptions/InvalidVariationException.php
@@ -8,11 +8,11 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Exceptions;
 
-use Exception;
+use Throwable;
 
 class InvalidVariationException extends InvalidArgumentException
 {
-    public function __construct(string $variationName, string $variationType, int $code = 0, ?Exception $previous = null)
+    public function __construct(string $variationName, string $variationType, int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct("Invalid variation '$variationName' for $variationType", $code, $previous);
     }

--- a/src/contracts/Repository/Exceptions/LimitationValidationException.php
+++ b/src/contracts/Repository/Exceptions/LimitationValidationException.php
@@ -17,7 +17,7 @@ abstract class LimitationValidationException extends ForbiddenException
     /**
      * Returns an array of limitation validation error messages.
      *
-     * @return array
+     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    abstract public function getLimitationErrors();
+    abstract public function getLimitationErrors(): array;
 }

--- a/src/contracts/Repository/Exceptions/NotImplementedException.php
+++ b/src/contracts/Repository/Exceptions/NotImplementedException.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Repository\Exceptions;
 
-use Exception;
+use Throwable;
 
 /**
  * This Exception is thrown if a feature has not been implemented
@@ -20,7 +20,7 @@ class NotImplementedException extends ForbiddenException
     /**
      * Generates: Intentionally not implemented: {$feature}.
      */
-    public function __construct(string $feature, int $code = 0, ?Exception $previous = null)
+    public function __construct(string $feature, int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct("Intentionally not implemented: {$feature}", $code, $previous);
     }

--- a/src/contracts/Repository/Exceptions/NotImplementedException.php
+++ b/src/contracts/Repository/Exceptions/NotImplementedException.php
@@ -19,12 +19,8 @@ class NotImplementedException extends ForbiddenException
 {
     /**
      * Generates: Intentionally not implemented: {$feature}.
-     *
-     * @param string $feature
-     * @param int $code
-     * @param \Exception|null $previous
      */
-    public function __construct($feature, $code = 0, Exception $previous = null)
+    public function __construct(string $feature, int $code = 0, ?Exception $previous = null)
     {
         parent::__construct("Intentionally not implemented: {$feature}", $code, $previous);
     }

--- a/src/contracts/Repository/Exceptions/PasswordInUnsupportedFormatException.php
+++ b/src/contracts/Repository/Exceptions/PasswordInUnsupportedFormatException.php
@@ -13,7 +13,7 @@ use Throwable;
 
 class PasswordInUnsupportedFormatException extends AuthenticationException
 {
-    public function __construct(Throwable $previous = null)
+    public function __construct(?Throwable $previous = null)
     {
         parent::__construct("User's password is in a format which is not supported any more.", 0, $previous);
     }

--- a/src/contracts/Repository/Exceptions/PropertyNotFoundException.php
+++ b/src/contracts/Repository/Exceptions/PropertyNotFoundException.php
@@ -19,11 +19,9 @@ class PropertyNotFoundException extends Exception implements RepositoryException
     /**
      * Generates: Property '{$propertyName}' not found.
      *
-     * @param string $propertyName
      * @param string|null $className Optionally to specify class in abstract/parent classes
-     * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $className = null, Exception $previous = null)
+    public function __construct(string $propertyName, ?string $className = null, ?Exception $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' not found", 0, $previous);

--- a/src/contracts/Repository/Exceptions/PropertyNotFoundException.php
+++ b/src/contracts/Repository/Exceptions/PropertyNotFoundException.php
@@ -10,6 +10,7 @@ namespace Ibexa\Contracts\Core\Repository\Exceptions;
 
 use Exception;
 use Ibexa\Contracts\Core\Repository\Exceptions\Exception as RepositoryException;
+use Throwable;
 
 /**
  * This Exception is thrown if an accessed property in a value object was not found.
@@ -21,7 +22,7 @@ class PropertyNotFoundException extends Exception implements RepositoryException
      *
      * @param string|null $className Optionally to specify class in abstract/parent classes
      */
-    public function __construct(string $propertyName, ?string $className = null, ?Exception $previous = null)
+    public function __construct(string $propertyName, ?string $className = null, ?Throwable $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' not found", 0, $previous);

--- a/src/contracts/Repository/Exceptions/PropertyReadOnlyException.php
+++ b/src/contracts/Repository/Exceptions/PropertyReadOnlyException.php
@@ -19,11 +19,9 @@ class PropertyReadOnlyException extends Exception implements RepositoryException
     /**
      * Generates: Property '{$propertyName}' is readonly[ on class '{$className}'].
      *
-     * @param string $propertyName
      * @param string|null $className Optionally to specify class in abstract/parent classes
-     * @param \Exception|null $previous
      */
-    public function __construct($propertyName, $className = null, Exception $previous = null)
+    public function __construct(string $propertyName, ?string $className = null, ?Exception $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' is readonly", 0, $previous);

--- a/src/contracts/Repository/Exceptions/PropertyReadOnlyException.php
+++ b/src/contracts/Repository/Exceptions/PropertyReadOnlyException.php
@@ -10,6 +10,7 @@ namespace Ibexa\Contracts\Core\Repository\Exceptions;
 
 use Exception;
 use Ibexa\Contracts\Core\Repository\Exceptions\Exception as RepositoryException;
+use Throwable;
 
 /**
  * This Exception is thrown on a write attempt in a read only property in a value object.
@@ -21,7 +22,7 @@ class PropertyReadOnlyException extends Exception implements RepositoryException
      *
      * @param string|null $className Optionally to specify class in abstract/parent classes
      */
-    public function __construct(string $propertyName, ?string $className = null, ?Exception $previous = null)
+    public function __construct(string $propertyName, ?string $className = null, ?Throwable $previous = null)
     {
         if ($className === null) {
             parent::__construct("Property '{$propertyName}' is readonly", 0, $previous);

--- a/src/lib/Base/Exceptions/ContentFieldValidationException.php
+++ b/src/lib/Base/Exceptions/ContentFieldValidationException.php
@@ -29,7 +29,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *  $fieldErrors[43]["eng-GB"]->getTranslatableMessage();
      * </code>
      *
-     * @var array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>>
+     * @var array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]>>
      */
     protected $errors;
 
@@ -41,7 +41,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *
      * Also sets the given $fieldErrors to the internal property, retrievable by getFieldErrors()
      *
-     * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
+     * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
      */
     public function __construct(array $errors)
     {
@@ -53,7 +53,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     /**
      * Generates: Content fields did not validate exception with additional information on affected fields.
      *
-     * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
+     * @param array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]>> $errors
      */
     public static function createNewWithMultiline(array $errors, ?string $contentName = null): self
     {
@@ -73,7 +73,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     /**
      * Returns an array of field validation error messages.
      *
-     * @return array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>>
+     * @return array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]>>
      */
     public function getFieldErrors(): array
     {

--- a/src/lib/Base/Exceptions/ContentFieldValidationException.php
+++ b/src/lib/Base/Exceptions/ContentFieldValidationException.php
@@ -75,7 +75,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *
      * @return array<int, array<string, \Ibexa\Contracts\Core\FieldType\ValidationError|\Ibexa\Contracts\Core\FieldType\ValidationError[]>>
      */
-    public function getFieldErrors()
+    public function getFieldErrors(): array
     {
         return $this->errors;
     }

--- a/src/lib/Base/Exceptions/ContentTypeFieldDefinitionValidationException.php
+++ b/src/lib/Base/Exceptions/ContentTypeFieldDefinitionValidationException.php
@@ -18,25 +18,13 @@ class ContentTypeFieldDefinitionValidationException extends APIContentTypeFieldD
 {
     use TranslatableBase;
 
-    /**
-     * Contains an array of field ValidationError objects indexed with FieldDefinition id and language code.
-     *
-     * Example:
-     * <code>
-     *  $fieldErrors = $exception->getFieldErrors();
-     *  $fieldErrors["43"]["eng-GB"]->getTranslatableMessage();
-     * </code>
-     *
-     * @var \Ibexa\Core\FieldType\ValidationError[]
-     */
-    protected $errors;
+    /** @var array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]> */
+    protected array $errors;
 
     /**
-     * Generates: Content fields did not validate.
+     * Generates: Content type field definitions did not validate.
      *
-     * Also sets the given $fieldErrors to the internal property, retrievable by getFieldErrors()
-     *
-     * @param \Ibexa\Core\FieldType\ValidationError[] $errors
+     * @param array<string, \Ibexa\Contracts\Core\FieldType\ValidationError[]> $errors
      */
     public function __construct(array $errors)
     {
@@ -45,12 +33,7 @@ class ContentTypeFieldDefinitionValidationException extends APIContentTypeFieldD
         parent::__construct($this->getBaseTranslation());
     }
 
-    /**
-     * Returns an array of field validation error messages.
-     *
-     * @return \Ibexa\Core\FieldType\ValidationError[]
-     */
-    public function getFieldErrors()
+    public function getFieldErrors(): array
     {
         return $this->errors;
     }

--- a/src/lib/Base/Exceptions/LimitationValidationException.php
+++ b/src/lib/Base/Exceptions/LimitationValidationException.php
@@ -45,7 +45,7 @@ class LimitationValidationException extends APILimitationValidationException imp
      *
      * @return \Ibexa\Core\FieldType\ValidationError[]
      */
-    public function getLimitationErrors()
+    public function getLimitationErrors(): array
     {
         return $this->errors;
     }

--- a/src/lib/Repository/Mapper/ContentTypeDomainMapper.php
+++ b/src/lib/Repository/Mapper/ContentTypeDomainMapper.php
@@ -287,7 +287,7 @@ class ContentTypeDomainMapper extends ProxyAwareDomainMapper
         );
 
         if (!empty($validationErrors)) {
-            throw new ContentTypeFieldDefinitionValidationException($validationErrors);
+            throw new ContentTypeFieldDefinitionValidationException([$fieldDefinition->identifier => $validationErrors]);
         }
 
         $spiFieldDefinition = new SPIFieldDefinition(


### PR DESCRIPTION
| :ticket: Issue | IBX-9727  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
* Add missing type hints to Ibexa\Contracts\Core\Repository\Exceptions\**
* Allowed passing \Throwable previous exception
* Aligned implementation and usage with contracts (https://github.com/ibexa/core/pull/561/files#diff-31587e12c8a8853f75a6f3bb37b2f3b6271250bf8287520450d341b7e80b4da8R290)     

#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
