### PR TITLE
IBX-10091 Preview Siteaccess: Show hidden locations

### DIFF
--- a/src/lib/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
+++ b/src/lib/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use Ibexa\Core\Persistence\Legacy\Content\Location\Mapper;
 
 /**
  * Visibility criterion handler.
@@ -36,29 +37,33 @@ class Visibility extends CriterionHandler
         array $languageSettings
     ) {
         $subSelect = $this->connection->createQueryBuilder();
-
-        if ($criterion->value[0] === Criterion\Visibility::VISIBLE) {
-            $expression = $queryBuilder->expr()->andX(
-                $queryBuilder->expr()->eq(
-                    'subquery_location.is_hidden',
-                    0
-                ),
-                $queryBuilder->expr()->eq(
-                    'subquery_location.is_invisible',
-                    0
-                )
-            );
+        if(!Mapper::isPreviewMode()) {
+            if ($criterion->value[0] === Criterion\Visibility::VISIBLE) {
+                $expression = $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq(
+                        'subquery_location.is_hidden',
+                        0
+                    ),
+                    $queryBuilder->expr()->eq(
+                        'subquery_location.is_invisible',
+                        0
+                    )
+                );
+            } else {
+                $expression = $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->eq(
+                        'subquery_location.is_hidden',
+                        1
+                    ),
+                    $queryBuilder->expr()->eq(
+                        'subquery_location.is_invisible',
+                        1
+                    )
+                );
+            }
         } else {
-            $expression = $queryBuilder->expr()->orX(
-                $queryBuilder->expr()->eq(
-                    'subquery_location.is_hidden',
-                    1
-                ),
-                $queryBuilder->expr()->eq(
-                    'subquery_location.is_invisible',
-                    1
-                )
-            );
+            // Dummy query to not break the WHERE statement
+            $expression = $queryBuilder->expr()->eq( '1', '1' );
         }
 
         $subSelect

--- a/src/lib/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
+++ b/src/lib/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
@@ -12,6 +12,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use RuntimeException;
+use Ibexa\Core\Persistence\Legacy\Content\Location\Mapper;
 
 /**
  * Location visibility criterion handler.
@@ -37,24 +38,28 @@ class Visibility extends CriterionHandler
         array $languageSettings
     ) {
         $column = 't.is_invisible';
+        if(!Mapper::isPreviewMode()) {
+            switch ($criterion->value[0]) {
+                case Criterion\Visibility::VISIBLE:
+                    return $queryBuilder->expr()->eq(
+                        $column,
+                        $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
+                    );
 
-        switch ($criterion->value[0]) {
-            case Criterion\Visibility::VISIBLE:
-                return $queryBuilder->expr()->eq(
-                    $column,
-                    $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
-                );
+                case Criterion\Visibility::HIDDEN:
+                    return $queryBuilder->expr()->eq(
+                        $column,
+                        $queryBuilder->createNamedParameter(1, ParameterType::INTEGER)
+                    );
 
-            case Criterion\Visibility::HIDDEN:
-                return $queryBuilder->expr()->eq(
-                    $column,
-                    $queryBuilder->createNamedParameter(1, ParameterType::INTEGER)
-                );
-
-            default:
-                throw new RuntimeException(
-                    "Unknown value '{$criterion->value[0]}' for Visibility Criterion handler."
-                );
+                default:
+                    throw new RuntimeException(
+                        "Unknown value '{$criterion->value[0]}' for Visibility Criterion handler."
+                    );
+            }
+        } else {
+            // Dummy query to not break the WHERE statement
+            return $queryBuilder->expr()->eq( '1', '1' );
         }
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-10091 |
|----------------|-----------|

We implemented some changes to the Ibexa 4.x kernel for a client to be able to configure a preview siteaccess where it is possible to browse hidden locations, this is achieved via a YML setting. This is working well for the client project.

We need that Ibexa adjust our solution and hopefully make it part of the kernel.

With this change it is possible to enable the preview mode for a certain siteaccess with this setting:


```
diff --git a/config/app/services.yaml b/config/app/services.yaml
index babb99f59e..59047f7764 100644
--- a/config/app/services.yaml
+++ b/config/app/services.yaml
@@ -4,8 +4,13 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+  #ibexa.$siteaccessName.show_hidden_locations: true
```

A possible improvement would be to move the Mapper::isPreviewMode to somewhere else ( see src/lib/Persistence/Legacy/Content/Location/Mapper.php ).

Note it is necessary to use a different redis cache namespace for the preview siteaccess, which is done when configuring the siteaccess like usual.

Here is a recommended redis config:

```
cache.preview:
    public: true
    class: Symfony\Component\Cache\Adapter\NullAdapter
    tags:
        - { name: cache.pool }
```

Then do this:

```
ibexa:
    system:
        preview_group:
            cache_service_name: 'cache.preview'
```