### PR TITLE
IBX-10116: Fixed `ibexa_render()` not using decorated fragment renders

### DIFF
--- a/src/contracts/MVC/Templating/BaseRenderStrategy.php
+++ b/src/contracts/MVC/Templating/BaseRenderStrategy.php
@@ -34,7 +34,9 @@ abstract class BaseRenderStrategy implements RenderStrategy
         RequestStack $requestStack
     ) {
         foreach ($fragmentRenderers as $fragmentRenderer) {
-            $this->fragmentRenderers[$fragmentRenderer->getName()] = $fragmentRenderer;
+            if (!isset($this->fragmentRenderers[$fragmentRenderer->getName()])) {
+                $this->fragmentRenderers[$fragmentRenderer->getName()] = $fragmentRenderer;
+            }
         }
 
         $this->defaultRenderer = $defaultRenderer;

--- a/tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
+++ b/tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
@@ -93,6 +93,27 @@ class RenderContentStrategyTest extends BaseRenderStrategyTest
         );
     }
 
+    public function testDuplicatedFragmentRenderers(): void
+    {
+        $renderContentStrategy = $this->createRenderStrategy(
+            RenderContentStrategy::class,
+            [
+                $this->createFragmentRenderer('method_a', 'decorator service used'),
+                $this->createFragmentRenderer('method_a', 'original service used'),
+            ],
+        );
+
+        $contentMock = $this->createMock(Content::class);
+        self::assertTrue($renderContentStrategy->supports($contentMock));
+
+        self::assertSame(
+            'decorator service used',
+            $renderContentStrategy->render($contentMock, new RenderOptions([
+                'method' => 'method_a',
+            ]))
+        );
+    }
+
     public function testExpectedMethodRenderArgumentsFormat(): void
     {
         $request = new Request();


### PR DESCRIPTION
| :ticket: Issue | IBX-10116 |
|----------------|-----------|


#### Description:
Decorations of the fragment renders are not available for the `ibexa_render()` [renderers (Ibexa\Core\MVC\Symfony\Templating\RenderLocationStrategy)](https://github.com/ibexa/core/blob/v4.6.20/src/bundle/Core/Resources/config/templating.yml#L196). This is because all renders are tagged `kernel.fragment_renderer`, both the original services, and the decorating ones! As the renders are stored in a hash array, the original services overwrites the decorating ones.

The result is that for instance the siteaccess is not serialized in esi calls when using `ibexa_render()` ( but it is if using `render_esi(Controller())`

This PR uses same approach as https://github.com/symfony/http-kernel/blob/v5.4.48/DependencyInjection/LazyLoadingFragmentHandler.php#L44-L47

#### For QA:
See ticket for How-to-reproduce instructions

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
