### PR TITLE
[Tests] Added `Case` suffix to abstract unit test cases

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -23947,16 +23947,16 @@ parameters:
 			path: tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver\\ConfigResolverTest\:\:parameterProvider\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver\\ConfigResolverTestCase\:\:parameterProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTest.php
+			path: tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver\\ConfigResolverTest\:\:testGetParameterGlobalScope\(\) has parameter \$expectedValue with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\DependencyInjection\\Configuration\\ConfigResolver\\ConfigResolverTestCase\:\:testGetParameterGlobalScope\(\) has parameter \$expectedValue with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTest.php
+			path: tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTestCase.php
 
 		-
 			message: '#^Parameter \#2 \$groupsBySiteAccess of class Ibexa\\Core\\MVC\\Symfony\\SiteAccess\\Provider\\StaticSiteAccessProvider constructor expects array\<string\>, array\<string, array\<int, string\>\> given\.$#'
@@ -26791,28 +26791,28 @@ parameters:
 			path: tests/bundle/IO/DependencyInjection/Compiler/IOConfigurationPassTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTest\:\:provideHandlerConfiguration\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTestCase\:\:provideHandlerConfiguration\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTest\:\:validateConfiguredHandler\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTestCase\:\:validateConfiguredHandler\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTestCase.php
 
 		-
-			message: '#^Property Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTest\:\:\$filesystemServiceId has no type specified\.$#'
+			message: '#^Property Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTestCase\:\:\$filesystemServiceId has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTestCase.php
 
 		-
-			message: '#^Property Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTest\:\:\$flysystemAdapterServiceId has no type specified\.$#'
+			message: '#^Property Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\BaseFlysystemTestCase\:\:\$flysystemAdapterServiceId has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactory\\MetadataHandler\\LegacyDFSClusterTest\:\:provideHandlerConfiguration\(\) has no return type specified\.$#'
@@ -26830,55 +26830,55 @@ parameters:
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\ArrayNodeDefinition'' and Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:provideExpectedParentServiceId\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTestCase\:\:provideExpectedParentServiceId\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:provideHandlerConfiguration\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTestCase\:\:provideHandlerConfiguration\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:registerHandler\(\) has parameter \$name with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTestCase\:\:registerHandler\(\) has parameter \$name with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:testAddConfiguration\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTestCase\:\:testAddConfiguration\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:testConfigureHandler\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTestCase\:\:testConfigureHandler\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:testGetParentServiceId\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTestCase\:\:testGetParentServiceId\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTest\:\:validateConfiguredHandler\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Bundle\\IO\\DependencyInjection\\ConfigurationFactoryTestCase\:\:validateConfiguredHandler\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$container$#'
 			identifier: parameter.notFound
 			count: 1
-			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTest.php
+			path: tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
 
 		-
 			message: '#^Call to an undefined method object\:\:decorate\(\)\.$#'
@@ -43384,73 +43384,73 @@ parameters:
 			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Collection\\CollectionInterface\:\:filter\(\)\.$#'
 			identifier: method.notFound
 			count: 2
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''IteratorAggregate'' and Ibexa\\Contracts\\Core\\Collection\\CollectionInterface will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:createCollection\(\) has invalid return type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:createCollection\(\) has invalid return type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
 			identifier: class.notFound
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:createCollection\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:createCollection\(\) has parameter \$data with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:createCollection\(\) return type with generic interface Ibexa\\Contracts\\Core\\Collection\\CollectionInterface does not specify its types\: TValue$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:createCollection\(\) return type with generic interface Ibexa\\Contracts\\Core\\Collection\\CollectionInterface does not specify its types\: TValue$#'
 			identifier: missingType.generics
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:createCollectionWithExampleData\(\) has invalid return type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:createCollectionWithExampleData\(\) has invalid return type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
 			identifier: class.notFound
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:createCollectionWithExampleData\(\) return type with generic interface Ibexa\\Contracts\\Core\\Collection\\CollectionInterface does not specify its types\: TValue$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:createCollectionWithExampleData\(\) return type with generic interface Ibexa\\Contracts\\Core\\Collection\\CollectionInterface does not specify its types\: TValue$#'
 			identifier: missingType.generics
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:createEmptyCollection\(\) has invalid return type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:createEmptyCollection\(\) has invalid return type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
 			identifier: class.notFound
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:createEmptyCollection\(\) return type with generic interface Ibexa\\Contracts\\Core\\Collection\\CollectionInterface does not specify its types\: TValue$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:createEmptyCollection\(\) return type with generic interface Ibexa\\Contracts\\Core\\Collection\\CollectionInterface does not specify its types\: TValue$#'
 			identifier: missingType.generics
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\:\:getExampleData\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\:\:getExampleData\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
 			message: '#^PHPDoc tag @return with type TCollection of Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces is not subtype of native type Ibexa\\Contracts\\Core\\Collection\\CollectionInterface\.$#'
 			identifier: return.phpDocType
 			count: 3
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
-			message: '#^PHPDoc tag @template TCollection for class Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest has invalid bound type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
+			message: '#^PHPDoc tag @template TCollection for class Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase has invalid bound type Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces\.$#'
 			identifier: class.notFound
 			count: 1
-			path: tests/lib/Collection/AbstractCollectionTest.php
+			path: tests/lib/Collection/AbstractCollectionTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\Collection\\ArrayListTest\:\:createCollection\(\) has parameter \$data with no value type specified in iterable type array\.$#'
@@ -43471,7 +43471,7 @@ parameters:
 			path: tests/lib/Collection/ArrayListTest.php
 
 		-
-			message: '#^Type Ibexa\\Contracts\\Core\\Collection\\ArrayList in generic type Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\<Ibexa\\Contracts\\Core\\Collection\\ArrayList\> in PHPDoc tag @extends is not subtype of template type TCollection of Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces of class Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\.$#'
+			message: '#^Type Ibexa\\Contracts\\Core\\Collection\\ArrayList in generic type Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\<Ibexa\\Contracts\\Core\\Collection\\ArrayList\> in PHPDoc tag @extends is not subtype of template type TCollection of Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces of class Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\.$#'
 			identifier: generics.notSubtype
 			count: 1
 			path: tests/lib/Collection/ArrayListTest.php
@@ -43531,7 +43531,7 @@ parameters:
 			path: tests/lib/Collection/ArrayMapTest.php
 
 		-
-			message: '#^Type Ibexa\\Contracts\\Core\\Collection\\ArrayMap in generic type Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\<Ibexa\\Contracts\\Core\\Collection\\ArrayMap\> in PHPDoc tag @extends is not subtype of template type TCollection of Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces of class Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTest\.$#'
+			message: '#^Type Ibexa\\Contracts\\Core\\Collection\\ArrayMap in generic type Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\<Ibexa\\Contracts\\Core\\Collection\\ArrayMap\> in PHPDoc tag @extends is not subtype of template type TCollection of Ibexa\\Contracts\\Core\\Repository\\Collection\\CollectionInterfaces of class Ibexa\\Tests\\Core\\Collection\\AbstractCollectionTestCase\.$#'
 			identifier: generics.notSubtype
 			count: 1
 			path: tests/lib/Collection/ArrayMapTest.php
@@ -43571,18 +43571,6 @@ parameters:
 			identifier: argument.type
 			count: 2
 			path: tests/lib/Container/Encore/ConfigurationDumperTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Event\\AbstractServiceTest\:\:getListenersStack\(\) has parameter \$listeners with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Event/AbstractServiceTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Event\\AbstractServiceTest\:\:getListenersStack\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Event/AbstractServiceTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\Event\\BookmarkServiceTest\:\:testCreateBookmarkEvents\(\) has no return type specified\.$#'
@@ -45217,382 +45205,382 @@ parameters:
 			path: tests/lib/FieldType/AuthorTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:assertIsValidHashValue\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:assertIsValidHashValue\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:assertIsValidHashValue\(\) has parameter \$keyChain with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:assertIsValidHashValue\(\) has parameter \$keyChain with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:doValidate\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:doValidate\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:doValidate\(\) has parameter \$fieldDefinitionData with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:doValidate\(\) has parameter \$fieldDefinitionData with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:doValidate\(\) has parameter \$value with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:doValidate\(\) has parameter \$value with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:getFieldDefinitionMock\(\) has parameter \$fieldSettings with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:getFieldDefinitionMock\(\) has parameter \$fieldSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:getSettingsSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:getSettingsSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:getValidatorConfigurationSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:getValidatorConfigurationSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideDataForGetName\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideDataForGetName\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideInValidFieldSettings\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideInValidFieldSettings\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideInputForFromHash\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideInputForFromHash\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideInputForToHash\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideInputForToHash\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideInvalidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideInvalidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideInvalidInputForAcceptValue\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideInvalidInputForAcceptValue\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideInvalidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideInvalidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideValidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideValidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideValidFieldSettings\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideValidFieldSettings\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideValidInputForAcceptValue\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideValidInputForAcceptValue\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:provideValidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:provideValidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testAcceptGetEmptyValue\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testAcceptGetEmptyValue\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testAcceptValue\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testAcceptValue\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testEmptyValue\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testEmptyValue\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testEmptyValueIsEmpty\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testEmptyValueIsEmpty\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testFieldSettingsFromHash\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testFieldSettingsFromHash\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testFieldSettingsFromHash\(\) has parameter \$inputSettings with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testFieldSettingsFromHash\(\) has parameter \$inputSettings with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testFieldSettingsToHash\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testFieldSettingsToHash\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testFieldSettingsToHash\(\) has parameter \$inputSettings with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testFieldSettingsToHash\(\) has parameter \$inputSettings with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testFromHash\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testFromHash\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testFromHash\(\) has parameter \$expectedResult with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testFromHash\(\) has parameter \$expectedResult with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testFromHash\(\) has parameter \$inputHash with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testFromHash\(\) has parameter \$inputHash with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testGetFieldTypeIdentifier\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testGetFieldTypeIdentifier\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testGetName\(\) has parameter \$fieldSettings with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testGetName\(\) has parameter \$fieldSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testSettingsSchema\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testSettingsSchema\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testToHash\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testToHash\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testToHash\(\) has parameter \$expectedResult with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testToHash\(\) has parameter \$expectedResult with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateFieldSettingsInvalid\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateFieldSettingsInvalid\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateFieldSettingsValid\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateFieldSettingsValid\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateInvalid\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateInvalid\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateInvalid\(\) has parameter \$errors with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateInvalid\(\) has parameter \$errors with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateInvalid\(\) has parameter \$fieldDefinitionData with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateInvalid\(\) has parameter \$fieldDefinitionData with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateInvalid\(\) has parameter \$value with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateInvalid\(\) has parameter \$value with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateValid\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateValid\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateValid\(\) has parameter \$fieldDefinitionData with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateValid\(\) has parameter \$fieldDefinitionData with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateValid\(\) has parameter \$value with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateValid\(\) has parameter \$value with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateValidatorConfigurationInvalid\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateValidatorConfigurationInvalid\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidateValidatorConfigurationValid\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidateValidatorConfigurationValid\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidatorConfigurationFromHash\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidatorConfigurationFromHash\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidatorConfigurationSchema\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidatorConfigurationSchema\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:testValidatorConfigurationToHash\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:testValidatorConfigurationToHash\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$inputConfiguration$#'
 			identifier: parameter.notFound
 			count: 2
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$inputValue$#'
 			identifier: parameter.notFound
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
 			message: '#^PHPDoc tag @var has invalid value \(\|\\PHPUnit\\Framework\\MockObject\\MockObject \$fieldDefinitionMock\)\: Unexpected token "\|", expected type at offset 9 on line 1$#'
 			identifier: phpDoc.parseError
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$exception of method PHPUnit\\Framework\\TestCase\:\:expectException\(\) expects class\-string\<Throwable\>, string given\.$#'
 			identifier: argument.type
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$expected of static method PHPUnit\\Framework\\Assert\:\:assertSame\(\) contains unresolvable type\.$#'
 			identifier: argument.unresolvableType
 			count: 2
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Property Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTest\:\:\$fieldTypeUnderTest \(Ibexa\\Contracts\\Core\\FieldType\\FieldType\) in isset\(\) is not nullable\.$#'
+			message: '#^Property Ibexa\\Tests\\Core\\FieldType\\BaseFieldTypeTestCase\:\:\$fieldTypeUnderTest \(Ibexa\\Contracts\\Core\\FieldType\\FieldType\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 1
-			path: tests/lib/FieldType/BaseFieldTypeTest.php
+			path: tests/lib/FieldType/BaseFieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:getBlackListValidatorMock\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:getBlackListValidatorMock\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:getConfigResolverMock\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:getConfigResolverMock\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:getSettingsSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:getSettingsSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:getValidatorConfigurationSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:getValidatorConfigurationSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:provideInvalidInputForAcceptValue\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:provideInvalidInputForAcceptValue\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:provideInvalidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:provideInvalidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:provideValidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:provideValidValidatorConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
-			message: '#^Property Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTest\:\:\$blackListedExtensions has no type specified\.$#'
+			message: '#^Property Ibexa\\Tests\\Core\\FieldType\\BinaryBaseTestCase\:\:\$blackListedExtensions has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
-			path: tests/lib/FieldType/BinaryBaseTest.php
+			path: tests/lib/FieldType/BinaryBaseTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\BinaryFileTest\:\:provideDataForGetName\(\) return type has no value type specified in iterable type array\.$#'
@@ -46120,13 +46108,13 @@ parameters:
 			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\FieldType\\FieldType\:\:valuesEqual\(\)\.$#'
 			identifier: method.notFound
 			count: 1
-			path: tests/lib/FieldType/FieldTypeTest.php
+			path: tests/lib/FieldType/FieldTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\FieldTypeTest\:\:provideInputForValuesEqual\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\FieldTypeTestCase\:\:provideInputForValuesEqual\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/FieldType/FieldTypeTest.php
+			path: tests/lib/FieldType/FieldTypeTestCase.php
 
 		-
 			message: '#^Access to an undefined property Ibexa\\Core\\FieldType\\Validator\\FileSizeValidator\:\:\$unexisting\.$#'
@@ -47875,28 +47863,28 @@ parameters:
 			path: tests/lib/IO/FilePathNormalizer/FlysystemTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTest\:\:getDataForTestForDirectory\(\) return type has no value type specified in iterable type iterable\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTestCase\:\:getDataForTestForDirectory\(\) return type has no value type specified in iterable type iterable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTest.php
+			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTest\:\:getDataForTestForFile\(\) return type has no value type specified in iterable type iterable\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTestCase\:\:getDataForTestForFile\(\) return type has no value type specified in iterable type iterable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTest.php
+			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTest\:\:getDataForTestInverseForDirectory\(\) return type has no value type specified in iterable type iterable\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTestCase\:\:getDataForTestInverseForDirectory\(\) return type has no value type specified in iterable type iterable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTest.php
+			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTest\:\:getDataForTestInverseForFile\(\) return type has no value type specified in iterable type iterable\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\BaseVisibilityConverterTestCase\:\:getDataForTestInverseForFile\(\) return type has no value type specified in iterable type iterable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTest.php
+			path: tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\IO\\Flysystem\\VisibilityConverter\\DFSVisibilityConverterTest\:\:getDataForTestForDirectory\(\) return type has no value type specified in iterable type iterable\.$#'
@@ -49735,28 +49723,28 @@ parameters:
 			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTest\:\:getContentInfoMock\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTestCase\:\:getContentInfoMock\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTest.php
+			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTest\:\:getLocationMock\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTestCase\:\:getLocationMock\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTest.php
+			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTest\:\:getPartiallyMockedViewProvider\(\) has parameter \$matchingConfig with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTestCase\:\:getPartiallyMockedViewProvider\(\) has parameter \$matchingConfig with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTest.php
+			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTest\:\:getPermissionResolverMock\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTestCase\:\:getPermissionResolverMock\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTest.php
+			path: tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\DepthTest\:\:matchContentInfoProvider\(\) has no return type specified\.$#'
@@ -51037,16 +51025,16 @@ parameters:
 			path: tests/lib/MVC/Symfony/SiteAccess/Provider/ChainSiteAccessProviderTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\SiteAccess\\RouterBaseTest\:\:matchProvider\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\SiteAccess\\RouterBaseTestCase\:\:matchProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/SiteAccess/RouterBaseTest.php
+			path: tests/lib/MVC/Symfony/SiteAccess/RouterBaseTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\SiteAccess\\RouterBaseTest\:\:testMatch\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\SiteAccess\\RouterBaseTestCase\:\:testMatch\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/MVC/Symfony/SiteAccess/RouterBaseTest.php
+			path: tests/lib/MVC/Symfony/SiteAccess/RouterBaseTestCase.php
 
 		-
 			message: '#^Class Ibexa\\Core\\MVC\\Symfony\\SiteAccess\\Matcher\\Map\\Host constructor invoked with 2 parameters, 1 required\.$#'
@@ -51973,46 +51961,46 @@ parameters:
 			path: tests/lib/MVC/Symfony/Translation/fixtures/WrongTranslationId.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTest\:\:badTemplateIdentifierProvider\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTestCase\:\:badTemplateIdentifierProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/View/AbstractViewTest.php
+			path: tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTest\:\:createViewUnderTest\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTestCase\:\:createViewUnderTest\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/View/AbstractViewTest.php
+			path: tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTest\:\:createViewUnderTest\(\) has parameter \$template with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTestCase\:\:createViewUnderTest\(\) has parameter \$template with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/MVC/Symfony/View/AbstractViewTest.php
+			path: tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTest\:\:createViewUnderTest\(\) has parameter \$viewType with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTestCase\:\:createViewUnderTest\(\) has parameter \$viewType with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/MVC/Symfony/View/AbstractViewTest.php
+			path: tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTest\:\:getAlwaysAvailableParams\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTestCase\:\:getAlwaysAvailableParams\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/View/AbstractViewTest.php
+			path: tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTest\:\:goodTemplateIdentifierProvider\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\AbstractViewTestCase\:\:goodTemplateIdentifierProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/MVC/Symfony/View/AbstractViewTest.php
+			path: tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$templateIdentifier of method Ibexa\\Core\\MVC\\Symfony\\View\\View\:\:setTemplateIdentifier\(\) expects \(Closure\(array\<string, mixed\>\)\: string\)\|string, \(callable\(\)\: mixed\)\|string given\.$#'
 			identifier: argument.type
 			count: 1
-			path: tests/lib/MVC/Symfony/View/AbstractViewTest.php
+			path: tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
 
 		-
 			message: '#^Property Ibexa\\Tests\\Core\\MVC\\Symfony\\View\\Builder\\ContentViewBuilderTest\:\:\$contentViewBuilder \(Ibexa\\Core\\MVC\\Symfony\\View\\Builder\\ContentViewBuilder&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept Ibexa\\Core\\MVC\\Symfony\\View\\Builder\\ContentViewBuilder\.$#'
@@ -52195,382 +52183,382 @@ parameters:
 			path: tests/lib/Pagination/ContentFilteringAdapterTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTest\:\:getCacheItem\(\) has parameter \$key with no type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTestCase\:\:getCacheItem\(\) has parameter \$key with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractBaseHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractBaseHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTest\:\:provideAbstractCacheHandlerArguments\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTestCase\:\:provideAbstractCacheHandlerArguments\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractBaseHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractBaseHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTest\:\:provideInMemoryCacheHandlerArguments\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTestCase\:\:provideInMemoryCacheHandlerArguments\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractBaseHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractBaseHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:providerForCachedLoadMethodsHit\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:providerForCachedLoadMethodsHit\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:providerForCachedLoadMethodsMiss\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:providerForCachedLoadMethodsMiss\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:providerForUnCachedMethods\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:providerForUnCachedMethods\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testUnCachedMethods\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testUnCachedMethods\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$key with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$key with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:willReturnOnConsecutiveCalls\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 6
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:with\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 2
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:withConsecutive\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 6
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
 			message: '#^Only iterables can be unpacked, array\|null given in argument \#1\.$#'
 			identifier: argument.unpackNonIterable
 			count: 5
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$callback of function call_user_func_array expects callable\(\)\: mixed, array\{mixed, string\} given\.$#'
 			identifier: argument.type
 			count: 3
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$originalClassName of method PHPUnit\\Framework\\TestCase\:\:createMock\(\) expects class\-string\<mixed\>, string given\.$#'
 			identifier: argument.type
 			count: 2
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
 			message: '#^Unable to resolve the template type T in call to method PHPUnit\\Framework\\TestCase\:\:createMock\(\)$#'
 			identifier: argument.templateType
 			count: 3
-			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:providerForCachedLoadMethodsHit\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:providerForCachedLoadMethodsHit\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:providerForCachedLoadMethodsMiss\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:providerForCachedLoadMethodsMiss\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:providerForUnCachedMethods\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:providerForUnCachedMethods\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheHit\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$additionalCalls with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$keyGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testLoadMethodsCacheMiss\(\) has parameter \$tagGeneratingResults with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testUnCachedMethods\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testUnCachedMethods\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$key with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$key with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$keyGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$tagGeneratingArguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTest\:\:testUnCachedMethods\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractInMemoryCacheHandlerTestCase\:\:testUnCachedMethods\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:willReturnOnConsecutiveCalls\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 6
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:with\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 2
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:withConsecutive\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 6
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Only iterables can be unpacked, array\|null given in argument \#1\.$#'
 			identifier: argument.unpackNonIterable
 			count: 5
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$callback of function call_user_func_array expects callable\(\)\: mixed, array\{mixed, string\} given\.$#'
 			identifier: argument.type
 			count: 3
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$originalClassName of method PHPUnit\\Framework\\TestCase\:\:createMock\(\) expects class\-string\<mixed\>, string given\.$#'
 			identifier: argument.type
 			count: 2
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Unable to resolve the template type T in call to method PHPUnit\\Framework\\TestCase\:\:createMock\(\)$#'
 			identifier: argument.templateType
 			count: 3
-			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTest.php
+			path: tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Cache\\Adapter\\InMemoryClearingProxyAdapterTest\:\:arrayAsGenerator\(\) has parameter \$array with no value type specified in iterable type array\.$#'
@@ -52741,7 +52729,7 @@ parameters:
 			path: tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
 
 		-
-			message: '#^Parameter \#2 \$value of method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTest\:\:getCacheItem\(\) expects null, Ibexa\\Contracts\\Core\\Persistence\\Content\\Type given\.$#'
+			message: '#^Parameter \#2 \$value of method Ibexa\\Tests\\Core\\Persistence\\Cache\\AbstractBaseHandlerTestCase\:\:getCacheItem\(\) expects null, Ibexa\\Contracts\\Core\\Persistence\\Content\\Type given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
@@ -59677,46 +59665,46 @@ parameters:
 			path: tests/lib/Persistence/Legacy/URL/MapperTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTest\:\:assertHandlerAcceptsCriterion\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTestCase\:\:assertHandlerAcceptsCriterion\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTest.php
+			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTest\:\:assertHandlerRejectsCriterion\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTestCase\:\:assertHandlerRejectsCriterion\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTest.php
+			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTest\:\:testAccept\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTestCase\:\:testAccept\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTest.php
+			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTest\:\:testHandle\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\CriterionHandlerTestCase\:\:testHandle\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTest.php
+			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$criterion of method Ibexa\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\:\:accept\(\) expects Ibexa\\Contracts\\Core\\Repository\\Values\\URL\\Query\\Criterion, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
 			identifier: argument.type
 			count: 2
-			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTest.php
+			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
 
 		-
 			message: '#^Parameter \#1 \$originalClassName of method PHPUnit\\Framework\\TestCase\:\:createMock\(\) expects class\-string\<mixed\>, string given\.$#'
 			identifier: argument.type
 			count: 2
-			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTest.php
+			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
 
 		-
 			message: '#^Unable to resolve the template type T in call to method PHPUnit\\Framework\\TestCase\:\:createMock\(\)$#'
 			identifier: argument.templateType
 			count: 2
-			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTest.php
+			path: tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\Persistence\\Legacy\\URL\\Query\\CriterionHandler\\LogicalAndTest\:\:testAccept\(\) has no return type specified\.$#'
@@ -60373,22 +60361,22 @@ parameters:
 			path: tests/lib/Persistence/TransformationProcessor/TransformationProcessorPreprocessedBasedTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\QueryType\\BuiltIn\\AbstractQueryTypeTest\:\:dataProviderForGetQuery\(\) return type has no value type specified in iterable type iterable\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\QueryType\\BuiltIn\\AbstractQueryTypeTestCase\:\:dataProviderForGetQuery\(\) return type has no value type specified in iterable type iterable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/QueryType/BuiltIn/AbstractQueryTypeTest.php
+			path: tests/lib/QueryType/BuiltIn/AbstractQueryTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\QueryType\\BuiltIn\\AbstractQueryTypeTest\:\:getExpectedSupportedParameters\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\QueryType\\BuiltIn\\AbstractQueryTypeTestCase\:\:getExpectedSupportedParameters\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/QueryType/BuiltIn/AbstractQueryTypeTest.php
+			path: tests/lib/QueryType/BuiltIn/AbstractQueryTypeTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\QueryType\\BuiltIn\\AbstractQueryTypeTest\:\:testGetQuery\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\QueryType\\BuiltIn\\AbstractQueryTypeTestCase\:\:testGetQuery\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/QueryType/BuiltIn/AbstractQueryTypeTest.php
+			path: tests/lib/QueryType/BuiltIn/AbstractQueryTypeTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\QueryType\\BuiltIn\\AncestorsQueryTypeTest\:\:dataProviderForGetQuery\(\) return type has no value type specified in iterable type iterable\.$#'
@@ -65992,139 +65980,139 @@ parameters:
 			message: '#^Call to method expects\(\) on an unknown class object\.$#'
 			identifier: class.notFound
 			count: 4
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:getAPIServiceClassName\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:getAPIServiceClassName\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:getSiteAccessAwareServiceClassName\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:getSiteAccessAwareServiceClassName\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:providerForLanguagesLookupMethods\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:providerForLanguagesLookupMethods\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:providerForPassTroughMethods\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:providerForPassTroughMethods\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesLookupArguments\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesLookupArguments\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesLookupArguments\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesLookupArguments\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesLookupExpectedArguments\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesLookupExpectedArguments\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesLookupExpectedArguments\(\) has parameter \$languages with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesLookupExpectedArguments\(\) has parameter \$languages with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesLookupExpectedArguments\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesLookupExpectedArguments\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesPassTroughArguments\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesPassTroughArguments\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesPassTroughArguments\(\) has parameter \$languages with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesPassTroughArguments\(\) has parameter \$languages with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:setLanguagesPassTroughArguments\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:setLanguagesPassTroughArguments\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:testForLanguagesLookup\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:testForLanguagesLookup\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:testForLanguagesLookup\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:testForLanguagesLookup\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:testForLanguagesPassTrough\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:testForLanguagesPassTrough\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:testForLanguagesPassTrough\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:testForLanguagesPassTrough\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:testForPassTrough\(\) has no return type specified\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:testForPassTrough\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:testForPassTrough\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:testForPassTrough\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:with\(\) invoked with unpacked array with possibly string key, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
 			count: 4
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Property Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:\$innerApiServiceMock \(object&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept PHPUnit\\Framework\\MockObject\\MockObject\.$#'
+			message: '#^Property Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:\$innerApiServiceMock \(object&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept PHPUnit\\Framework\\MockObject\\MockObject\.$#'
 			identifier: assign.propertyType
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
-			message: '#^Property Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTest\:\:\$innerApiServiceMock has unknown class object as its type\.$#'
+			message: '#^Property Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\AbstractServiceTestCase\:\:\$innerApiServiceMock has unknown class object as its type\.$#'
 			identifier: class.notFound
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
 			message: '#^Unable to resolve the template type T in call to method PHPUnit\\Framework\\TestCase\:\:getMockBuilder\(\)$#'
 			identifier: argument.templateType
 			count: 1
-			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTest.php
+			path: tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\Repository\\SiteAccessAware\\ContentServiceTest\:\:providerForLanguagesLookupMethods\(\) return type has no value type specified in iterable type array\.$#'

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTestCase.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTestCase.php
@@ -14,7 +14,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-abstract class ConfigResolverTest extends TestCase
+abstract class ConfigResolverTestCase extends TestCase
 {
     protected const EXISTING_SA_NAME = 'existing_sa';
     protected const UNDEFINED_SA_NAME = 'undefined_sa';

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolverTest.php
@@ -11,7 +11,7 @@ namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Configuration\ConfigResolv
 use Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 
-class DefaultScopeConfigResolverTest extends ConfigResolverTest
+class DefaultScopeConfigResolverTest extends ConfigResolverTestCase
 {
     protected function getResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolverTest.php
@@ -11,7 +11,7 @@ namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Configuration\ConfigResolv
 use Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\GlobalScopeConfigResolver;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 
-class GlobalScopeConfigResolverTest extends ConfigResolverTest
+class GlobalScopeConfigResolverTest extends ConfigResolverTestCase
 {
     protected function getResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
 
-class SiteAccessGroupConfigResolverTest extends ConfigResolverTest
+class SiteAccessGroupConfigResolverTest extends ConfigResolverTestCase
 {
     protected function getResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {

--- a/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolverTest.php
+++ b/tests/bundle/Core/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolverTest.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
 
-class StaticSiteAccessConfigResolverTest extends ConfigResolverTest
+class StaticSiteAccessConfigResolverTest extends ConfigResolverTestCase
 {
     protected function getResolver(string $defaultNamespace = self::DEFAULT_NAMESPACE): ConfigResolverInterface
     {

--- a/tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTestCase.php
+++ b/tests/bundle/IO/DependencyInjection/ConfigurationFactory/BaseFlysystemTestCase.php
@@ -7,11 +7,11 @@
 
 namespace Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactory;
 
-use Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactoryTest;
+use Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactoryTestCase;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-abstract class BaseFlysystemTest extends ConfigurationFactoryTest
+abstract class BaseFlysystemTestCase extends ConfigurationFactoryTestCase
 {
     private $flysystemAdapterServiceId = 'oneup_flysystem.test_adapter';
 

--- a/tests/bundle/IO/DependencyInjection/ConfigurationFactory/BinarydataHandler/FlysystemTest.php
+++ b/tests/bundle/IO/DependencyInjection/ConfigurationFactory/BinarydataHandler/FlysystemTest.php
@@ -8,9 +8,9 @@
 namespace Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactory\BinarydataHandler;
 
 use Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory\BinarydataHandler\Flysystem;
-use Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactory\BaseFlysystemTest;
+use Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactory\BaseFlysystemTestCase;
 
-class FlysystemTest extends BaseFlysystemTest
+final class FlysystemTest extends BaseFlysystemTestCase
 {
     public function provideTestedFactory(): Flysystem
     {

--- a/tests/bundle/IO/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSClusterTest.php
+++ b/tests/bundle/IO/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSClusterTest.php
@@ -8,11 +8,11 @@
 namespace Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactory\MetadataHandler;
 
 use Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory\MetadataHandler\LegacyDFSCluster;
-use Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactoryTest;
+use Ibexa\Tests\Bundle\IO\DependencyInjection\ConfigurationFactoryTestCase;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class LegacyDFSClusterTest extends ConfigurationFactoryTest
+final class LegacyDFSClusterTest extends ConfigurationFactoryTestCase
 {
     /**
      * Returns an instance of the tested factory.

--- a/tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
+++ b/tests/bundle/IO/DependencyInjection/ConfigurationFactoryTestCase.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
  *
  * The part about the container can rely on the matthiasnoback/SymfonyDependencyInjectionTest assertContainer* methods.
  */
-abstract class ConfigurationFactoryTest extends AbstractContainerBuilderTestCase
+abstract class ConfigurationFactoryTestCase extends AbstractContainerBuilderTestCase
 {
     /** @var \Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory */
     protected $factory;

--- a/tests/lib/Collection/AbstractCollectionTestCase.php
+++ b/tests/lib/Collection/AbstractCollectionTestCase.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @template TCollection of \Ibexa\Contracts\Core\Repository\Collection\CollectionInterfaces
  */
-abstract class AbstractCollectionTest extends TestCase
+abstract class AbstractCollectionTestCase extends TestCase
 {
     public function testIsEmptyReturnsTrue(): void
     {

--- a/tests/lib/Collection/ArrayListTest.php
+++ b/tests/lib/Collection/ArrayListTest.php
@@ -12,11 +12,11 @@ use Ibexa\Contracts\Core\Collection\ArrayList;
 use Ibexa\Contracts\Core\Exception\OutOfBoundsException;
 
 /**
- * @template-extends \Ibexa\Tests\Core\Collection\AbstractCollectionTest<
+ * @template-extends \Ibexa\Tests\Core\Collection\AbstractCollectionTestCase<
  *     \Ibexa\Contracts\Core\Collection\ArrayList
  * >
  */
-class ArrayListTest extends AbstractCollectionTest
+class ArrayListTest extends AbstractCollectionTestCase
 {
     public function testFirst(): void
     {

--- a/tests/lib/Collection/ArrayMapTest.php
+++ b/tests/lib/Collection/ArrayMapTest.php
@@ -13,11 +13,11 @@ use Ibexa\Contracts\Core\Collection\MapInterface;
 use Ibexa\Contracts\Core\Exception\OutOfBoundsException;
 
 /**
- * @template-extends \Ibexa\Tests\Core\Collection\AbstractCollectionTest<
+ * @template-extends \Ibexa\Tests\Core\Collection\AbstractCollectionTestCase<
  *     \Ibexa\Contracts\Core\Collection\ArrayMap
  * >
  */
-class ArrayMapTest extends AbstractCollectionTest
+class ArrayMapTest extends AbstractCollectionTestCase
 {
     protected const EXAMPLE_DATA = [
         'A' => 'foo',

--- a/tests/lib/Event/AbstractServiceTestCase.php
+++ b/tests/lib/Event/AbstractServiceTestCase.php
@@ -14,7 +14,7 @@ use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-abstract class AbstractServiceTest extends TestCase
+abstract class AbstractServiceTestCase extends TestCase
 {
     public function getEventDispatcher(string $beforeEventName, string $eventName): TraceableEventDispatcher
     {
@@ -28,6 +28,11 @@ abstract class AbstractServiceTest extends TestCase
         );
     }
 
+    /**
+     * @param array<array{event: string, priority: int}> $listeners
+     *
+     * @return array<array{0: string, 1: int}>
+     */
     public function getListenersStack(array $listeners): array
     {
         $stack = [];

--- a/tests/lib/Event/BookmarkServiceTest.php
+++ b/tests/lib/Event/BookmarkServiceTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Repository\Events\Bookmark\DeleteBookmarkEvent;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\Event\BookmarkService;
 
-class BookmarkServiceTest extends AbstractServiceTest
+class BookmarkServiceTest extends AbstractServiceTestCase
 {
     public function testCreateBookmarkEvents()
     {

--- a/tests/lib/Event/ContentServiceTest.php
+++ b/tests/lib/Event/ContentServiceTest.php
@@ -45,7 +45,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Ibexa\Core\Event\ContentService;
 
-class ContentServiceTest extends AbstractServiceTest
+class ContentServiceTest extends AbstractServiceTestCase
 {
     public function testDeleteContentEvents()
     {

--- a/tests/lib/Event/ContentTypeServiceTest.php
+++ b/tests/lib/Event/ContentTypeServiceTest.php
@@ -51,7 +51,7 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionUpdateStru
 use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Ibexa\Core\Event\ContentTypeService;
 
-class ContentTypeServiceTest extends AbstractServiceTest
+class ContentTypeServiceTest extends AbstractServiceTestCase
 {
     public function testAddFieldDefinitionEvents()
     {

--- a/tests/lib/Event/LanguageServiceTest.php
+++ b/tests/lib/Event/LanguageServiceTest.php
@@ -22,7 +22,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Language;
 use Ibexa\Contracts\Core\Repository\Values\Content\LanguageCreateStruct;
 use Ibexa\Core\Event\LanguageService;
 
-class LanguageServiceTest extends AbstractServiceTest
+class LanguageServiceTest extends AbstractServiceTestCase
 {
     public function testDeleteLanguageEvents()
     {

--- a/tests/lib/Event/LocationServiceTest.php
+++ b/tests/lib/Event/LocationServiceTest.php
@@ -30,7 +30,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\LocationCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationUpdateStruct;
 use Ibexa\Core\Event\LocationService;
 
-class LocationServiceTest extends AbstractServiceTest
+class LocationServiceTest extends AbstractServiceTestCase
 {
     public function testCopySubtreeEvents()
     {

--- a/tests/lib/Event/NotificationServiceTest.php
+++ b/tests/lib/Event/NotificationServiceTest.php
@@ -20,7 +20,7 @@ use Ibexa\Contracts\Core\Repository\Values\Notification\CreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Notification\Notification;
 use Ibexa\Core\Event\NotificationService;
 
-class NotificationServiceTest extends AbstractServiceTest
+class NotificationServiceTest extends AbstractServiceTestCase
 {
     public function testCreateNotificationEvents()
     {

--- a/tests/lib/Event/ObjectStateServiceTest.php
+++ b/tests/lib/Event/ObjectStateServiceTest.php
@@ -33,7 +33,7 @@ use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateGroupUpdateStr
 use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateUpdateStruct;
 use Ibexa\Core\Event\ObjectStateService;
 
-class ObjectStateServiceTest extends AbstractServiceTest
+class ObjectStateServiceTest extends AbstractServiceTestCase
 {
     public function testSetContentStateEvents()
     {

--- a/tests/lib/Event/RoleServiceTest.php
+++ b/tests/lib/Event/RoleServiceTest.php
@@ -45,7 +45,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 use Ibexa\Core\Event\RoleService;
 
-class RoleServiceTest extends AbstractServiceTest
+class RoleServiceTest extends AbstractServiceTestCase
 {
     public function testPublishRoleDraftEvents()
     {

--- a/tests/lib/Event/SectionServiceTest.php
+++ b/tests/lib/Event/SectionServiceTest.php
@@ -25,7 +25,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\SectionCreateStruct;
 use Ibexa\Contracts\Core\Repository\Values\Content\SectionUpdateStruct;
 use Ibexa\Core\Event\SectionService;
 
-class SectionServiceTest extends AbstractServiceTest
+class SectionServiceTest extends AbstractServiceTestCase
 {
     public function testAssignSectionEvents()
     {

--- a/tests/lib/Event/SettingServiceTest.php
+++ b/tests/lib/Event/SettingServiceTest.php
@@ -20,7 +20,7 @@ use Ibexa\Contracts\Core\Repository\Values\Setting\SettingUpdateStruct;
 use Ibexa\Core\Event\SettingService;
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 
-class SettingServiceTest extends AbstractServiceTest
+class SettingServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateSettingEvents(): void
     {

--- a/tests/lib/Event/TrashServiceTest.php
+++ b/tests/lib/Event/TrashServiceTest.php
@@ -22,7 +22,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Trash\TrashItemDeleteResultLi
 use Ibexa\Contracts\Core\Repository\Values\Content\TrashItem;
 use Ibexa\Core\Event\TrashService;
 
-class TrashServiceTest extends AbstractServiceTest
+class TrashServiceTest extends AbstractServiceTestCase
 {
     public function testEmptyTrashEvents()
     {

--- a/tests/lib/Event/URLAliasServiceTest.php
+++ b/tests/lib/Event/URLAliasServiceTest.php
@@ -20,7 +20,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\URLAlias;
 use Ibexa\Core\Event\URLAliasService;
 
-class URLAliasServiceTest extends AbstractServiceTest
+class URLAliasServiceTest extends AbstractServiceTestCase
 {
     public function testCreateGlobalUrlAliasEvents()
     {

--- a/tests/lib/Event/URLServiceTest.php
+++ b/tests/lib/Event/URLServiceTest.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\URL;
 use Ibexa\Contracts\Core\Repository\Values\URL\URLUpdateStruct;
 use Ibexa\Core\Event\URLService;
 
-class URLServiceTest extends AbstractServiceTest
+class URLServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateUrlEvents()
     {

--- a/tests/lib/Event/URLWildcardServiceTest.php
+++ b/tests/lib/Event/URLWildcardServiceTest.php
@@ -21,7 +21,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\URLWildcardTranslationResult;
 use Ibexa\Contracts\Core\Repository\Values\Content\URLWildcardUpdateStruct;
 use Ibexa\Core\Event\URLWildcardService;
 
-class URLWildcardServiceTest extends AbstractServiceTest
+class URLWildcardServiceTest extends AbstractServiceTestCase
 {
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException

--- a/tests/lib/Event/UserPreferenceServiceTest.php
+++ b/tests/lib/Event/UserPreferenceServiceTest.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Repository\Events\UserPreference\SetUserPreferenceEvent
 use Ibexa\Contracts\Core\Repository\UserPreferenceService as UserPreferenceServiceInterface;
 use Ibexa\Core\Event\UserPreferenceService;
 
-class UserPreferenceServiceTest extends AbstractServiceTest
+class UserPreferenceServiceTest extends AbstractServiceTestCase
 {
     public function testSetUserPreferenceEvents()
     {

--- a/tests/lib/Event/UserServiceTest.php
+++ b/tests/lib/Event/UserServiceTest.php
@@ -37,7 +37,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserTokenUpdateStruct;
 use Ibexa\Contracts\Core\Repository\Values\User\UserUpdateStruct;
 use Ibexa\Core\Event\UserService;
 
-class UserServiceTest extends AbstractServiceTest
+class UserServiceTest extends AbstractServiceTestCase
 {
     public function testUpdateUserGroupEvents()
     {

--- a/tests/lib/FieldType/AuthorTest.php
+++ b/tests/lib/FieldType/AuthorTest.php
@@ -18,7 +18,7 @@ use Ibexa\Core\FieldType\Value;
  * @group fieldType
  * @group ezauthor
  */
-class AuthorTest extends FieldTypeTest
+class AuthorTest extends FieldTypeTestCase
 {
     /** @var \Ibexa\Core\FieldType\Author\Author[] */
     private $authors;

--- a/tests/lib/FieldType/BaseFieldTypeTestCase.php
+++ b/tests/lib/FieldType/BaseFieldTypeTestCase.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseFieldTypeTest extends TestCase
+abstract class BaseFieldTypeTestCase extends TestCase
 {
     /**
      * Generic cache for the getFieldTypeUnderTest() method.

--- a/tests/lib/FieldType/BinaryBaseTestCase.php
+++ b/tests/lib/FieldType/BinaryBaseTestCase.php
@@ -17,7 +17,7 @@ use Ibexa\Core\FieldType\Value;
  *
  * @group fieldType
  */
-abstract class BinaryBaseTest extends FieldTypeTest
+abstract class BinaryBaseTestCase extends FieldTypeTestCase
 {
     protected $blackListedExtensions = [
         'php',

--- a/tests/lib/FieldType/BinaryFileTest.php
+++ b/tests/lib/FieldType/BinaryFileTest.php
@@ -20,7 +20,7 @@ use Ibexa\Core\FieldType\ValidationError;
  *
  * @covers \Ibexa\Core\FieldType\BinaryFile\Type
  */
-class BinaryFileTest extends BinaryBaseTest
+class BinaryFileTest extends BinaryBaseTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/CheckboxTest.php
+++ b/tests/lib/FieldType/CheckboxTest.php
@@ -15,7 +15,7 @@ use Ibexa\Core\FieldType\Checkbox\Value as CheckboxValue;
  * @group fieldType
  * @group ezboolean
  */
-class CheckboxTest extends FieldTypeTest
+class CheckboxTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/CountryTest.php
+++ b/tests/lib/FieldType/CountryTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezcountry
  */
-class CountryTest extends FieldTypeTest
+class CountryTest extends FieldTypeTestCase
 {
     protected function provideFieldTypeIdentifier(): string
     {

--- a/tests/lib/FieldType/DateAndTimeTest.php
+++ b/tests/lib/FieldType/DateAndTimeTest.php
@@ -17,7 +17,7 @@ use stdClass;
  * @group fieldType
  * @group ezdatetime
  */
-class DateAndTimeTest extends FieldTypeTest
+class DateAndTimeTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/DateTest.php
+++ b/tests/lib/FieldType/DateTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\FieldType\Date\Value as DateValue;
  * @group fieldType
  * @group ezdate
  */
-class DateTest extends FieldTypeTest
+class DateTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/EmailAddressTest.php
+++ b/tests/lib/FieldType/EmailAddressTest.php
@@ -16,7 +16,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezemail
  */
-class EmailAddressTest extends FieldTypeTest
+class EmailAddressTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/FieldTypeTestCase.php
+++ b/tests/lib/FieldType/FieldTypeTestCase.php
@@ -9,9 +9,8 @@ namespace Ibexa\Tests\Core\FieldType;
 
 use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Core\Persistence\TransformationProcessor;
-use Ibexa\Tests\Core\FieldType\BaseFieldTypeTest as BaseFieldTypeTest;
 
-abstract class FieldTypeTest extends BaseFieldTypeTest
+abstract class FieldTypeTestCase extends BaseFieldTypeTestCase
 {
     /**
      * @return \Ibexa\Core\Persistence\TransformationProcessor|\PHPUnit\Framework\MockObject\MockObject

--- a/tests/lib/FieldType/FloatTest.php
+++ b/tests/lib/FieldType/FloatTest.php
@@ -16,7 +16,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezfloat
  */
-class FloatTest extends FieldTypeTest
+class FloatTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/Generic/GenericTest.php
+++ b/tests/lib/FieldType/Generic/GenericTest.php
@@ -11,7 +11,7 @@ namespace Ibexa\Tests\Core\FieldType\Generic;
 use Ibexa\Contracts\Core\FieldType\ValidationError;
 use Ibexa\Contracts\Core\FieldType\ValueSerializerInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
-use Ibexa\Tests\Core\FieldType\BaseFieldTypeTest;
+use Ibexa\Tests\Core\FieldType\BaseFieldTypeTestCase;
 use Ibexa\Tests\Core\FieldType\Generic\Stubs\Type as GenericFieldTypeStub;
 use Ibexa\Tests\Core\FieldType\Generic\Stubs\Value as GenericFieldValueStub;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-class GenericTest extends BaseFieldTypeTest
+class GenericTest extends BaseFieldTypeTestCase
 {
     /** @var \Ibexa\Contracts\Core\FieldType\ValueSerializerInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $serializer;

--- a/tests/lib/FieldType/ISBNTest.php
+++ b/tests/lib/FieldType/ISBNTest.php
@@ -16,7 +16,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezisbn
  */
-class ISBNTest extends FieldTypeTest
+class ISBNTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/ImageAssetTest.php
+++ b/tests/lib/FieldType/ImageAssetTest.php
@@ -26,7 +26,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezimageasset
  */
-class ImageAssetTest extends FieldTypeTest
+class ImageAssetTest extends FieldTypeTestCase
 {
     private const DESTINATION_CONTENT_ID = 14;
 

--- a/tests/lib/FieldType/ImageTest.php
+++ b/tests/lib/FieldType/ImageTest.php
@@ -20,7 +20,7 @@ use Ibexa\Core\FieldType\Validator\ImageValidator;
  * @group fieldType
  * @group ezfloat
  */
-class ImageTest extends FieldTypeTest
+class ImageTest extends FieldTypeTestCase
 {
     private const MIME_TYPES = [
         'image/png',

--- a/tests/lib/FieldType/IntegerTest.php
+++ b/tests/lib/FieldType/IntegerTest.php
@@ -16,7 +16,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezinteger
  */
-class IntegerTest extends FieldTypeTest
+class IntegerTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/KeywordTest.php
+++ b/tests/lib/FieldType/KeywordTest.php
@@ -15,7 +15,7 @@ use Ibexa\Core\FieldType\Keyword\Value as KeywordValue;
  * @group fieldType
  * @group ezinteger
  */
-class KeywordTest extends FieldTypeTest
+class KeywordTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/MapLocationTest.php
+++ b/tests/lib/FieldType/MapLocationTest.php
@@ -10,7 +10,7 @@ namespace Ibexa\Tests\Core\FieldType;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\FieldType\MapLocation;
 
-class MapLocationTest extends FieldTypeTest
+class MapLocationTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/MediaTest.php
+++ b/tests/lib/FieldType/MediaTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezbinaryfile
  */
-class MediaTest extends BinaryBaseTest
+class MediaTest extends BinaryBaseTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/RelationListTest.php
+++ b/tests/lib/FieldType/RelationListTest.php
@@ -18,7 +18,7 @@ use Ibexa\Core\FieldType\RelationList\Value;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\Repository\Validator\TargetContentValidatorInterface;
 
-class RelationListTest extends FieldTypeTest
+class RelationListTest extends FieldTypeTestCase
 {
     private const DESTINATION_CONTENT_ID_14 = 14;
     private const DESTINATION_CONTENT_ID_22 = 22;

--- a/tests/lib/FieldType/RelationTest.php
+++ b/tests/lib/FieldType/RelationTest.php
@@ -19,7 +19,7 @@ use Ibexa\Core\FieldType\Relation\Value;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\Repository\Validator\TargetContentValidatorInterface;
 
-class RelationTest extends FieldTypeTest
+class RelationTest extends FieldTypeTestCase
 {
     private const DESTINATION_CONTENT_ID = 14;
 

--- a/tests/lib/FieldType/SelectionTest.php
+++ b/tests/lib/FieldType/SelectionTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezselection
  */
-class SelectionTest extends FieldTypeTest
+class SelectionTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/TextBlockTest.php
+++ b/tests/lib/FieldType/TextBlockTest.php
@@ -16,7 +16,7 @@ use Ibexa\Core\FieldType\TextBlock\Value as TextBlockValue;
  * @group fieldType
  * @group eztext
  */
-final class TextBlockTest extends FieldTypeTest
+final class TextBlockTest extends FieldTypeTestCase
 {
     private const string SAMPLE_TEXT_LINE_VALUE = ' sindelfingen ';
 

--- a/tests/lib/FieldType/TextLineTest.php
+++ b/tests/lib/FieldType/TextLineTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\FieldType\ValidationError;
  * @group fieldType
  * @group ezstring
  */
-final class TextLineTest extends FieldTypeTest
+final class TextLineTest extends FieldTypeTestCase
 {
     private const string STRING_TOO_SHORT_EXPECTED_SINGULAR_MESSAGE = 'The string cannot be shorter than %size% character.';
     private const string STRING_TOO_SHORT_EXPECTED_PLURAL_MESSAGE = 'The string cannot be shorter than %size% characters.';

--- a/tests/lib/FieldType/TimeTest.php
+++ b/tests/lib/FieldType/TimeTest.php
@@ -16,7 +16,7 @@ use Ibexa\Core\FieldType\Time\Value as TimeValue;
  * @group fieldType
  * @group eztime
  */
-class TimeTest extends FieldTypeTest
+class TimeTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/UrlTest.php
+++ b/tests/lib/FieldType/UrlTest.php
@@ -15,7 +15,7 @@ use Ibexa\Core\FieldType\Url\Value as UrlValue;
  * @group fieldType
  * @group ezurl
  */
-class UrlTest extends FieldTypeTest
+class UrlTest extends FieldTypeTestCase
 {
     /**
      * Returns the field type under test.

--- a/tests/lib/FieldType/UserTest.php
+++ b/tests/lib/FieldType/UserTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
  * @group fieldType
  * @group ezurl
  */
-class UserTest extends FieldTypeTest
+class UserTest extends FieldTypeTestCase
 {
     private const UNSUPPORTED_HASH_TYPE = 0xDEADBEEF;
 

--- a/tests/lib/IO/Flysystem/Adapter/DynamicPathFilesystemAdapterDecoratorTest.php
+++ b/tests/lib/IO/Flysystem/Adapter/DynamicPathFilesystemAdapterDecoratorTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * Note: SiteAccess-aware dynamic settings resolving aspect has been tested via PathPrefixer
  * and Visibility converter test cases:
- * {@see \Ibexa\Tests\Core\IO\Flysystem\VisibilityConverter\BaseVisibilityConverterTest}
+ * {@see \Ibexa\Tests\Core\IO\Flysystem\VisibilityConverter\BaseVisibilityConverterTestCase}
  * {@see \Ibexa\Tests\Core\IO\Flysystem\PathPrefixer\DFSSiteAccessAwarePathPrefixerTest}
  */
 final class DynamicPathFilesystemAdapterDecoratorTest extends TestCase

--- a/tests/lib/IO/Flysystem/PathPrefixer/BaseSiteAccessAwarePathPrefixerTestCase.php
+++ b/tests/lib/IO/Flysystem/PathPrefixer/BaseSiteAccessAwarePathPrefixerTestCase.php
@@ -14,7 +14,7 @@ use Ibexa\Tests\Core\Search\TestCase;
 /**
  * @covers \Ibexa\Core\IO\Flysystem\PathPrefixer\PathPrefixerInterface
  */
-abstract class BaseSiteAccessAwarePathPrefixerTest extends TestCase
+abstract class BaseSiteAccessAwarePathPrefixerTestCase extends TestCase
 {
     abstract protected function getPrefixer(): PathPrefixerInterface;
 

--- a/tests/lib/IO/Flysystem/PathPrefixer/DFSSiteAccessAwarePathPrefixerTest.php
+++ b/tests/lib/IO/Flysystem/PathPrefixer/DFSSiteAccessAwarePathPrefixerTest.php
@@ -15,7 +15,7 @@ use Ibexa\Core\IO\Flysystem\PathPrefixer\PathPrefixerInterface;
 /**
  * @covers \Ibexa\Core\IO\Flysystem\PathPrefixer\DFSSiteAccessAwarePathPrefixer
  */
-final class DFSSiteAccessAwarePathPrefixerTest extends BaseSiteAccessAwarePathPrefixerTest
+final class DFSSiteAccessAwarePathPrefixerTest extends BaseSiteAccessAwarePathPrefixerTestCase
 {
     public function getDataForTestPrefixPath(): iterable
     {

--- a/tests/lib/IO/Flysystem/PathPrefixer/LocalSiteAccessAwarePathPrefixerTest.php
+++ b/tests/lib/IO/Flysystem/PathPrefixer/LocalSiteAccessAwarePathPrefixerTest.php
@@ -15,7 +15,7 @@ use Ibexa\Core\IO\IOConfigProvider;
 /**
  * @covers \Ibexa\Core\IO\Flysystem\PathPrefixer\LocalSiteAccessAwarePathPrefixer
  */
-final class LocalSiteAccessAwarePathPrefixerTest extends BaseSiteAccessAwarePathPrefixerTest
+final class LocalSiteAccessAwarePathPrefixerTest extends BaseSiteAccessAwarePathPrefixerTestCase
 {
     public function getDataForTestPrefixPath(): iterable
     {

--- a/tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTestCase.php
+++ b/tests/lib/IO/Flysystem/VisibilityConverter/BaseVisibilityConverterTestCase.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \Ibexa\Core\IO\Flysystem\VisibilityConverter\BaseVisibilityConverter
  */
-abstract class BaseVisibilityConverterTest extends TestCase
+abstract class BaseVisibilityConverterTestCase extends TestCase
 {
     protected const FLYSYSTEM_FILE_FLAGS = 0600;
     protected const FLYSYSTEM_DIRECTORY_FLAGS = 0700;

--- a/tests/lib/IO/Flysystem/VisibilityConverter/DFSVisibilityConverterTest.php
+++ b/tests/lib/IO/Flysystem/VisibilityConverter/DFSVisibilityConverterTest.php
@@ -15,7 +15,7 @@ use League\Flysystem\Visibility;
 /**
  * @covers \Ibexa\Core\IO\Flysystem\VisibilityConverter\DFSVisibilityConverter
  */
-final class DFSVisibilityConverterTest extends BaseVisibilityConverterTest
+final class DFSVisibilityConverterTest extends BaseVisibilityConverterTestCase
 {
     private const DFS_FILE_FLAGS = 0640;
     private const DFS_DIRECTORY_FLAGS = 0750;

--- a/tests/lib/IO/Flysystem/VisibilityConverter/SiteAccessAwareVisibilityConverterTest.php
+++ b/tests/lib/IO/Flysystem/VisibilityConverter/SiteAccessAwareVisibilityConverterTest.php
@@ -16,7 +16,7 @@ use League\Flysystem\Visibility;
 /**
  * @covers \Ibexa\Core\IO\Flysystem\VisibilityConverter\SiteAccessAwareVisibilityConverter
  */
-final class SiteAccessAwareVisibilityConverterTest extends BaseVisibilityConverterTest
+final class SiteAccessAwareVisibilityConverterTest extends BaseVisibilityConverterTestCase
 {
     private const int SITE_FILE_FLAGS = 0644;
     private const int SITE_DIRECTORY_FLAGS = 0755;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTestCase.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/BaseTestCase.php
@@ -18,7 +18,7 @@ use Ibexa\Core\Repository\Permission\PermissionResolver;
 use Ibexa\Core\Repository\Repository;
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseTest extends TestCase
+abstract class BaseTestCase extends TestCase
 {
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     protected $repositoryMock;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/DepthTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/DepthTest.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Depth as DepthMatcher;
 
-class DepthTest extends BaseTest
+class DepthTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Depth */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ContentTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ContentTest.php
@@ -10,9 +10,9 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Content as ContentIdMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class ContentTest extends BaseTest
+class ContentTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Content */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ContentTypeGroupTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ContentTypeGroupTest.php
@@ -12,9 +12,9 @@ use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\ContentTypeGroup as ContentTypeGroupIdMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class ContentTypeGroupTest extends BaseTest
+class ContentTypeGroupTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\ContentTypeGroup */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ContentTypeTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ContentTypeTest.php
@@ -10,9 +10,9 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\ContentType as ContentTypeIdMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class ContentTypeTest extends BaseTest
+class ContentTypeTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\ContentType */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/LocationTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/LocationTest.php
@@ -10,9 +10,9 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Location as LocationIdMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class LocationTest extends BaseTest
+class LocationTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Location */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ParentContentTypeTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ParentContentTypeTest.php
@@ -10,9 +10,9 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\ParentContentType as ParentContentTypeMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class ParentContentTypeTest extends BaseTest
+class ParentContentTypeTest extends BaseTestCase
 {
     private const EXAMPLE_LOCATION_ID = 54;
     private const EXAMPLE_PARENT_LOCATION_ID = 2;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ParentLocationTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/ParentLocationTest.php
@@ -11,9 +11,9 @@ use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\ParentLocation as ParentLocationIdMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class ParentLocationTest extends BaseTest
+class ParentLocationTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\ParentLocation */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/RemoteTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/RemoteTest.php
@@ -10,9 +10,9 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Remote as RemoteIdMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class RemoteTest extends BaseTest
+class RemoteTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Remote */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/SectionTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Id/SectionTest.php
@@ -10,9 +10,9 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Section as SectionIdMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class SectionTest extends BaseTest
+class SectionTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Id\Section */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Identifier/ContentTypeTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Identifier/ContentTypeTest.php
@@ -11,9 +11,9 @@ use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Identifier\ContentType as ContentTypeIdentifierMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class ContentTypeTest extends BaseTest
+class ContentTypeTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Identifier\ContentType */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Identifier/ParentContentTypeTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Identifier/ParentContentTypeTest.php
@@ -12,9 +12,9 @@ use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Identifier\ParentContentType as ParentContentTypeMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class ParentContentTypeTest extends BaseTest
+class ParentContentTypeTest extends BaseTestCase
 {
     private const EXAMPLE_LOCATION_ID = 54;
     private const EXAMPLE_PARENT_LOCATION_ID = 2;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/Identifier/SectionTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/Identifier/SectionTest.php
@@ -12,9 +12,9 @@ use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\SectionService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Section;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Identifier\Section as SectionIdentifierMatcher;
-use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTest;
+use Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased\BaseTestCase;
 
-class SectionTest extends BaseTest
+class SectionTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\Identifier\Section */
     private $matcher;

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/MultipleValuedTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/MultipleValuedTest.php
@@ -9,7 +9,7 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Matcher\ContentBased;
 
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 
-class MultipleValuedTest extends BaseTest
+class MultipleValuedTest extends BaseTestCase
 {
     /**
      * @dataProvider matchingConfigProvider

--- a/tests/lib/MVC/Symfony/Matcher/ContentBased/UrlAliasTest.php
+++ b/tests/lib/MVC/Symfony/Matcher/ContentBased/UrlAliasTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\URLAlias;
 use Ibexa\Core\MVC\Symfony\Matcher\ContentBased\UrlAlias as UrlAliasMatcher;
 
-class UrlAliasTest extends BaseTest
+class UrlAliasTest extends BaseTestCase
 {
     /** @var \Ibexa\Core\MVC\Symfony\Matcher\ContentBased\UrlAlias */
     private $matcher;

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterBaseTestCase.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterBaseTestCase.php
@@ -14,7 +14,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use PHPUnit\Framework\TestCase;
 
-abstract class RouterBaseTest extends TestCase
+abstract class RouterBaseTestCase extends TestCase
 {
     protected const UNDEFINED_SA_NAME = 'undefined_sa';
     protected const ENV_SA_NAME = 'env_sa';

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterHostElementTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterHostElementTest.php
@@ -14,7 +14,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Map\Host as HostMapMatcher;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterHostElementTest extends RouterBaseTest
+class RouterHostElementTest extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterHostPortURITest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterHostPortURITest.php
@@ -13,7 +13,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Map\Port;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterHostPortURITest extends RouterBaseTest
+class RouterHostPortURITest extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterHostTextTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterHostTextTest.php
@@ -12,7 +12,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\HostText as HostTextMatcher;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterHostTextTest extends RouterBaseTest
+class RouterHostTextTest extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterPortHostURITest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterPortHostURITest.php
@@ -11,7 +11,7 @@ use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterPortHostURITest extends RouterBaseTest
+class RouterPortHostURITest extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterSpecialPortsTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterSpecialPortsTest.php
@@ -12,7 +12,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\Map\Port as PortMatcher;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterSpecialPortsTest extends RouterBaseTest
+class RouterSpecialPortsTest extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class RouterTest extends RouterBaseTest
+class RouterTest extends RouterBaseTestCase
 {
     protected function tearDown(): void
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterURIElement2Test.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterURIElement2Test.php
@@ -14,7 +14,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterURIElement2Test extends RouterBaseTest
+class RouterURIElement2Test extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterURIElementTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterURIElementTest.php
@@ -14,7 +14,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterURIElementTest extends RouterBaseTest
+class RouterURIElementTest extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterURITextTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterURITextTest.php
@@ -13,7 +13,7 @@ use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher\URIText as URITextMatcher;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
 use Psr\Log\LoggerInterface;
 
-class RouterURITextTest extends RouterBaseTest
+class RouterURITextTest extends RouterBaseTestCase
 {
     public function matchProvider(): array
     {

--- a/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTestCase.php
+++ b/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTestCase.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
-abstract class BaseRenderStrategyTest extends TestCase
+abstract class BaseRenderStrategyTestCase extends TestCase
 {
     /**
      * @phpstan-param class-string<\Ibexa\Contracts\Core\MVC\Templating\BaseRenderStrategy> $typeClass

--- a/tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
+++ b/tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
-class RenderContentStrategyTest extends BaseRenderStrategyTest
+class RenderContentStrategyTest extends BaseRenderStrategyTestCase
 {
     public function testUnsupportedValueObject(): void
     {

--- a/tests/lib/MVC/Symfony/Templating/RenderLocationStrategyTest.php
+++ b/tests/lib/MVC/Symfony/Templating/RenderLocationStrategyTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
-class RenderLocationStrategyTest extends BaseRenderStrategyTest
+class RenderLocationStrategyTest extends BaseRenderStrategyTestCase
 {
     public function testUnsupportedValueObject(): void
     {

--- a/tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
+++ b/tests/lib/MVC/Symfony/View/AbstractViewTestCase.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \Ibexa\Core\MVC\Symfony\View\View
  */
-abstract class AbstractViewTest extends TestCase
+abstract class AbstractViewTestCase extends TestCase
 {
     abstract protected function createViewUnderTest($template = null, array $parameters = [], $viewType = 'full'): View;
 

--- a/tests/lib/MVC/Symfony/View/ContentViewTest.php
+++ b/tests/lib/MVC/Symfony/View/ContentViewTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\MVC\Symfony\View\View;
  *
  * @covers \Ibexa\Core\MVC\Symfony\View\ContentView
  */
-class ContentViewTest extends AbstractViewTest
+class ContentViewTest extends AbstractViewTestCase
 {
     /**
      * Params that are always returned by this view.

--- a/tests/lib/MVC/Symfony/View/LoginFormViewTest.php
+++ b/tests/lib/MVC/Symfony/View/LoginFormViewTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 /**
  * @group mvc
  */
-final class LoginFormViewTest extends AbstractViewTest
+final class LoginFormViewTest extends AbstractViewTestCase
 {
     public function testSetLastUsername(): void
     {

--- a/tests/lib/Persistence/Cache/AbstractBaseHandlerTestCase.php
+++ b/tests/lib/Persistence/Cache/AbstractBaseHandlerTestCase.php
@@ -39,7 +39,7 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * Abstract test case for spi cache impl.
  */
-abstract class AbstractBaseHandlerTest extends TestCase
+abstract class AbstractBaseHandlerTestCase extends TestCase
 {
     /** @var \Ibexa\Core\Persistence\Cache\Adapter\TransactionalInMemoryCacheAdapter|\PHPUnit\Framework\MockObject\MockObject */
     protected $cacheMock;

--- a/tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
+++ b/tests/lib/Persistence/Cache/AbstractInMemoryCacheHandlerTestCase.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Core\Persistence\Cache;
 
 /**
- * Abstract test case for spi cache impl.
+ * Abstract test case for spi cache impl, with in-memory handling.
  */
-abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
+abstract class AbstractInMemoryCacheHandlerTestCase extends AbstractBaseHandlerTestCase
 {
     abstract public function getHandlerMethodName(): string;
 
@@ -27,7 +27,7 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
      * @param array|null $tagGeneratingArguments
      * @param array|null $keyGeneratingArguments
      * @param array|null $tags
-     * @param string|array|null $key
+     * @param array|null $key
      * @param mixed $returnValue
      */
     final public function testUnCachedMethods(
@@ -36,8 +36,9 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
         array $tagGeneratingArguments = null,
         array $keyGeneratingArguments = null,
         array $tags = null,
-        $key = null,
-        $returnValue = null
+        array $key = null,
+        $returnValue = null,
+        bool $callInnerHandler = true
     ) {
         $handlerMethodName = $this->getHandlerMethodName();
 
@@ -47,12 +48,12 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
 
         $innerHandler = $this->createMock($this->getHandlerClassName());
         $this->persistenceHandlerMock
-            ->expects(self::once())
+            ->expects($callInnerHandler ? self::once() : self::never())
             ->method($handlerMethodName)
             ->willReturn($innerHandler);
 
         $invocationMocker = $innerHandler
-            ->expects(self::once())
+            ->expects($callInnerHandler ? self::once() : self::never())
             ->method($method)
             ->with(...$arguments);
         // workaround for mocking void-returning methods, null in this case denotes that, not null value
@@ -93,14 +94,13 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
                 ->with($tags);
 
             $this->cacheMock
-                ->expects(!empty($key) && is_string($key) ? self::once() : self::never())
-                ->method('deleteItem')
-                ->with($key);
-
-            $this->cacheMock
-                ->expects(!empty($key) && is_array($key) ? self::once() : self::never())
+                ->expects(!empty($key) ? self::once() : self::never())
                 ->method('deleteItems')
                 ->with($key);
+        } else {
+            $this->cacheMock
+                ->expects(self::never())
+                ->method(self::anything());
         }
 
         $handler = $this->persistenceCacheHandler->$handlerMethodName();
@@ -140,7 +140,9 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
         $cacheItem = $this->getCacheItem($key, $multi ? reset($data) : $data);
         $handlerMethodName = $this->getHandlerMethodName();
 
+        $this->loggerMock->expects(self::once())->method('logCacheHit');
         $this->loggerMock->expects(self::never())->method('logCall');
+        $this->loggerMock->expects(self::never())->method('logCacheMiss');
 
         if ($tagGeneratingArguments) {
             $this->cacheIdentifierGeneratorMock
@@ -200,7 +202,7 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
      * @param array|null $tagGeneratingResults
      * @param array|null $keyGeneratingArguments
      * @param array|null $keyGeneratingResults
-     * @param object $data
+     * @param null $data
      * @param bool $multi Default false, set to true if method will lookup several cache items.
      * @param array $additionalCalls Sets of additional calls being made to handlers, with 4 values (0: handler name, 1: handler class, 2: method, 3: return data)
      */
@@ -219,11 +221,9 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
         $cacheItem = $this->getCacheItem($key, null);
         $handlerMethodName = $this->getHandlerMethodName();
 
-        $handler = $this->persistenceCacheHandler->$handlerMethodName();
-        $this->loggerMock
-            ->expects(self::once())
-            ->method('logCall')
-            ->with(get_class($handler) . '::' . $method, self::isType('array'));
+        $this->loggerMock->expects(self::once())->method('logCacheMiss');
+        $this->loggerMock->expects(self::never())->method('logCall');
+        $this->loggerMock->expects(self::never())->method('logCacheHit');
 
         if ($tagGeneratingArguments) {
             $this->cacheIdentifierGeneratorMock
@@ -285,11 +285,12 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
             ->method('save')
             ->with($cacheItem);
 
+        $handler = $this->persistenceCacheHandler->$handlerMethodName();
         $return = call_user_func_array([$handler, $method], $arguments);
 
         self::assertEquals($data, $return);
 
-        // Assert use of tags would probably need custom logic as internal property is [$tag => $tag] value and we don't want to know that.
+        // Assert use of tags would probably need custom logic as internal property is [$tag => $tag] value, and we don't want to know that.
         //$this->assertAttributeEquals([], 'tags', $cacheItem);
     }
 }

--- a/tests/lib/Persistence/Cache/BookmarkHandlerTest.php
+++ b/tests/lib/Persistence/Cache/BookmarkHandlerTest.php
@@ -17,7 +17,7 @@ use Ibexa\Contracts\Core\Persistence\Content\Location\Handler as SPILocationHand
 /**
  * Test case for Persistence\Cache\BookmarkHandler.
  */
-class BookmarkHandlerTest extends AbstractCacheHandlerTest
+class BookmarkHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/ContentHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentHandlerTest.php
@@ -23,7 +23,7 @@ use Ibexa\Core\Persistence\Cache\ContentHandler;
 /**
  * @covers \Ibexa\Core\Persistence\Cache\ContentHandler
  */
-class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
+class ContentHandlerTest extends AbstractInMemoryCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/ContentLanguageHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentLanguageHandlerTest.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Core\Persistence\Content\Language\Handler;
 /**
  * Test case for Persistence\Cache\ContentLanguageHandler.
  */
-class ContentLanguageHandlerTest extends AbstractInMemoryCacheHandlerTest
+class ContentLanguageHandlerTest extends AbstractInMemoryCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ContentTypeHandlerTest.php
@@ -19,7 +19,7 @@ use Ibexa\Contracts\Core\Persistence\Content\Type\UpdateStruct as SPITypeUpdateS
 /**
  * Test case for Persistence\Cache\ContentTypeHandler.
  */
-class ContentTypeHandlerTest extends AbstractInMemoryCacheHandlerTest
+class ContentTypeHandlerTest extends AbstractInMemoryCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/LocationHandlerTest.php
+++ b/tests/lib/Persistence/Cache/LocationHandlerTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Persistence\Content\Location\UpdateStruct;
 /**
  * Test case for Persistence\Cache\LocationHandler.
  */
-class LocationHandlerTest extends AbstractInMemoryCacheHandlerTest
+class LocationHandlerTest extends AbstractInMemoryCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/NotificationHandlerTest.php
+++ b/tests/lib/Persistence/Cache/NotificationHandlerTest.php
@@ -17,7 +17,7 @@ use Ibexa\Contracts\Core\Repository\Values\Notification\Notification;
 /**
  * Test case for Persistence\Cache\NotificationHandler.
  */
-class NotificationHandlerTest extends AbstractCacheHandlerTest
+class NotificationHandlerTest extends AbstractCacheHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Cache/ObjectStateHandlerTest.php
+++ b/tests/lib/Persistence/Cache/ObjectStateHandlerTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Persistence\Content\ObjectState\InputStruct as SPIInput
 /**
  * Test case for Persistence\Cache\ObjectStateHandler.
  */
-class ObjectStateHandlerTest extends AbstractCacheHandlerTest
+class ObjectStateHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/PersistenceHandlerTest.php
+++ b/tests/lib/Persistence/Cache/PersistenceHandlerTest.php
@@ -15,7 +15,7 @@ use Ibexa\Core\Persistence\Cache;
  *
  * @covers \Ibexa\Core\Persistence\Cache\Handler
  */
-class PersistenceHandlerTest extends AbstractBaseHandlerTest
+class PersistenceHandlerTest extends AbstractBaseHandlerTestCase
 {
     public function testHandler()
     {

--- a/tests/lib/Persistence/Cache/SectionHandlerTest.php
+++ b/tests/lib/Persistence/Cache/SectionHandlerTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Persistence\Content\Section\Handler as SPISectionHandle
 /**
  * Test case for Persistence\Cache\SectionHandler.
  */
-class SectionHandlerTest extends AbstractCacheHandlerTest
+class SectionHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/SettingHandlerTest.php
+++ b/tests/lib/Persistence/Cache/SettingHandlerTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Persistence\Setting\Setting;
 /**
  * Test case for Persistence\Cache\SettingHandler.
  */
-class SettingHandlerTest extends AbstractCacheHandlerTest
+class SettingHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/TransactionHandlerTest.php
+++ b/tests/lib/Persistence/Cache/TransactionHandlerTest.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Persistence\TransactionHandler;
 /**
  * @covers \Ibexa\Core\Persistence\Cache\TransactionHandler
  */
-class TransactionHandlerTest extends AbstractCacheHandlerTest
+class TransactionHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/TrashHandlerTest.php
+++ b/tests/lib/Persistence/Cache/TrashHandlerTest.php
@@ -18,7 +18,7 @@ use Ibexa\Core\Persistence\Cache\LocationHandler;
 /**
  * Test case for Persistence\Cache\SectionHandler.
  */
-class TrashHandlerTest extends AbstractCacheHandlerTest
+class TrashHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/URLHandlerTest.php
+++ b/tests/lib/Persistence/Cache/URLHandlerTest.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Persistence\URL\URL;
 use Ibexa\Contracts\Core\Persistence\URL\URLUpdateStruct;
 use Ibexa\Contracts\Core\Repository\Values\URL\URLQuery;
 
-class URLHandlerTest extends AbstractCacheHandlerTest
+class URLHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/UrlAliasHandlerTest.php
+++ b/tests/lib/Persistence/Cache/UrlAliasHandlerTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Persistence\Content\UrlAlias\Handler as SPIUrlAliasHand
 /**
  * Test case for Persistence\Cache\UrlAliasHandler.
  */
-class UrlAliasHandlerTest extends AbstractInMemoryCacheHandlerTest
+class UrlAliasHandlerTest extends AbstractInMemoryCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/UrlWildcardHandlerTest.php
+++ b/tests/lib/Persistence/Cache/UrlWildcardHandlerTest.php
@@ -10,7 +10,7 @@ namespace Ibexa\Tests\Core\Persistence\Cache;
 use Ibexa\Contracts\Core\Persistence\Content\UrlWildcard;
 use Ibexa\Contracts\Core\Persistence\Content\UrlWildcard\Handler as SpiUrlWildcardHandler;
 
-class UrlWildcardHandlerTest extends AbstractCacheHandlerTest
+class UrlWildcardHandlerTest extends AbstractCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/UserHandlerTest.php
+++ b/tests/lib/Persistence/Cache/UserHandlerTest.php
@@ -21,7 +21,7 @@ use Ibexa\Core\Persistence\Legacy\Content\Location\Handler as SPILocationHandler
 /**
  * Test case for Persistence\Cache\UserHandler.
  */
-class UserHandlerTest extends AbstractInMemoryCacheHandlerTest
+class UserHandlerTest extends AbstractInMemoryCacheHandlerTestCase
 {
     public function getHandlerMethodName(): string
     {

--- a/tests/lib/Persistence/Cache/UserPreferenceHandlerTest.php
+++ b/tests/lib/Persistence/Cache/UserPreferenceHandlerTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Persistence\UserPreference\UserPreferenceSetStruct;
 /**
  * Test case for Persistence\Cache\UserPreferenceHandler.
  */
-class UserPreferenceHandlerTest extends AbstractInMemoryCacheHandlerTest
+class UserPreferenceHandlerTest extends AbstractInMemoryCacheHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/CriterionHandlerTestCase.php
@@ -15,7 +15,7 @@ use Ibexa\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 use PHPUnit\Framework\TestCase;
 
-abstract class CriterionHandlerTest extends TestCase
+abstract class CriterionHandlerTestCase extends TestCase
 {
     abstract public function testAccept();
 

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/LogicalAndTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/LogicalAndTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion\LogicalAnd;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\LogicalAnd as LogicalAndHandler;
 
-class LogicalAndTest extends CriterionHandlerTest
+class LogicalAndTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/LogicalNotTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/LogicalNotTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion\LogicalNot;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\LogicalNot as LogicalNotHandler;
 
-class LogicalNotTest extends CriterionHandlerTest
+class LogicalNotTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/LogicalOrTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/LogicalOrTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion;
 use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion\LogicalOr;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\LogicalOr as LogicalOrHandler;
 
-class LogicalOrTest extends CriterionHandlerTest
+class LogicalOrTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/MatchAllTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/MatchAllTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion\MatchAll;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\MatchAll as MatchAllHandler;
 
-class MatchAllTest extends CriterionHandlerTest
+class MatchAllTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/MatchNoneTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/MatchNoneTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion\MatchNone;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\MatchNone as MatchNoneHandler;
 
-class MatchNoneTest extends CriterionHandlerTest
+class MatchNoneTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/PatternTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/PatternTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion\Pattern;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\Pattern as PatternHandler;
 
-class PatternTest extends CriterionHandlerTest
+class PatternTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/ValidityTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/ValidityTest.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\URL\Query\Criterion\Validity;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\Validity as ValidityHandler;
 
-class ValidityTest extends CriterionHandlerTest
+class ValidityTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/VisibleOnlyTest.php
+++ b/tests/lib/Persistence/Legacy/URL/Query/CriterionHandler/VisibleOnlyTest.php
@@ -18,7 +18,7 @@ use Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\VisibleOnly as Visi
 /**
  * @covers \Ibexa\Core\Persistence\Legacy\URL\Query\CriterionHandler\VisibleOnly
  */
-class VisibleOnlyTest extends CriterionHandlerTest
+class VisibleOnlyTest extends CriterionHandlerTestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/lib/QueryType/BuiltIn/AbstractQueryTypeTestCase.php
+++ b/tests/lib/QueryType/BuiltIn/AbstractQueryTypeTestCase.php
@@ -17,7 +17,7 @@ use Ibexa\Core\QueryType\QueryType;
 use Ibexa\Core\Repository\Values\Content\Location;
 use PHPUnit\Framework\TestCase;
 
-abstract class AbstractQueryTypeTest extends TestCase
+abstract class AbstractQueryTypeTestCase extends TestCase
 {
     protected const ROOT_LOCATION_ID = 2;
     protected const ROOT_LOCATION_PATH_STRING = '/1/2/';

--- a/tests/lib/QueryType/BuiltIn/AncestorsQueryTypeTest.php
+++ b/tests/lib/QueryType/BuiltIn/AncestorsQueryTypeTest.php
@@ -25,7 +25,7 @@ use Ibexa\Core\QueryType\BuiltIn\SortClausesFactoryInterface;
 use Ibexa\Core\QueryType\QueryType;
 use Ibexa\Core\Repository\Values\Content\Location;
 
-final class AncestorsQueryTypeTest extends AbstractQueryTypeTest
+final class AncestorsQueryTypeTest extends AbstractQueryTypeTestCase
 {
     private const EXAMPLE_LOCATION_ID = 54;
     private const EXAMPLE_LOCATION_PATH_STRING = '/1/2/54/';

--- a/tests/lib/QueryType/BuiltIn/ChildrenQueryTypeTest.php
+++ b/tests/lib/QueryType/BuiltIn/ChildrenQueryTypeTest.php
@@ -23,7 +23,7 @@ use Ibexa\Core\QueryType\BuiltIn\SortClausesFactoryInterface;
 use Ibexa\Core\QueryType\QueryType;
 use Ibexa\Core\Repository\Values\Content\Location;
 
-final class ChildrenQueryTypeTest extends AbstractQueryTypeTest
+final class ChildrenQueryTypeTest extends AbstractQueryTypeTestCase
 {
     private const EXAMPLE_LOCATION_ID = 54;
 

--- a/tests/lib/QueryType/BuiltIn/GeoLocationQueryTypeTest.php
+++ b/tests/lib/QueryType/BuiltIn/GeoLocationQueryTypeTest.php
@@ -22,7 +22,7 @@ use Ibexa\Core\QueryType\BuiltIn\GeoLocationQueryType;
 use Ibexa\Core\QueryType\BuiltIn\SortClausesFactoryInterface;
 use Ibexa\Core\QueryType\QueryType;
 
-final class GeoLocationQueryTypeTest extends AbstractQueryTypeTest
+final class GeoLocationQueryTypeTest extends AbstractQueryTypeTestCase
 {
     private const EXAMPLE_FIELD = 'location';
     private const EXAMPLE_DISTANCE = 40.0;

--- a/tests/lib/QueryType/BuiltIn/RelatedToContentQueryTypeTest.php
+++ b/tests/lib/QueryType/BuiltIn/RelatedToContentQueryTypeTest.php
@@ -22,7 +22,7 @@ use Ibexa\Core\QueryType\BuiltIn\RelatedToContentQueryType;
 use Ibexa\Core\QueryType\BuiltIn\SortClausesFactoryInterface;
 use Ibexa\Core\QueryType\QueryType;
 
-final class RelatedToContentQueryTypeTest extends AbstractQueryTypeTest
+final class RelatedToContentQueryTypeTest extends AbstractQueryTypeTestCase
 {
     private const EXAMPLE_CONTENT_ID = 52;
     private const EXAMPLE_FIELD = 'related';

--- a/tests/lib/QueryType/BuiltIn/SiblingsQueryTypeTest.php
+++ b/tests/lib/QueryType/BuiltIn/SiblingsQueryTypeTest.php
@@ -23,7 +23,7 @@ use Ibexa\Core\QueryType\BuiltIn\SortClausesFactoryInterface;
 use Ibexa\Core\QueryType\QueryType;
 use Ibexa\Core\Repository\Values\Content\Location;
 
-final class SiblingsQueryTypeTest extends AbstractQueryTypeTest
+final class SiblingsQueryTypeTest extends AbstractQueryTypeTestCase
 {
     private const EXAMPLE_LOCATION_ID = 54;
 

--- a/tests/lib/QueryType/BuiltIn/SubtreeQueryTest.php
+++ b/tests/lib/QueryType/BuiltIn/SubtreeQueryTest.php
@@ -24,7 +24,7 @@ use Ibexa\Core\QueryType\BuiltIn\SubtreeQueryType;
 use Ibexa\Core\QueryType\QueryType;
 use Ibexa\Core\Repository\Values\Content\Location;
 
-final class SubtreeQueryTest extends AbstractQueryTypeTest
+final class SubtreeQueryTest extends AbstractQueryTypeTestCase
 {
     private const EXAMPLE_LOCATION_ID = 54;
     private const EXAMPLE_LOCATION_PATH_STRING = '/1/2/54/';

--- a/tests/lib/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapterTestCase.php
+++ b/tests/lib/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapterTestCase.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @phpstan-import-type TSearchLanguageFilter from \Ibexa\Contracts\Core\Repository\SearchService
  */
-abstract class AbstractSearchAdapterTest extends TestCase
+abstract class AbstractSearchAdapterTestCase extends TestCase
 {
     protected const EXAMPLE_LANGUAGE_FILTER = [
         'languages' => ['eng-GB', 'pol-PL'],

--- a/tests/lib/Repository/Iterator/BatchIteratorAdapter/ContentInfoSearchAdapterTest.php
+++ b/tests/lib/Repository/Iterator/BatchIteratorAdapter/ContentInfoSearchAdapterTest.php
@@ -14,9 +14,9 @@ use Ibexa\Contracts\Core\Repository\SearchService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 
 /**
- * @extends \Ibexa\Tests\Core\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapterTest<\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo>
+ * @extends \Ibexa\Tests\Core\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapterTestCase<\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo>
  */
-final class ContentInfoSearchAdapterTest extends AbstractSearchAdapterTest
+final class ContentInfoSearchAdapterTest extends AbstractSearchAdapterTestCase
 {
     protected function createAdapterUnderTest(
         SearchService $searchService,

--- a/tests/lib/Repository/Iterator/BatchIteratorAdapter/ContentSearchAdapterTest.php
+++ b/tests/lib/Repository/Iterator/BatchIteratorAdapter/ContentSearchAdapterTest.php
@@ -16,9 +16,9 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 /**
  * @phpstan-import-type TSearchLanguageFilter from \Ibexa\Contracts\Core\Repository\SearchService
  *
- * @extends \Ibexa\Tests\Core\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapterTest<\Ibexa\Contracts\Core\Repository\Values\Content\Content>
+ * @extends \Ibexa\Tests\Core\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapterTestCase<\Ibexa\Contracts\Core\Repository\Values\Content\Content>
  */
-final class ContentSearchAdapterTest extends AbstractSearchAdapterTest
+final class ContentSearchAdapterTest extends AbstractSearchAdapterTestCase
 {
     protected function createAdapterUnderTest(
         SearchService $searchService,

--- a/tests/lib/Repository/Iterator/BatchIteratorAdapter/LocationSearchAdapterTest.php
+++ b/tests/lib/Repository/Iterator/BatchIteratorAdapter/LocationSearchAdapterTest.php
@@ -15,9 +15,9 @@ use Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 
 /**
- * @extends \Ibexa\Tests\Core\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapterTest<\Ibexa\Contracts\Core\Repository\Values\Content\Location>
+ * @extends \Ibexa\Tests\Core\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapterTestCase<\Ibexa\Contracts\Core\Repository\Values\Content\Location>
  */
-final class LocationSearchAdapterTest extends AbstractSearchAdapterTest
+final class LocationSearchAdapterTest extends AbstractSearchAdapterTestCase
 {
     protected function createAdapterUnderTest(
         SearchService $searchService,

--- a/tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
+++ b/tests/lib/Repository/SiteAccessAware/AbstractServiceTestCase.php
@@ -20,7 +20,7 @@ use ReflectionMethod;
  * - Do nothing, pass-through call and optionally (default:true) return value
  * - lookup languages [IF not defined by callee] on one of the arguments given and pass it to next one.
  */
-abstract class AbstractServiceTest extends TestCase
+abstract class AbstractServiceTestCase extends TestCase
 {
     /**
      * Purely to attempt to make tests easier to read.

--- a/tests/lib/Repository/SiteAccessAware/ContentServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/ContentServiceTest.php
@@ -29,7 +29,7 @@ use Ibexa\Core\Repository\Values\User\User;
 /**
  * @property \Ibexa\Contracts\Core\Repository\ContentService $service
  */
-class ContentServiceTest extends AbstractServiceTest
+class ContentServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/ContentTypeServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/ContentTypeServiceTest.php
@@ -21,7 +21,7 @@ use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Repository\Values\User\User;
 
-class ContentTypeServiceTest extends AbstractServiceTest
+class ContentTypeServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/LanguageServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/LanguageServiceTest.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Language;
 use Ibexa\Contracts\Core\Repository\Values\Content\LanguageCreateStruct;
 use Ibexa\Core\Repository\SiteAccessAware\LanguageService;
 
-class LanguageServiceTest extends AbstractServiceTest
+class LanguageServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/LocationServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/LocationServiceTest.php
@@ -18,7 +18,7 @@ use Ibexa\Core\Repository\SiteAccessAware\LocationService;
 use Ibexa\Core\Repository\Values\Content\Location;
 use Ibexa\Core\Repository\Values\Content\VersionInfo;
 
-class LocationServiceTest extends AbstractServiceTest
+class LocationServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/ObjectStateServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/ObjectStateServiceTest.php
@@ -17,7 +17,7 @@ use Ibexa\Core\Repository\SiteAccessAware\ObjectStateService;
 use Ibexa\Core\Repository\Values\ObjectState\ObjectState;
 use Ibexa\Core\Repository\Values\ObjectState\ObjectStateGroup;
 
-class ObjectStateServiceTest extends AbstractServiceTest
+class ObjectStateServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/SearchServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/SearchServiceTest.php
@@ -14,7 +14,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchResult;
 use Ibexa\Core\Repository\SiteAccessAware\SearchService;
 use Ibexa\Core\Repository\Values\Content\Content;
 
-class SearchServiceTest extends AbstractServiceTest
+class SearchServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/TrashServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/TrashServiceTest.php
@@ -16,7 +16,7 @@ use Ibexa\Core\Repository\SiteAccessAware\TrashService;
 use Ibexa\Core\Repository\Values\Content\Location;
 use Ibexa\Core\Repository\Values\Content\TrashItem;
 
-class TrashServiceTest extends AbstractServiceTest
+class TrashServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/UrlAliasServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/UrlAliasServiceTest.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\URLAlias;
 use Ibexa\Core\Repository\SiteAccessAware\URLAliasService;
 use Ibexa\Core\Repository\Values\Content\Location;
 
-class UrlAliasServiceTest extends AbstractServiceTest
+class UrlAliasServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Repository/SiteAccessAware/UserServiceTest.php
+++ b/tests/lib/Repository/SiteAccessAware/UserServiceTest.php
@@ -22,7 +22,7 @@ use Ibexa\Core\Repository\Values\User\UserCreateStruct;
 use Ibexa\Core\Repository\Values\User\UserGroup;
 use Ibexa\Core\Repository\Values\User\UserGroupCreateStruct;
 
-class UserServiceTest extends AbstractServiceTest
+class UserServiceTest extends AbstractServiceTestCase
 {
     public function getAPIServiceClassName(): string
     {

--- a/tests/lib/Specification/AbstractSpecificationTest.php
+++ b/tests/lib/Specification/AbstractSpecificationTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Core\Specification;
 
-class AbstractSpecificationTest extends BaseSpecificationTest
+class AbstractSpecificationTest extends BaseSpecificationTestCase
 {
     public function testSpecification(): void
     {

--- a/tests/lib/Specification/AndSpecificationTest.php
+++ b/tests/lib/Specification/AndSpecificationTest.php
@@ -9,7 +9,7 @@ namespace Ibexa\Tests\Core\Specification;
 
 use Ibexa\Contracts\Core\Specification\AndSpecification;
 
-class AndSpecificationTest extends BaseSpecificationTest
+class AndSpecificationTest extends BaseSpecificationTestCase
 {
     public function testAndSpecification(): void
     {

--- a/tests/lib/Specification/BaseSpecificationTestCase.php
+++ b/tests/lib/Specification/BaseSpecificationTestCase.php
@@ -11,7 +11,7 @@ use Ibexa\Contracts\Core\Specification\AbstractSpecification;
 use Ibexa\Contracts\Core\Specification\SpecificationInterface;
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseSpecificationTest extends TestCase
+abstract class BaseSpecificationTestCase extends TestCase
 {
     protected function getIsStringSpecification(): SpecificationInterface
     {

--- a/tests/lib/Specification/NotSpecificationTest.php
+++ b/tests/lib/Specification/NotSpecificationTest.php
@@ -9,7 +9,7 @@ namespace Ibexa\Tests\Core\Specification;
 
 use Ibexa\Contracts\Core\Specification\NotSpecification;
 
-class NotSpecificationTest extends BaseSpecificationTest
+class NotSpecificationTest extends BaseSpecificationTestCase
 {
     public function testNotSpecification(): void
     {

--- a/tests/lib/Specification/OrSpecificationTest.php
+++ b/tests/lib/Specification/OrSpecificationTest.php
@@ -9,7 +9,7 @@ namespace Ibexa\Tests\Core\Specification;
 
 use Ibexa\Contracts\Core\Specification\OrSpecification;
 
-class OrSpecificationTest extends BaseSpecificationTest
+class OrSpecificationTest extends BaseSpecificationTestCase
 {
     public function testOrSpecification(): void
     {


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:

Since PHPUnit 9.6 having a `Test` suffix for abstract test case classes is deprecated (see the issue 
https://github.com/sebastianbergmann/phpunit/issues/5132).

Renamed unit test abstract test case classes suffixes to `TestCase`. I'll follow up with integration test cases.

To keep the diff simple, I've mostly limited the changes to the class rename, renaming also file path occurrences in the PHPStan baseline. Fixing issues from the baseline is out of scope in this context.


#### For QA:
No QA required.