### PR TITLE
IBX-6554: Added SafeContentController to handle secure content rendering with fallback support

### DIFF
--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -100,6 +100,18 @@ services:
         tags:
             - { name: controller.service_arguments }
 
+    Ibexa\Core\MVC\Symfony\Controller\Content\SafeContentController:
+        class: Ibexa\Core\MVC\Symfony\Controller\Content\SafeContentController
+        arguments:
+            $repository: '@Ibexa\Contracts\Core\Repository\Repository'
+            $logger: '@logger'
+        tags:
+            - { name: controller.service_arguments }
+
+    ibexa_safe_content:
+        public: true
+        alias: Ibexa\Core\MVC\Symfony\Controller\Content\SafeContentController
+
     Ibexa\Core\MVC\Symfony\Controller\Content\PreviewController:
         class: Ibexa\Core\MVC\Symfony\Controller\Content\PreviewController
         arguments:

--- a/src/bundle/Core/Resources/translations/messages.en.xlf
+++ b/src/bundle/Core/Resources/translations/messages.en.xlf
@@ -31,6 +31,11 @@
         <target>Username:</target>
         <note>key: Username:</note>
       </trans-unit>
+      <trans-unit id="901dd92dad081c7f72970b873a49663c5d94fa43" resname="asset.unavailable.message">
+        <source>Asset with ID %asset_id% is not available or has been removed.</source>
+        <target state="new">Asset with ID %asset_id% is not available or has been removed.</target>
+        <note>key: asset.unavailable.message</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Core/Resources/views/default/content/asset_unavailable.html.twig
+++ b/src/bundle/Core/Resources/views/default/content/asset_unavailable.html.twig
@@ -1,0 +1,5 @@
+<div>
+    {{ 'asset.unavailable.message'|trans({'%asset_id%': asset_id})|desc(
+        'Asset with ID %asset_id% is not available or has been removed.'
+    ) }}
+</div>

--- a/src/lib/MVC/Symfony/Controller/Content/SafeContentController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/SafeContentController.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Core\MVC\Symfony\Controller\Content;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
+use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
+use Ibexa\Contracts\Core\Repository\Repository;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+class SafeContentController extends AbstractController
+{
+    use LoggerAwareTrait;
+
+    protected Repository $repository;
+
+    public function __construct(
+        Repository $repository,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->repository = $repository;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function safeViewAction(
+        int $contentId,
+        string $viewType = 'embed',
+        bool $noLayout = true,
+        string $fallbackTemplate = '@IbexaCore/default/content/asset_unavailable.html.twig'
+    ): Response {
+        try {
+            $this->repository->getContentService()->loadContent($contentId);
+        } catch (NotFoundException|UnauthorizedException $e) {
+            $this->logger->warning(
+                sprintf('Failed to load content with ID: %d', $contentId),
+                ['exception' => $e]
+            );
+
+            return $this->render($fallbackTemplate, [
+                'asset_id' => $contentId,
+            ]);
+        }
+
+        return $this->forward('ibexa_content:viewAction', [
+            'contentId' => $contentId,
+            'viewType' => $viewType,
+            'no_layout' => $noLayout,
+        ]);
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-6554 |
|----------------|----------|

#### Description:
This PR introduces SafeContentController, which allows rendering embedded assets using a fallback template when the content is not available (NotFoundException) or access is denied (UnauthorizedException).
- Adds fallback template configuration
- Uses logger for warnings
- Keeps original controller delegation with forward()

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
