### PR TITLE
IBX-9727: Add missing type hints to image variants contracts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3427,12 +3427,6 @@ parameters:
 			path: src/bundle/Core/Imagine/AliasCleaner.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\AliasGenerator\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/Imagine/AliasGenerator.php
-
-		-
 			message: '#^Parameter \#1 \$image of method Ibexa\\Bundle\\Core\\Imagine\\AliasGenerator\:\:applyFilter\(\) expects Liip\\ImagineBundle\\Binary\\BinaryInterface, Liip\\ImagineBundle\\Binary\\BinaryInterface\|string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3715,18 +3709,6 @@ parameters:
 			path: src/bundle/Core/Imagine/IORepositoryResolver.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\ImageAsset\\AliasGenerator\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/Imagine/ImageAsset/AliasGenerator.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\PlaceholderAliasGenerator\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/Imagine/PlaceholderAliasGenerator.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\PlaceholderAliasGenerator\:\:setPlaceholderProvider\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3859,12 +3841,6 @@ parameters:
 			path: src/bundle/Core/Imagine/PlaceholderProviderRegistry.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\Variation\\ImagineAwareAliasGenerator\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/Imagine/Variation/ImagineAwareAliasGenerator.php
-
-		-
 			message: '#^Property Ibexa\\Bundle\\Core\\Imagine\\Variation\\ImagineAwareAliasGenerator\:\:\$configResolver is unused\.$#'
 			identifier: property.unused
 			count: 1
@@ -3881,18 +3857,6 @@ parameters:
 			identifier: offsetAccess.notFound
 			count: 1
 			path: src/bundle/Core/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\VariationPurger\\IOVariationPurger\:\:purge\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/Imagine/VariationPurger/IOVariationPurger.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\VariationPurger\\IOVariationPurger\:\:purge\(\) has parameter \$aliasNames with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/Imagine/VariationPurger/IOVariationPurger.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\VariationPurger\\IOVariationPurger\:\:setLogger\(\) has no return type specified\.$#'
@@ -3917,18 +3881,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: src/bundle/Core/Imagine/VariationPurger/ImageFileRowReader.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\VariationPurger\\ImageFileVariationPurger\:\:purge\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurger.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\VariationPurger\\ImageFileVariationPurger\:\:purge\(\) has parameter \$aliasNames with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurger.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\VariationPurger\\ImageFileVariationPurger\:\:setLogger\(\) has no return type specified\.$#'
@@ -4169,12 +4121,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/bundle/Core/Variation/PathResolver.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Variation\\VariationHandlerResolver\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/bundle/Core/Variation/VariationHandlerResolver.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\Core\\View\\Provider\\Configured\:\:setSiteAccess\(\) has no return type specified\.$#'
@@ -6911,24 +6857,6 @@ parameters:
 			identifier: isset.property
 			count: 1
 			path: src/contracts/Test/Repository/SetupFactory/Legacy.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Variation\\VariationHandler\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Variation/VariationHandler.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Variation\\VariationPurger\:\:purge\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/contracts/Variation/VariationPurger.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Variation\\VariationPurger\:\:purge\(\) has parameter \$aliasNames with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Variation/VariationPurger.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\AbstractFieldTypeBasedPass\:\:getFieldTypeServiceIds\(\) return type has no value type specified in iterable type iterable\.$#'
@@ -27047,12 +26975,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/integration/Core/Persistence/Search/Content/IndexerGatewayTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Persistence\\Variation\\InMemoryVariationHandler\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/integration/Core/Persistence/Variation/InMemoryVariationHandler.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Repository\\BaseContentServiceTest\:\:createContentDraft\(\) has parameter \$fieldValues with no value type specified in iterable type array\.$#'

--- a/src/bundle/Core/Imagine/AliasGenerator.php
+++ b/src/bundle/Core/Imagine/AliasGenerator.php
@@ -12,6 +12,7 @@ use Ibexa\Contracts\Core\Repository\Exceptions\InvalidVariationException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Variation\Values\ImageVariation;
+use Ibexa\Contracts\Core\Variation\Values\Variation;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
 use Ibexa\Core\FieldType\Image\Value as ImageValue;
 use Ibexa\Core\MVC\Exception\SourceImageNotFoundException;
@@ -77,7 +78,7 @@ class AliasGenerator implements VariationHandler
      * @throws \Ibexa\Core\MVC\Exception\SourceImageNotFoundException If source image cannot be found.
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidVariationException If a problem occurs with generated variation.
      */
-    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = [])
+    public function getVariation(Field $field, VersionInfo $versionInfo, string $variationName, array $parameters = []): Variation
     {
         /** @var \Ibexa\Core\FieldType\Image\Value $imageValue */
         $imageValue = $field->value;

--- a/src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
@@ -9,6 +9,7 @@ namespace Ibexa\Bundle\Core\Imagine\Cache;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Contracts\Core\Variation\Values\Variation;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
@@ -72,7 +73,7 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
      *
      * @throws \Psr\Cache\InvalidArgumentException
      */
-    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = [])
+    public function getVariation(Field $field, VersionInfo $versionInfo, string $variationName, array $parameters = []): Variation
     {
         $item = $this->cache->getItem($this->getCacheKey($field, $versionInfo, $variationName));
         $image = $item->get();

--- a/src/bundle/Core/Imagine/ImageAsset/AliasGenerator.php
+++ b/src/bundle/Core/Imagine/ImageAsset/AliasGenerator.php
@@ -49,7 +49,7 @@ class AliasGenerator implements VariationHandler
     /**
      * {@inheritdoc}
      */
-    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = []): Variation
+    public function getVariation(Field $field, VersionInfo $versionInfo, string $variationName, array $parameters = []): Variation
     {
         if ($this->supportsValue($field->value)) {
             $destinationContent = $this->contentService->loadContent(

--- a/src/bundle/Core/Imagine/PlaceholderAliasGenerator.php
+++ b/src/bundle/Core/Imagine/PlaceholderAliasGenerator.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException as APIIn
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Contracts\Core\Variation\Values\Variation;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
 use Ibexa\Core\FieldType\Image\Value as ImageValue;
 use Ibexa\Core\FieldType\Value;
@@ -52,7 +53,7 @@ class PlaceholderAliasGenerator implements VariationHandler
     /**
      * {@inheritdoc}
      */
-    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = [])
+    public function getVariation(Field $field, VersionInfo $versionInfo, string $variationName, array $parameters = []): Variation
     {
         if ($this->placeholderProvider !== null) {
             /** @var \Ibexa\Core\FieldType\Image\Value $imageValue */

--- a/src/bundle/Core/Imagine/Variation/ImagineAwareAliasGenerator.php
+++ b/src/bundle/Core/Imagine/Variation/ImagineAwareAliasGenerator.php
@@ -11,6 +11,7 @@ use Ibexa\Bundle\Core\Imagine\IORepositoryResolver;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Variation\Values\ImageVariation;
+use Ibexa\Contracts\Core\Variation\Values\Variation;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
 use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Core\IO\IOServiceInterface;
@@ -60,9 +61,9 @@ class ImagineAwareAliasGenerator implements VariationHandler
     public function getVariation(
         Field $field,
         VersionInfo $versionInfo,
-        $variationName,
+        string $variationName,
         array $parameters = []
-    ) {
+    ): Variation {
         /** @var \Ibexa\Contracts\Core\Variation\Values\ImageVariation $variation */
         $variation = $this->aliasGenerator->getVariation(
             $field,

--- a/src/bundle/Core/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
+++ b/src/bundle/Core/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
@@ -17,13 +17,13 @@ use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
  */
 class AliasDirectoryVariationPathGenerator implements VariationPathGenerator
 {
-    public function getVariationPath($originalPath, $filter): string
+    public function getVariationPath(string $path, string $variation): string
     {
-        $info = pathinfo($originalPath);
+        $info = pathinfo($path);
 
         return sprintf(
             '_aliases/%s/%s/%s%s',
-            $filter,
+            $variation,
             $info['dirname'],
             $info['filename'],
             empty($info['extension']) ? '' : '.' . $info['extension']

--- a/src/bundle/Core/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
+++ b/src/bundle/Core/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
@@ -17,15 +17,15 @@ use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
  */
 class OriginalDirectoryVariationPathGenerator implements VariationPathGenerator
 {
-    public function getVariationPath($originalPath, $filter): string
+    public function getVariationPath(string $path, string $variation): string
     {
-        $info = pathinfo($originalPath);
+        $info = pathinfo($path);
 
         return sprintf(
             '%s/%s_%s%s',
             $info['dirname'],
             $info['filename'],
-            $filter,
+            $variation,
             empty($info['extension']) ? '' : '.' . $info['extension']
         );
     }

--- a/src/bundle/Core/Imagine/VariationPathGenerator/WebpFormatVariationPathGenerator.php
+++ b/src/bundle/Core/Imagine/VariationPathGenerator/WebpFormatVariationPathGenerator.php
@@ -28,10 +28,10 @@ final class WebpFormatVariationPathGenerator implements VariationPathGenerator
         $this->filterConfiguration = $filterConfiguration;
     }
 
-    public function getVariationPath($originalPath, $filter): string
+    public function getVariationPath(string $path, string $variation): string
     {
-        $variationPath = $this->innerVariationPathGenerator->getVariationPath($originalPath, $filter);
-        $filterConfig = $this->filterConfiguration->get($filter);
+        $variationPath = $this->innerVariationPathGenerator->getVariationPath($path, $variation);
+        $filterConfig = $this->filterConfiguration->get($variation);
 
         if (!isset($filterConfig['format']) || $filterConfig['format'] !== 'webp') {
             return $variationPath;

--- a/src/bundle/Core/Imagine/VariationPurger/IOVariationPurger.php
+++ b/src/bundle/Core/Imagine/VariationPurger/IOVariationPurger.php
@@ -55,7 +55,7 @@ class IOVariationPurger implements VariationPurger
         $this->logger = $logger;
     }
 
-    public function purge(array $aliasNames)
+    public function purge(array $aliasNames): void
     {
         $variationNameTag = $this->aliasGeneratorDecorator->getVariationNameTag();
 

--- a/src/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurger.php
+++ b/src/bundle/Core/Imagine/VariationPurger/ImageFileVariationPurger.php
@@ -39,12 +39,7 @@ class ImageFileVariationPurger implements VariationPurger
         $this->variationPathGenerator = $variationPathGenerator;
     }
 
-    /**
-     * Purge all variations generated for aliases in $aliasName.
-     *
-     * @param array $aliasNames
-     */
-    public function purge(array $aliasNames)
+    public function purge(array $aliasNames): void
     {
         foreach ($this->imageFileList as $originalImageId) {
             foreach ($aliasNames as $aliasName) {

--- a/src/bundle/Core/Variation/VariationHandlerResolver.php
+++ b/src/bundle/Core/Variation/VariationHandlerResolver.php
@@ -31,7 +31,7 @@ final class VariationHandlerResolver implements VariationHandler
     public function getVariation(
         Field $field,
         VersionInfo $versionInfo,
-        $variationName,
+        string $variationName,
         array $parameters = []
     ): Variation {
         $variationHandlerIdentifier = $this->configResolver->getParameter('variation_handler_identifier');

--- a/src/contracts/Variation/Values/ImageVariation.php
+++ b/src/contracts/Variation/Values/ImageVariation.php
@@ -25,7 +25,7 @@ class ImageVariation extends Variation
     /**
      * The height as number of pixels (for example "256").
      */
-    protected ?int $height;
+    protected ?int $height = null;
 
     /**
      * The name of the image alias (for example "original").

--- a/src/contracts/Variation/Values/ImageVariation.php
+++ b/src/contracts/Variation/Values/ImageVariation.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Variation\Values;
 
@@ -18,24 +19,18 @@ class ImageVariation extends Variation
 {
     /**
      * The width as number of pixels (for example "320").
-     *
-     * @var int|null
      */
-    protected $width;
+    protected ?int $width = null;
 
     /**
      * The height as number of pixels (for example "256").
-     *
-     * @var int|null
      */
-    protected $height;
+    protected ?int $height;
 
     /**
      * The name of the image alias (for example "original").
-     *
-     * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * Contains extra information about the image, depending on the image type.
@@ -44,13 +39,10 @@ class ImageVariation extends Variation
      *
      * Beware: This information may contain e.g. HTML, JavaScript, or PHP code, and should be treated like any
      * other user-submitted data. Make sure it is properly escaped before use.
-     *
-     * @var mixed
      */
-    protected $info;
+    protected mixed $info;
 
-    /** @var mixed */
-    protected $imageId;
+    protected mixed $imageId;
 
     /**
      * Contains identifier of variation handler used to generate this particular variation.

--- a/src/contracts/Variation/Values/Variation.php
+++ b/src/contracts/Variation/Values/Variation.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Variation\Values;
 
+use DateTimeInterface;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 /**
@@ -18,7 +19,7 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  * @property-read string $fileName The name of the file (for example "my_image.png")
  * @property-read string $dirPath The path to the file (for example "var/storage/images/test/199-2-eng-GB")
  * @property-read string $uri Complete path + name of image file (for example "var/storage/images/test/199-2-eng-GB/apple.png")
- * @property-read \DateTime $lastModified When the variation was last modified
+ * @property-read \DateTimeInterface $lastModified When the variation was last modified
  */
 class Variation extends ValueObject
 {
@@ -50,5 +51,5 @@ class Variation extends ValueObject
     /**
      * When the variation was last modified.
      */
-    protected \DateTime $lastModified;
+    protected DateTimeInterface $lastModified;
 }

--- a/src/contracts/Variation/Values/Variation.php
+++ b/src/contracts/Variation/Values/Variation.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Variation\Values;
 
@@ -23,43 +24,31 @@ class Variation extends ValueObject
 {
     /**
      * Number of bytes for current variation.
-     *
-     * @var int
      */
-    protected $fileSize;
+    protected int $fileSize;
 
     /**
      * The MIME type (for example "image/png").
-     *
-     * @var string
      */
-    protected $mimeType;
+    protected string $mimeType;
 
     /**
      * The name of the file (for example "my_image.png").
-     *
-     * @var string
      */
-    protected $fileName;
+    protected string $fileName;
 
     /**
      * The path to the file (for example "var/storage/images/test/199-2-eng-GB").
-     *
-     * @var string
      */
-    protected $dirPath;
+    protected string $dirPath;
 
     /**
      * Complete path + name of image file (for example "var/storage/images/test/199-2-eng-GB/apple.png").
-     *
-     * @var string
      */
-    protected $uri;
+    protected string $uri;
 
     /**
      * When the variation was last modified.
-     *
-     * @var \DateTime
      */
-    protected $lastModified;
+    protected \DateTime $lastModified;
 }

--- a/src/contracts/Variation/VariationHandler.php
+++ b/src/contracts/Variation/VariationHandler.php
@@ -4,11 +4,13 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Variation;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Contracts\Core\Variation\Values\Variation;
 
 /**
  * Interface for Variation services.
@@ -22,12 +24,12 @@ interface VariationHandler
      * This method is responsible to create the variation if needed.
      * Variations might be applicable for images (aliases), documents...
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field $field
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
-     * @param string $variationName
-     * @param array $parameters Hash of arbitrary parameters useful to generate the variation
-     *
-     * @return \Ibexa\Contracts\Core\Variation\Values\Variation
+     * @param array<string, mixed> $parameters Hash of arbitrary parameters useful to generate the variation
      */
-    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = []);
+    public function getVariation(
+        Field $field,
+        VersionInfo $versionInfo,
+        string $variationName,
+        array $parameters = []
+    ): Variation;
 }

--- a/src/contracts/Variation/VariationPathGenerator.php
+++ b/src/contracts/Variation/VariationPathGenerator.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Variation;
 
@@ -14,11 +15,6 @@ interface VariationPathGenerator
 {
     /**
      * Returns the variation for image $path with $variation.
-     *
-     * @param string $path
-     * @param string $variation
-     *
-     * @return string
      */
-    public function getVariationPath($path, $variation);
+    public function getVariationPath(string $path, string $variation): string;
 }

--- a/src/contracts/Variation/VariationPurger.php
+++ b/src/contracts/Variation/VariationPurger.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Variation;
 
@@ -15,7 +16,7 @@ interface VariationPurger
     /**
      * Purge all variations generated for aliases in $aliasNames.
      *
-     * @param array $aliasNames
+     * @param string[] $aliasNames
      */
-    public function purge(array $aliasNames);
+    public function purge(array $aliasNames): void;
 }

--- a/tests/bundle/Core/Imagine/AliasGeneratorTest.php
+++ b/tests/bundle/Core/Imagine/AliasGeneratorTest.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Tests\Bundle\Core\Imagine;
 
+use DateTime;
 use Ibexa\Bundle\Core\Imagine\AliasGenerator;
 use Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator;
 use Ibexa\Contracts\Core\FieldType\Value as FieldTypeValue;
@@ -428,7 +429,7 @@ class AliasGeneratorTest extends TestCase
             [
                 'id' => 'foo/bar/image.jpg',
                 'uri' => "_aliases/{$variationName}/foo/bar/image.jpg",
-                'mtime' => null,
+                'mtime' => new DateTime('2020-01-01 00:00:00'),
                 'size' => 123,
             ]
         );
@@ -457,11 +458,17 @@ class AliasGeneratorTest extends TestCase
             ->with($binaryFile)
             ->willReturn('file contents mock');
 
+        $this->ioService
+            ->method('getMimeType')
+            ->with($binaryFile->id)
+            ->willReturn('image/jpeg');
+
         $this->imagine
             ->expects(self::once())
             ->method('load')
             ->with('file contents mock')
             ->willReturn($this->image);
+
         $this->image
             ->expects(self::once())
             ->method('getSize')
@@ -486,6 +493,8 @@ class AliasGeneratorTest extends TestCase
                 'imageId' => $imageId,
                 'height' => $imageHeight,
                 'width' => $imageWidth,
+                'mimeType' => 'image/jpeg',
+                'lastModified' => new DateTime('2020-01-01 00:00:00'),
             ]
         );
         self::assertEquals(

--- a/tests/integration/Core/Persistence/Variation/InMemoryVariationHandler.php
+++ b/tests/integration/Core/Persistence/Variation/InMemoryVariationHandler.php
@@ -18,9 +18,9 @@ class InMemoryVariationHandler implements VariationHandler
     public function getVariation(
         Field $field,
         VersionInfo $versionInfo,
-        $variationName,
+        string $variationName,
         array $parameters = []
-    ) {
+    ): Variation {
         return new Variation([
             'uri' => $field->value . '-in-memory-test',
         ]);


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Add missing type hints to image variants contracts

#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
