### PR TITLE
Corrected PHPDoc for removeFieldDefinition() param

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5245,12 +5245,6 @@ parameters:
 			path: src/contracts/Persistence/Content/Type/Handler.php
 
 		-
-			message: '#^PHPDoc tag @param for parameter \$contentTypeId with type mixed is not subtype of native type int\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: src/contracts/Persistence/Content/Type/Handler.php
-
-		-
 			message: '#^Property Ibexa\\Contracts\\Core\\Persistence\\Content\\UrlAlias\:\:\$pathData type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5251,12 +5251,6 @@ parameters:
 			path: src/contracts/Persistence/Content/Type/Handler.php
 
 		-
-			message: '#^PHPDoc tag @param references unknown parameter\: \$fieldDefinitionId$#'
-			identifier: parameter.notFound
-			count: 1
-			path: src/contracts/Persistence/Content/Type/Handler.php
-
-		-
 			message: '#^Property Ibexa\\Contracts\\Core\\Persistence\\Content\\UrlAlias\:\:\$pathData type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/contracts/Persistence/Content/Type/Handler.php
+++ b/src/contracts/Persistence/Content/Type/Handler.php
@@ -265,7 +265,7 @@ interface Handler
      *
      * @param mixed $contentTypeId
      * @param int $status One of Type::STATUS_DEFINED|Type::STATUS_DRAFT|Type::STATUS_MODIFIED
-     * @param mixed $fieldDefinitionId
+     * @param \Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException If field is not found
      */

--- a/src/contracts/Persistence/Content/Type/Handler.php
+++ b/src/contracts/Persistence/Content/Type/Handler.php
@@ -263,9 +263,7 @@ interface Handler
      * referred to by $fieldDefinitionId removed. It does not update existing
      * content objects depending on the field (default) values.
      *
-     * @param mixed $contentTypeId
      * @param int $status One of Type::STATUS_DEFINED|Type::STATUS_DRAFT|Type::STATUS_MODIFIED
-     * @param \Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException If field is not found
      */


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
This PR fixes a misleading PHPDoc in the removeFieldDefinition() method from the Handler interface.
The third parameter is currently a FieldDefinition object, not an ID, and the PHPDoc has been updated accordingly.
No logic changes were made.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
