### PR TITLE
IBX-9727: Add missing type hints to limitation contracts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5089,12 +5089,6 @@ parameters:
 			path: src/contracts/Limitation/Target/Builder/VersionBuilder.php
 
 		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Limitation\\Type\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/contracts/Limitation/Type.php
-
-		-
 			message: '#^Method Ibexa\\Contracts\\Core\\MVC\\Templating\\BaseRenderStrategy\:\:__construct\(\) has parameter \$fragmentRenderers with no value type specified in iterable type iterable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -10537,28 +10531,10 @@ parameters:
 			path: src/lib/IO/UrlDecorator/Prefix.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Limitation\\BlockingLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/BlockingLimitationType.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Limitation\\BlockingLimitationType\:\:evaluate\(\) has Ibexa\\Contracts\\Core\\Repository\\Exceptions\\BadStateException in PHPDoc @throws tag but it''s not thrown\.$#'
 			identifier: throws.unusedType
 			count: 1
 			path: src/lib/Limitation/BlockingLimitationType.php
-
-		-
-			message: '#^Return type \(void\) of method Ibexa\\Core\\Limitation\\ChangeOwnerLimitationType\:\:valueSchema\(\) should be compatible with return type \(array\<mixed\>\|int\) of method Ibexa\\Contracts\\Core\\Limitation\\Type\:\:valueSchema\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: src/lib/Limitation/ChangeOwnerLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\ContentTypeLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/ContentTypeLimitationType.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Limitation\\LanguageLimitation\\ContentDeleteEvaluator\:\:evaluate\(\) never returns null so it can be removed from the return type\.$#'
@@ -10597,12 +10573,6 @@ parameters:
 			path: src/lib/Limitation/LanguageLimitationType.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Limitation\\LanguageLimitationType\:\:valueSchema\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Limitation/LanguageLimitationType.php
-
-		-
 			message: '#^Parameter \#1 \$array of function array_keys expects array, iterable\<Ibexa\\Contracts\\Core\\Persistence\\Content\\Language\> given\.$#'
 			identifier: argument.type
 			count: 1
@@ -10613,12 +10583,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: src/lib/Limitation/LanguageLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\LocationLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/LocationLimitationType.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Limitation\\LocationLimitationType\:\:evaluateForContentCreateStruct\(\) has parameter \$targets with no value type specified in iterable type array\.$#'
@@ -10645,18 +10609,6 @@ parameters:
 			path: src/lib/Limitation/MemberOfLimitationType.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Limitation\\NewObjectStateLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/NewObjectStateLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\NewSectionLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/NewSectionLimitationType.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Limitation\\NewSectionLimitationType\:\:doEvaluate\(\) has parameter \$targets with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -10681,12 +10633,6 @@ parameters:
 			path: src/lib/Limitation/NewSectionLimitationType.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Limitation\\ObjectStateLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/ObjectStateLimitationType.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Limitation\\ObjectStateLimitationType\:\:getObjectStateIdsToVerify\(\) has parameter \$limitationValues with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -10705,82 +10651,16 @@ parameters:
 			path: src/lib/Limitation/ObjectStateLimitationType.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Limitation\\OwnerLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/OwnerLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\ParentContentTypeLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/ParentContentTypeLimitationType.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Limitation\\ParentContentTypeLimitationType\:\:evaluateForContentCreateStruct\(\) has parameter \$targets with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Limitation/ParentContentTypeLimitationType.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Limitation\\ParentDepthLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/ParentDepthLimitationType.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Limitation\\ParentDepthLimitationType\:\:evaluateForContentCreateStruct\(\) has parameter \$targets with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Limitation/ParentDepthLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\ParentOwnerLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/ParentOwnerLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\ParentUserGroupLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/ParentUserGroupLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\SectionLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/SectionLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\SectionLimitationType\:\:evaluate\(\) should return bool but returns null\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Limitation/SectionLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\SiteAccessLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/SiteAccessLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\StatusLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/StatusLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\SubtreeLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/SubtreeLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\SubtreeLimitationType\:\:evaluate\(\) should return bool but returns null\.$#'
-			identifier: return.type
-			count: 2
-			path: src/lib/Limitation/SubtreeLimitationType.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Limitation\\SubtreeLimitationType\:\:evaluateForContentCreateStruct\(\) has parameter \$targets with no value type specified in iterable type array\.$#'
@@ -10799,12 +10679,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Limitation/TargetOnlyLimitationType.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Limitation\\UserGroupLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Limitation/UserGroupLimitationType.php
 
 		-
 			message: '#^PHPDoc tag @var does not specify variable name\.$#'

--- a/src/contracts/Limitation/Target/Version.php
+++ b/src/contracts/Limitation/Target/Version.php
@@ -29,35 +29,33 @@ final class Version extends ValueObject implements Target
      *
      * @var string[]
      */
-    protected $allLanguageCodesList = [];
+    protected array $allLanguageCodesList = [];
 
     /**
      * List of content types. At least one must match Limitation values.
      *
      * @var int[]
      */
-    protected $allContentTypeIdsList = [];
+    protected array $allContentTypeIdsList = [];
 
     /**
      * Language code of a translation used when updated, can be null for e.g. multiple translations changed.
-     *
-     * @var string|null
      */
-    protected $forUpdateInitialLanguageCode;
+    protected ?string $forUpdateInitialLanguageCode;
 
     /**
      * List of language codes of translations to update. All must match Limitation values.
      *
      * @var string[]
      */
-    protected $forUpdateLanguageCodesList = [];
+    protected array $forUpdateLanguageCodesList = [];
 
     /**
      * List of language codes of translations to publish. All must match Limitation values.
      *
      * @var string[]
      */
-    protected $forPublishLanguageCodesList = [];
+    protected array $forPublishLanguageCodesList = [];
 
     /**
      * One of the following: STATUS_DRAFT, STATUS_PUBLISHED, STATUS_ARCHIVED.
@@ -68,10 +66,10 @@ final class Version extends ValueObject implements Target
      *
      * @var int|null
      */
-    protected $newStatus;
+    protected ?int $newStatus;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Field[] */
-    protected $updatedFields = [];
+    protected array $updatedFields = [];
 
     /**
      * List of language codes of translations to delete. All must match Limitation values.

--- a/src/contracts/Limitation/Type.php
+++ b/src/contracts/Limitation/Type.php
@@ -4,9 +4,11 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Limitation;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject as APIValueObject;
@@ -28,7 +30,7 @@ interface Type
      *
      * Note: In future version constant values might change to 1, 0 and -1 as used in Symfony.
      */
-    public const ACCESS_GRANTED = true;
+    public const ?bool ACCESS_GRANTED = true;
 
     /**
      * The type abstains from voting.
@@ -40,7 +42,7 @@ interface Type
      *
      * Note: In future version constant values might change to 1, 0 and -1 as used in Symfony.
      */
-    public const ACCESS_ABSTAIN = null;
+    public const ?bool ACCESS_ABSTAIN = null;
 
     /**
      * Access is denied.
@@ -49,7 +51,7 @@ interface Type
      *
      * Note: In future version constant values might change to 1, 0 and -1 as used in Symfony.
      */
-    public const ACCESS_DENIED = false;
+    public const ?bool ACCESS_DENIED = false;
 
     /**
      * Limitation's value must be an array of location IDs.
@@ -58,7 +60,7 @@ interface Type
      *
      * GUI should typically present option to browse content tree to select limitation value(s).
      */
-    public const VALUE_SCHEMA_LOCATION_ID = 1;
+    public const int VALUE_SCHEMA_LOCATION_ID = 1;
 
     /**
      * Limitation's value must be an array of location paths.
@@ -67,7 +69,7 @@ interface Type
      *
      * GUI should typically present option to browse content tree to select limitation value(s).
      */
-    public const VALUE_SCHEMA_LOCATION_PATH = 2;
+    public const int VALUE_SCHEMA_LOCATION_PATH = 2;
 
     /**
      * Accepts a Limitation value and checks for structural validity.
@@ -78,7 +80,7 @@ interface Type
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
      */
-    public function acceptValue(APILimitationValue $limitationValue);
+    public function acceptValue(APILimitationValue $limitationValue): void;
 
     /**
      * Makes sure LimitationValue->limitationValues is valid according to valueSchema().
@@ -89,7 +91,7 @@ interface Type
      *
      * @return array<int, \Ibexa\Contracts\Core\FieldType\ValidationError>
      */
-    public function validate(APILimitationValue $limitationValue);
+    public function validate(APILimitationValue $limitationValue): array;
 
     /**
      * Create the Limitation Value.
@@ -101,16 +103,10 @@ interface Type
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues);
+    public function buildValue(array $limitationValues): APILimitationValue;
 
     /**
      * Evaluate ("Vote") against a main value object and targets for the context.
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     *         However if $object or $targets is unsupported by ROLE limitation, ACCESS_ABSTAIN should be returned!
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
@@ -120,7 +116,7 @@ interface Type
      *
      * @return bool|null Returns one of ACCESS_* constants, {@see Type::ACCESS_GRANTED}, {@see Type::ACCESS_ABSTAIN}, or {@see Type::ACCESS_DENIED}.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, APIValueObject $object, array $targets = null);
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, APIValueObject $object, array $targets = null): ?bool;
 
     /**
      * Returns Criterion for use in find() query.
@@ -131,16 +127,16 @@ interface Type
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface|\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\LogicalOperator
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser);
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface;
 
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_* constants.
      *                     Note: The hash might be an instance of Traversable, and not a native php array.
      */
-    public function valueSchema();
+    public function valueSchema(): array|int;
 }

--- a/src/lib/Limitation/BlockingLimitationType.php
+++ b/src/lib/Limitation/BlockingLimitationType.php
@@ -10,6 +10,7 @@ namespace Ibexa\Core\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\BlockingLimitation as APIBlockingLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
@@ -50,11 +51,11 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIBlockingLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'BlockingLimitation', $limitationValue);
@@ -72,7 +73,7 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         if (empty($limitationValue->limitationValues)) {
@@ -95,7 +96,7 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIBlockingLimitation($this->identifier, $limitationValues);
     }
@@ -103,19 +104,19 @@ class BlockingLimitationType implements SPILimitationTypeInterface
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIBlockingLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: BlockingLimitation');
@@ -132,7 +133,7 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         return new Criterion\MatchNone();
     }
@@ -140,12 +141,12 @@ class BlockingLimitationType implements SPILimitationTypeInterface
     /**
      * Returns info on valid $limitationValues.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException Values will need to be injected in ctor.
-     *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException Values will need to be injected in ctor.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/ChangeOwnerLimitationType.php
+++ b/src/lib/Limitation/ChangeOwnerLimitationType.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ChangeOwnerLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
@@ -63,7 +64,7 @@ final class ChangeOwnerLimitationType extends AbstractPersistenceLimitationType 
         return $validationErrors;
     }
 
-    public function buildValue(array $limitationValues): ChangeOwnerLimitation
+    public function buildValue(array $limitationValues): Limitation
     {
         return new ChangeOwnerLimitation($limitationValues);
     }
@@ -101,7 +102,7 @@ final class ChangeOwnerLimitationType extends AbstractPersistenceLimitationType 
         return self::ACCESS_DENIED;
     }
 
-    public function getCriterion(Limitation $value, APIUserReference $currentUser): Criterion\UserMetadata
+    public function getCriterion(Limitation $value, APIUserReference $currentUser): CriterionInterface
     {
         return new Criterion\UserMetadata(
             Criterion\UserMetadata::OWNER,
@@ -113,7 +114,7 @@ final class ChangeOwnerLimitationType extends AbstractPersistenceLimitationType 
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException
      */
-    public function valueSchema(): void
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/ContentTypeLimitationType.php
+++ b/src/lib/Limitation/ContentTypeLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Target;
 use Ibexa\Contracts\Core\Limitation\TargetAwareType as SPITargetAwareLimitationType;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException as APINotFoundException;
@@ -15,6 +16,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ContentTypeLimitation as APIContentTypeLimitation;
@@ -34,11 +36,11 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIContentTypeLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIContentTypeLimitation', $limitationValue);
@@ -62,7 +64,7 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $id) {
@@ -90,7 +92,7 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIContentTypeLimitation(['limitationValues' => $limitationValues]);
     }
@@ -98,17 +100,17 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
     public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
@@ -165,7 +167,7 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         if (empty($value->limitationValues)) {
             // A Policy should not have empty limitationValues stored
@@ -184,10 +186,10 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/LanguageLimitationType.php
+++ b/src/lib/Limitation/LanguageLimitationType.php
@@ -333,7 +333,7 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
      *
      * @see validate for business logic.
      */
-    public function valueSchema(): array
+    public function valueSchema(): array|int
     {
         return [];
     }

--- a/src/lib/Limitation/LocationLimitationType.php
+++ b/src/lib/Limitation/LocationLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException as APINotFoundException;
@@ -16,6 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\LocationLimitation as APILocationLimitation;
@@ -35,11 +37,11 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APILocationLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APILocationLimitation', $limitationValue);
@@ -63,7 +65,7 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $id) {
@@ -91,7 +93,7 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APILocationLimitation(['limitationValues' => $limitationValues]);
     }
@@ -99,19 +101,19 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APILocationLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APILocationLimitation');
@@ -208,7 +210,7 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         if (empty($value->limitationValues)) {
             // A Policy should not have empty limitationValues stored
@@ -224,7 +226,7 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
         return new Criterion\LocationId($value->limitationValues);
     }
 
-    public function valueSchema(): int
+    public function valueSchema(): array|int
     {
         return self::VALUE_SCHEMA_LOCATION_ID;
     }

--- a/src/lib/Limitation/MemberOfLimitationType.php
+++ b/src/lib/Limitation/MemberOfLimitationType.php
@@ -11,6 +11,7 @@ namespace Ibexa\Core\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\MemberOfLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\User;
@@ -55,7 +56,7 @@ final class MemberOfLimitationType extends AbstractPersistenceLimitationType imp
         }
     }
 
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
 
@@ -88,7 +89,7 @@ final class MemberOfLimitationType extends AbstractPersistenceLimitationType imp
         return new MemberOfLimitation(['limitationValues' => $limitationValues]);
     }
 
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof MemberOfLimitation) {
             throw new InvalidArgumentException(
@@ -124,12 +125,12 @@ final class MemberOfLimitationType extends AbstractPersistenceLimitationType imp
         return self::ACCESS_DENIED;
     }
 
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException('Member of Limitation Criterion');
     }
 
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/NewObjectStateLimitationType.php
+++ b/src/lib/Limitation/NewObjectStateLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\ObjectState as SPIObjectState;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException as APINotFoundException;
@@ -14,6 +15,7 @@ use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectState;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
@@ -34,11 +36,11 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APINewObjectStateLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'NewObjectStateLimitation', $limitationValue);
@@ -62,7 +64,7 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $id) {
@@ -90,7 +92,7 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APINewObjectStateLimitation(['limitationValues' => $limitationValues]);
     }
@@ -98,19 +100,19 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APINewObjectStateLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: NewObjectStateLimitation');
@@ -147,11 +149,11 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException Not applicable, needs context of new state.
-     *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException Not applicable, needs context of new state.
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -159,10 +161,10 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/NewSectionLimitationType.php
+++ b/src/lib/Limitation/NewSectionLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Section as SPISection;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException as APINotFoundException;
@@ -36,11 +37,11 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APINewSectionLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APINewSectionLimitation', $limitationValue);
@@ -64,7 +65,7 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $id) {
@@ -92,7 +93,7 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APINewSectionLimitation(['limitationValues' => $limitationValues]);
     }
@@ -100,19 +101,19 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APINewSectionLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APINewSectionLimitation');
@@ -139,11 +140,11 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException Not applicable, needs context of new section.
-     *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException Not applicable, needs context of new section.
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -151,10 +152,10 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/ObjectStateLimitationType.php
+++ b/src/lib/Limitation/ObjectStateLimitationType.php
@@ -16,6 +16,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ObjectStateLimitation as APIObjectStateLimitation;
@@ -37,11 +38,11 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIObjectStateLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIObjectStateLimitation', $limitationValue);
@@ -67,7 +68,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $id) {
@@ -95,7 +96,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIObjectStateLimitation(['limitationValues' => $limitationValues]);
     }
@@ -103,24 +104,24 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets An array of location, parent or "assignment" value objects
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
     public function evaluate(
         APILimitationValue $value,
         APIUserReference $currentUser,
         ValueObject $object,
         array $targets = null
-    ): bool {
+    ): ?bool {
         if (!$value instanceof APIObjectStateLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIObjectStateLimitation');
         }
@@ -209,9 +210,9 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface|\Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\LogicalOperator
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         if (empty($value->limitationValues)) {
             // A Policy should not have empty limitationValues stored
@@ -268,7 +269,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/OwnerLimitationType.php
+++ b/src/lib/Limitation/OwnerLimitationType.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\OwnerLimitation as APIOwnerLimitation;
@@ -33,11 +34,11 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIOwnerLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIOwnerLimitation', $limitationValue);
@@ -64,7 +65,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $value) {
@@ -90,7 +91,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIOwnerLimitation(['limitationValues' => $limitationValues]);
     }
@@ -98,21 +99,21 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow, or deprecate
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIOwnerLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIOwnerLimitation');
@@ -157,7 +158,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow, or deprecate
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         if (empty($value->limitationValues)) {
             // A Policy should not have empty limitationValues stored
@@ -181,10 +182,10 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/ParentContentTypeLimitationType.php
+++ b/src/lib/Limitation/ParentContentTypeLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException as APINotFoundException;
@@ -16,6 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentContentTypeLimitation as APIParentContentTypeLimitation;
@@ -35,11 +37,11 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIParentContentTypeLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIParentContentTypeLimitation', $limitationValue);
@@ -63,7 +65,7 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $id) {
@@ -91,7 +93,7 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIParentContentTypeLimitation(['limitationValues' => $limitationValues]);
     }
@@ -99,19 +101,19 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentContentTypeLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentContentTypeLimitation');
@@ -222,7 +224,7 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -230,10 +232,10 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/ParentDepthLimitationType.php
+++ b/src/lib/Limitation/ParentDepthLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
@@ -15,6 +16,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentDepthLimitation as APIParentDepthLimitation;
@@ -33,11 +35,11 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIParentDepthLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIParentDepthLimitation', $limitationValue);
@@ -64,7 +66,7 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
 
@@ -78,7 +80,7 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIParentDepthLimitation(['limitationValues' => $limitationValues]);
     }
@@ -86,19 +88,19 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentDepthLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentDepthLimitation');
@@ -201,7 +203,7 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -209,10 +211,10 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/ParentOwnerLimitationType.php
+++ b/src/lib/Limitation/ParentOwnerLimitationType.php
@@ -7,12 +7,14 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Target;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentOwnerLimitation as APIParentOwnerLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
@@ -32,11 +34,11 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIParentOwnerLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIParentOwnerLimitation', $limitationValue);
@@ -63,7 +65,7 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $value) {
@@ -89,7 +91,7 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIParentOwnerLimitation(['limitationValues' => $limitationValues]);
     }
@@ -97,21 +99,21 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentOwnerLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentOwnerLimitation');
@@ -174,7 +176,7 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -182,10 +184,10 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/ParentUserGroupLimitationType.php
+++ b/src/lib/Limitation/ParentUserGroupLimitationType.php
@@ -7,12 +7,14 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Target;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentUserGroupLimitation as APIParentUserGroupLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
@@ -32,11 +34,11 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIParentUserGroupLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIParentUserGroupLimitation', $limitationValue);
@@ -66,7 +68,7 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $value) {
@@ -92,7 +94,7 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIParentUserGroupLimitation(['limitationValues' => $limitationValues]);
     }
@@ -100,19 +102,19 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentUserGroupLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentUserGroupLimitation');
@@ -198,7 +200,7 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -206,10 +208,10 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/RoleLimitationType.php
+++ b/src/lib/Limitation/RoleLimitationType.php
@@ -11,6 +11,7 @@ namespace Ibexa\Core\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\UserRoleLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Role;
@@ -54,7 +55,7 @@ final class RoleLimitationType extends AbstractPersistenceLimitationType impleme
         }
     }
 
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
 
@@ -84,7 +85,7 @@ final class RoleLimitationType extends AbstractPersistenceLimitationType impleme
         return new UserRoleLimitation(['limitationValues' => $limitationValues]);
     }
 
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof UserRoleLimitation) {
             throw new InvalidArgumentException(
@@ -123,12 +124,12 @@ final class RoleLimitationType extends AbstractPersistenceLimitationType impleme
         return self::ACCESS_DENIED;
     }
 
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException('Role Limitation Criterion');
     }
 
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/SectionLimitationType.php
+++ b/src/lib/Limitation/SectionLimitationType.php
@@ -14,6 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Section;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
@@ -34,11 +35,11 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APISectionLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APISectionLimitation', $limitationValue);
@@ -62,7 +63,7 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $id) {
@@ -90,7 +91,7 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APISectionLimitation(['limitationValues' => $limitationValues]);
     }
@@ -98,19 +99,19 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APISectionLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISectionLimitation');
@@ -157,7 +158,7 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         if (empty($value->limitationValues)) {
             // A Policy should not have empty limitationValues stored
@@ -176,10 +177,10 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/SiteAccessLimitationType.php
+++ b/src/lib/Limitation/SiteAccessLimitationType.php
@@ -7,8 +7,10 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\SiteAccessLimitation as APISiteAccessLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
@@ -45,11 +47,11 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APISiteAccessLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APISiteAccessLimitation', $limitationValue);
@@ -74,7 +76,7 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         $siteAccessList = $this->getSiteAccessList();
@@ -101,7 +103,7 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APISiteAccessLimitation(['limitationValues' => $limitationValues]);
     }
@@ -112,19 +114,19 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      * SiteAccess limitation takes a SiteAccess as ValueObject, and is hence like in legacy only suitable for user/login
      * and similar policies.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APISiteAccessLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISiteAccessLimitation');
@@ -155,7 +157,7 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException(__METHOD__);
     }
@@ -163,10 +165,10 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/StatusLimitationType.php
+++ b/src/lib/Limitation/StatusLimitationType.php
@@ -10,6 +10,7 @@ namespace Ibexa\Core\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\StatusLimitation as APIStatusLimitation;
@@ -29,11 +30,11 @@ class StatusLimitationType implements SPILimitationTypeInterface
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIStatusLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIStatusLimitation', $limitationValue);
@@ -57,7 +58,7 @@ class StatusLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         // For limitation values used here see \Ibexa\Contracts\Core\Persistence\Content\VersionInfo::STATUS_* constants.
         $availableStatusSet = [
@@ -90,7 +91,7 @@ class StatusLimitationType implements SPILimitationTypeInterface
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIStatusLimitation(['limitationValues' => $limitationValues]);
     }
@@ -98,19 +99,19 @@ class StatusLimitationType implements SPILimitationTypeInterface
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIStatusLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIStatusLimitation');
@@ -138,15 +139,15 @@ class StatusLimitationType implements SPILimitationTypeInterface
     /**
      * Returns Criterion for use in find() query.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException If the limitation does not support
-     *         being used as a Criterion.
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException If the limitation does not support
+     *         being used as a Criterion.
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         throw new NotImplementedException('Status Limitation Criterion');
     }
@@ -154,10 +155,10 @@ class StatusLimitationType implements SPILimitationTypeInterface
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/src/lib/Limitation/SubtreeLimitationType.php
+++ b/src/lib/Limitation/SubtreeLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Target\Version;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Persistence\Content\Location as SPILocation;
@@ -16,6 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation as APISubtreeLimitation;
@@ -36,11 +38,11 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APISubtreeLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APISubtreeLimitation', $limitationValue);
@@ -64,7 +66,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $path) {
@@ -108,7 +110,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APISubtreeLimitation(['limitationValues' => $limitationValues]);
     }
@@ -116,19 +118,19 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         $targets = $targets ?? [];
 
@@ -242,7 +244,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         if (empty($value->limitationValues)) {
             // A Policy should not have empty limitationValues store
@@ -258,7 +260,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
         return new PermissionSubtree($value->limitationValues);
     }
 
-    public function valueSchema(): int
+    public function valueSchema(): array|int
     {
         return self::VALUE_SCHEMA_LOCATION_PATH;
     }

--- a/src/lib/Limitation/UserGroupLimitationType.php
+++ b/src/lib/Limitation/UserGroupLimitationType.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Core\Limitation;
 
+use Ibexa\Contracts\Core\Limitation\Limitation;
 use Ibexa\Contracts\Core\Limitation\Type as SPILimitationTypeInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
@@ -14,6 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\UserGroupLimitation as APIUserGroupLimitation;
@@ -34,11 +36,11 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      *
      * Makes sure LimitationValue object and ->limitationValues is of correct type.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof APIUserGroupLimitation) {
             throw new InvalidArgumentType('$limitationValue', 'APIUserGroupLimitation', $limitationValue);
@@ -68,7 +70,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validate(APILimitationValue $limitationValue)
+    public function validate(APILimitationValue $limitationValue): array
     {
         $validationErrors = [];
         foreach ($limitationValue->limitationValues as $key => $value) {
@@ -94,7 +96,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\Limitation
      */
-    public function buildValue(array $limitationValues)
+    public function buildValue(array $limitationValues): APILimitationValue
     {
         return new APIUserGroupLimitation(['limitationValues' => $limitationValues]);
     }
@@ -102,19 +104,19 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
     /**
      * Evaluate permission against content & target(placement/parent/assignment).
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
-     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
-     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1 ]
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
-     * @return bool
+     * @return bool|null
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1 ]
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIUserGroupLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIUserGroupLimitation');
@@ -177,7 +179,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser): CriterionInterface
     {
         if (empty($value->limitationValues)) {
             // A Policy should not have empty limitationValues stored
@@ -214,10 +216,10 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
     /**
      * Returns info on valid $limitationValues.
      *
-     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     * @return int|mixed[] In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
      */
-    public function valueSchema()
+    public function valueSchema(): array|int
     {
         throw new NotImplementedException(__METHOD__);
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
 Add missing type hints to limitation contracts. 

#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
