### PR TITLE
IBX-10129: Replaced ValueObject with `object` for PermissionResolver

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -42235,12 +42235,6 @@ parameters:
 			path: tests/integration/Core/Repository/Values/User/Limitation/LanguageLimitationTest.php
 
 		-
-			message: '#^Parameter \#4 \$targets of method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver\:\:canUser\(\) expects array\<Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject\>, array\<Ibexa\\Contracts\\Core\\Limitation\\Target\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/integration/Core/Repository/Values/User/Limitation/LanguageLimitationTest.php
-
-		-
 			message: '#^Cannot access property \$text on Ibexa\\Contracts\\Core\\FieldType\\Value\|null\.$#'
 			identifier: property.nonObject
 			count: 1

--- a/src/contracts/Limitation/TargetAwareType.php
+++ b/src/contracts/Limitation/TargetAwareType.php
@@ -38,7 +38,7 @@ interface TargetAwareType extends Type
     public function evaluate(
         APILimitationValue $value,
         APIUserReference $currentUser,
-        APIValueObject $object,
+        object $object,
         array $targets = null
     ): ?bool;
 }

--- a/src/contracts/Limitation/TargetAwareType.php
+++ b/src/contracts/Limitation/TargetAwareType.php
@@ -10,7 +10,6 @@ namespace Ibexa\Contracts\Core\Limitation;
 
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject as APIValueObject;
 
 /**
  * Represents Limitation type.

--- a/src/contracts/Limitation/Type.php
+++ b/src/contracts/Limitation/Type.php
@@ -11,7 +11,6 @@ namespace Ibexa\Contracts\Core\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject as APIValueObject;
 
 /**
  * This interface represent the Limitation Type.
@@ -108,15 +107,12 @@ interface Type
     /**
      * Evaluate ("Vote") against a main value object and targets for the context.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param array<int, \Ibexa\Contracts\Core\Repository\Values\ValueObject>|null $targets An array of location, parent or "assignment"
+     * @param array<int, object>|null $targets An array of location, parent or "assignment"
      *                                                                 objects, if null: none where provided by caller
      *
      * @return bool|null Returns one of ACCESS_* constants, {@see Type::ACCESS_GRANTED}, {@see Type::ACCESS_ABSTAIN}, or {@see Type::ACCESS_DENIED}.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, APIValueObject $object, array $targets = null): ?bool;
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool;
 
     /**
      * Returns Criterion for use in find() query.

--- a/src/contracts/Repository/PermissionResolver.php
+++ b/src/contracts/Repository/PermissionResolver.php
@@ -10,7 +10,6 @@ namespace Ibexa\Contracts\Core\Repository;
 
 use Ibexa\Contracts\Core\Repository\Values\User\LookupLimitationResult;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 /**
  * This service provides methods for resolving permissions.

--- a/src/contracts/Repository/PermissionResolver.php
+++ b/src/contracts/Repository/PermissionResolver.php
@@ -19,15 +19,11 @@ interface PermissionResolver
 {
     /**
      * Get current user reference.
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\User\UserReference
      */
     public function getCurrentUserReference(): UserReference;
 
     /**
      * Sets the current user to the given $user.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $userReference
      */
     public function setCurrentUserReference(UserReference $userReference): void;
 
@@ -74,18 +70,16 @@ interface PermissionResolver
      *
      * @param string $module The module, aka controller identifier to check permissions on
      * @param string $function The function, aka the controller action to check permissions on
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object The object to check if the user has access to
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[] $targets An array of location, parent or "assignment" value objects
-     *
-     * @return bool
+     * @param object $object The object to check if the user has access to
+     * @param object[] $targets An array of location, parent or "assignment" value objects
      */
-    public function canUser(string $module, string $function, ValueObject $object, array $targets = []): bool;
+    public function canUser(string $module, string $function, object $object, array $targets = []): bool;
 
     /**
      * @param string $module The module, aka controller identifier to check permissions on
      * @param string $function The function, aka the controller action to check permissions on
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object The object to check if the user has access to
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[] $targets An array of location, parent or "assignment" value objects
+     * @param object $object The object to check if the user has access to
+     * @param object[] $targets An array of location, parent or "assignment" value objects
      * @param string[] $limitationsIdentifiers An array of Limitations identifiers to filter from all which will pass
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\User\LookupLimitationResult
@@ -96,7 +90,7 @@ interface PermissionResolver
     public function lookupLimitations(
         string $module,
         string $function,
-        ValueObject $object,
+        object $object,
         array $targets = [],
         array $limitationsIdentifiers = []
     ): LookupLimitationResult;

--- a/src/lib/Limitation/BlockingLimitationType.php
+++ b/src/lib/Limitation/BlockingLimitationType.php
@@ -116,7 +116,7 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIBlockingLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: BlockingLimitation');

--- a/src/lib/Limitation/BlockingLimitationType.php
+++ b/src/lib/Limitation/BlockingLimitationType.php
@@ -105,8 +105,8 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/BlockingLimitationType.php
+++ b/src/lib/Limitation/BlockingLimitationType.php
@@ -14,7 +14,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\BlockingLimitation as APIBlockingLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/ChangeOwnerLimitationType.php
+++ b/src/lib/Limitation/ChangeOwnerLimitationType.php
@@ -71,7 +71,7 @@ final class ChangeOwnerLimitationType extends AbstractPersistenceLimitationType 
     public function evaluate(
         Limitation $value,
         APIUserReference $currentUser,
-        \object $object,
+        object $object,
         array $targets = null
     ): ?bool {
         if (!$object instanceof ContentCreateStruct) {

--- a/src/lib/Limitation/ChangeOwnerLimitationType.php
+++ b/src/lib/Limitation/ChangeOwnerLimitationType.php
@@ -17,7 +17,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ChangeOwnerLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject as APIValueObject;
 use Ibexa\Core\FieldType\ValidationError;
 
 final class ChangeOwnerLimitationType extends AbstractPersistenceLimitationType implements SPILimitationTypeInterface

--- a/src/lib/Limitation/ChangeOwnerLimitationType.php
+++ b/src/lib/Limitation/ChangeOwnerLimitationType.php
@@ -72,7 +72,7 @@ final class ChangeOwnerLimitationType extends AbstractPersistenceLimitationType 
     public function evaluate(
         Limitation $value,
         APIUserReference $currentUser,
-        APIValueObject $object,
+        \object $object,
         array $targets = null
     ): ?bool {
         if (!$object instanceof ContentCreateStruct) {

--- a/src/lib/Limitation/ContentTypeLimitationType.php
+++ b/src/lib/Limitation/ContentTypeLimitationType.php
@@ -101,8 +101,8 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/ContentTypeLimitationType.php
+++ b/src/lib/Limitation/ContentTypeLimitationType.php
@@ -21,7 +21,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ContentTypeLimitation as APIContentTypeLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/ContentTypeLimitationType.php
+++ b/src/lib/Limitation/ContentTypeLimitationType.php
@@ -112,7 +112,7 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         $targets = $targets ?? [];
         foreach ($targets as $target) {

--- a/src/lib/Limitation/LanguageLimitationType.php
+++ b/src/lib/Limitation/LanguageLimitationType.php
@@ -146,7 +146,7 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
     public function evaluate(
         APILimitationValue $value,
         APIUserReference $currentUser,
-        ValueObject $object,
+        object $object,
         array $targets = null
     ): ?bool {
         if (null === $targets) {

--- a/src/lib/Limitation/LocationLimitationType.php
+++ b/src/lib/Limitation/LocationLimitationType.php
@@ -22,7 +22,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\LocationLimitation as APILocationLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/LocationLimitationType.php
+++ b/src/lib/Limitation/LocationLimitationType.php
@@ -113,7 +113,7 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APILocationLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APILocationLimitation');

--- a/src/lib/Limitation/LocationLimitationType.php
+++ b/src/lib/Limitation/LocationLimitationType.php
@@ -102,8 +102,8 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/MemberOfLimitationType.php
+++ b/src/lib/Limitation/MemberOfLimitationType.php
@@ -89,7 +89,7 @@ final class MemberOfLimitationType extends AbstractPersistenceLimitationType imp
         return new MemberOfLimitation(['limitationValues' => $limitationValues]);
     }
 
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof MemberOfLimitation) {
             throw new InvalidArgumentException(

--- a/src/lib/Limitation/MemberOfLimitationType.php
+++ b/src/lib/Limitation/MemberOfLimitationType.php
@@ -19,7 +19,6 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 use Ibexa\Contracts\Core\Repository\Values\User\UserGroupRoleAssignment;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
 use Ibexa\Contracts\Core\Repository\Values\User\UserRoleAssignment;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/NewObjectStateLimitationType.php
+++ b/src/lib/Limitation/NewObjectStateLimitationType.php
@@ -21,7 +21,6 @@ use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectState;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\NewObjectStateLimitation as APINewObjectStateLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/NewObjectStateLimitationType.php
+++ b/src/lib/Limitation/NewObjectStateLimitationType.php
@@ -112,7 +112,7 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APINewObjectStateLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: NewObjectStateLimitation');

--- a/src/lib/Limitation/NewObjectStateLimitationType.php
+++ b/src/lib/Limitation/NewObjectStateLimitationType.php
@@ -101,8 +101,8 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/NewSectionLimitationType.php
+++ b/src/lib/Limitation/NewSectionLimitationType.php
@@ -22,7 +22,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\NewSectionLimitation as APINewSectionLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/NewSectionLimitationType.php
+++ b/src/lib/Limitation/NewSectionLimitationType.php
@@ -102,8 +102,8 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/NewSectionLimitationType.php
+++ b/src/lib/Limitation/NewSectionLimitationType.php
@@ -113,7 +113,7 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APINewSectionLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APINewSectionLimitation');

--- a/src/lib/Limitation/ObjectStateLimitationType.php
+++ b/src/lib/Limitation/ObjectStateLimitationType.php
@@ -119,7 +119,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
     public function evaluate(
         APILimitationValue $value,
         APIUserReference $currentUser,
-        ValueObject $object,
+        object $object,
         array $targets = null
     ): ?bool {
         if (!$value instanceof APIObjectStateLimitation) {

--- a/src/lib/Limitation/OwnerLimitationType.php
+++ b/src/lib/Limitation/OwnerLimitationType.php
@@ -113,7 +113,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow, or deprecate
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIOwnerLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIOwnerLimitation');

--- a/src/lib/Limitation/OwnerLimitationType.php
+++ b/src/lib/Limitation/OwnerLimitationType.php
@@ -18,7 +18,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\OwnerLimitation as APIOwnerLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\BadStateException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;

--- a/src/lib/Limitation/OwnerLimitationType.php
+++ b/src/lib/Limitation/OwnerLimitationType.php
@@ -100,8 +100,8 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/ParentContentTypeLimitationType.php
+++ b/src/lib/Limitation/ParentContentTypeLimitationType.php
@@ -113,7 +113,7 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentContentTypeLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentContentTypeLimitation');

--- a/src/lib/Limitation/ParentContentTypeLimitationType.php
+++ b/src/lib/Limitation/ParentContentTypeLimitationType.php
@@ -102,8 +102,8 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/ParentContentTypeLimitationType.php
+++ b/src/lib/Limitation/ParentContentTypeLimitationType.php
@@ -22,7 +22,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentContentTypeLimitation as APIParentContentTypeLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/ParentDepthLimitationType.php
+++ b/src/lib/Limitation/ParentDepthLimitationType.php
@@ -21,7 +21,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentDepthLimitation as APIParentDepthLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 

--- a/src/lib/Limitation/ParentDepthLimitationType.php
+++ b/src/lib/Limitation/ParentDepthLimitationType.php
@@ -89,8 +89,8 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/ParentDepthLimitationType.php
+++ b/src/lib/Limitation/ParentDepthLimitationType.php
@@ -100,7 +100,7 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentDepthLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentDepthLimitation');

--- a/src/lib/Limitation/ParentOwnerLimitationType.php
+++ b/src/lib/Limitation/ParentOwnerLimitationType.php
@@ -100,8 +100,8 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/ParentOwnerLimitationType.php
+++ b/src/lib/Limitation/ParentOwnerLimitationType.php
@@ -18,7 +18,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentOwnerLimitation as APIParentOwnerLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\BadStateException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;

--- a/src/lib/Limitation/ParentOwnerLimitationType.php
+++ b/src/lib/Limitation/ParentOwnerLimitationType.php
@@ -113,7 +113,7 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentOwnerLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentOwnerLimitation');

--- a/src/lib/Limitation/ParentUserGroupLimitationType.php
+++ b/src/lib/Limitation/ParentUserGroupLimitationType.php
@@ -103,8 +103,8 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *

--- a/src/lib/Limitation/ParentUserGroupLimitationType.php
+++ b/src/lib/Limitation/ParentUserGroupLimitationType.php
@@ -18,7 +18,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ParentUserGroupLimitation as APIParentUserGroupLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\BadStateException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;

--- a/src/lib/Limitation/ParentUserGroupLimitationType.php
+++ b/src/lib/Limitation/ParentUserGroupLimitationType.php
@@ -114,7 +114,7 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIParentUserGroupLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentUserGroupLimitation');

--- a/src/lib/Limitation/RoleLimitationType.php
+++ b/src/lib/Limitation/RoleLimitationType.php
@@ -85,7 +85,7 @@ final class RoleLimitationType extends AbstractPersistenceLimitationType impleme
         return new UserRoleLimitation(['limitationValues' => $limitationValues]);
     }
 
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof UserRoleLimitation) {
             throw new InvalidArgumentException(

--- a/src/lib/Limitation/RoleLimitationType.php
+++ b/src/lib/Limitation/RoleLimitationType.php
@@ -20,7 +20,6 @@ use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 use Ibexa\Contracts\Core\Repository\Values\User\UserGroupRoleAssignment;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
 use Ibexa\Contracts\Core\Repository\Values\User\UserRoleAssignment;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/SectionLimitationType.php
+++ b/src/lib/Limitation/SectionLimitationType.php
@@ -20,7 +20,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation as APISectionLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/SectionLimitationType.php
+++ b/src/lib/Limitation/SectionLimitationType.php
@@ -100,8 +100,8 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *
@@ -110,7 +110,7 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APISectionLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISectionLimitation');

--- a/src/lib/Limitation/SectionLimitationType.php
+++ b/src/lib/Limitation/SectionLimitationType.php
@@ -111,7 +111,7 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APISectionLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISectionLimitation');

--- a/src/lib/Limitation/SiteAccessLimitationType.php
+++ b/src/lib/Limitation/SiteAccessLimitationType.php
@@ -126,7 +126,7 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APISiteAccessLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISiteAccessLimitation');

--- a/src/lib/Limitation/SiteAccessLimitationType.php
+++ b/src/lib/Limitation/SiteAccessLimitationType.php
@@ -116,8 +116,8 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *
@@ -126,7 +126,7 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APISiteAccessLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISiteAccessLimitation');

--- a/src/lib/Limitation/StatusLimitationType.php
+++ b/src/lib/Limitation/StatusLimitationType.php
@@ -100,8 +100,8 @@ class StatusLimitationType implements SPILimitationTypeInterface
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *
@@ -110,7 +110,7 @@ class StatusLimitationType implements SPILimitationTypeInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIStatusLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIStatusLimitation');

--- a/src/lib/Limitation/StatusLimitationType.php
+++ b/src/lib/Limitation/StatusLimitationType.php
@@ -15,7 +15,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\StatusLimitation as APIStatusLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/StatusLimitationType.php
+++ b/src/lib/Limitation/StatusLimitationType.php
@@ -111,7 +111,7 @@ class StatusLimitationType implements SPILimitationTypeInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIStatusLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIStatusLimitation');

--- a/src/lib/Limitation/SubtreeLimitationType.php
+++ b/src/lib/Limitation/SubtreeLimitationType.php
@@ -119,8 +119,8 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *
@@ -129,7 +129,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         $targets = $targets ?? [];
 

--- a/src/lib/Limitation/SubtreeLimitationType.php
+++ b/src/lib/Limitation/SubtreeLimitationType.php
@@ -130,7 +130,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
     {
         $targets = $targets ?? [];
 

--- a/src/lib/Limitation/SubtreeLimitationType.php
+++ b/src/lib/Limitation/SubtreeLimitationType.php
@@ -22,7 +22,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation as APISubtreeLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\ValidationError;

--- a/src/lib/Limitation/UserGroupLimitationType.php
+++ b/src/lib/Limitation/UserGroupLimitationType.php
@@ -116,7 +116,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIUserGroupLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIUserGroupLimitation');

--- a/src/lib/Limitation/UserGroupLimitationType.php
+++ b/src/lib/Limitation/UserGroupLimitationType.php
@@ -105,8 +105,8 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $value
      * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUser
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     * @param object $object
+     * @param object[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool|null
      *
@@ -115,7 +115,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
      */
-    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, \object $object, array $targets = null): ?bool
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, object $object, array $targets = null): ?bool
     {
         if (!$value instanceof APIUserGroupLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIUserGroupLimitation');

--- a/src/lib/Limitation/UserGroupLimitationType.php
+++ b/src/lib/Limitation/UserGroupLimitationType.php
@@ -20,7 +20,6 @@ use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation as APILimitationValue;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\UserGroupLimitation as APIUserGroupLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Core\Base\Exceptions\BadStateException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;

--- a/src/lib/Repository/Permission/CachedPermissionService.php
+++ b/src/lib/Repository/Permission/CachedPermissionService.php
@@ -63,8 +63,8 @@ class CachedPermissionService implements PermissionService
     /**
      * CachedPermissionService constructor.
      *
-     * @param APIPermissionResolver $innerPermissionResolver
-     * @param APIPermissionCriterionResolver $permissionCriterionResolver
+     * @param \Ibexa\Contracts\Core\Repository\PermissionResolver $innerPermissionResolver
+     * @param \Ibexa\Contracts\Core\Repository\PermissionCriterionResolver $permissionCriterionResolver
      * @param int $cacheTTL By default set to 5 seconds, should be low to avoid to many permission exceptions on long running requests / processes (even if tolerant search service should handle that)
      */
     public function __construct(

--- a/src/lib/Repository/Permission/CachedPermissionService.php
+++ b/src/lib/Repository/Permission/CachedPermissionService.php
@@ -16,7 +16,6 @@ use Ibexa\Contracts\Core\Repository\Repository as RepositoryInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\CriterionInterface;
 use Ibexa\Contracts\Core\Repository\Values\User\LookupLimitationResult;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 /**
  * Cache implementation of PermissionResolver and PermissionCriterionResolver interface.
@@ -31,11 +30,9 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  */
 class CachedPermissionService implements PermissionService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
-    private $innerPermissionResolver;
+    private APIPermissionResolver $innerPermissionResolver;
 
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionCriterionResolver */
-    private $permissionCriterionResolver;
+    private APIPermissionCriterionResolver $permissionCriterionResolver;
 
     /** @var int */
     private $cacheTTL;
@@ -66,8 +63,8 @@ class CachedPermissionService implements PermissionService
     /**
      * CachedPermissionService constructor.
      *
-     * @param \Ibexa\Contracts\Core\Repository\PermissionResolver $innerPermissionResolver
-     * @param \Ibexa\Contracts\Core\Repository\PermissionCriterionResolver $permissionCriterionResolver
+     * @param APIPermissionResolver $innerPermissionResolver
+     * @param APIPermissionCriterionResolver $permissionCriterionResolver
      * @param int $cacheTTL By default set to 5 seconds, should be low to avoid to many permission exceptions on long running requests / processes (even if tolerant search service should handle that)
      */
     public function __construct(
@@ -96,7 +93,7 @@ class CachedPermissionService implements PermissionService
         return $this->innerPermissionResolver->hasAccess($module, $function, $userReference);
     }
 
-    public function canUser(string $module, string $function, ValueObject $object, array $targets = []): bool
+    public function canUser(string $module, string $function, object $object, array $targets = []): bool
     {
         return $this->innerPermissionResolver->canUser($module, $function, $object, $targets);
     }
@@ -107,11 +104,11 @@ class CachedPermissionService implements PermissionService
     public function lookupLimitations(
         string $module,
         string $function,
-        ValueObject $object,
+        object $object,
         array $targets = [],
-        array $limitations = []
+        array $limitationsIdentifiers = []
     ): LookupLimitationResult {
-        return $this->innerPermissionResolver->lookupLimitations($module, $function, $object, $targets, $limitations);
+        return $this->innerPermissionResolver->lookupLimitations($module, $function, $object, $targets, $limitationsIdentifiers);
     }
 
     public function getPermissionsCriterion(string $module = 'content', string $function = 'read', ?array $targets = null)

--- a/src/lib/Repository/Permission/PermissionResolver.php
+++ b/src/lib/Repository/Permission/PermissionResolver.php
@@ -330,12 +330,7 @@ class PermissionResolver implements PermissionResolverInterface
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitation
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUserReference
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param array|null $targets
-     *
-     * @return bool
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
@@ -343,7 +338,7 @@ class PermissionResolver implements PermissionResolverInterface
     private function isGrantedByLimitation(
         Limitation $limitation,
         APIUserReference $currentUserReference,
-        ValueObject $object,
+        object $object,
         ?array $targets
     ): bool {
         $type = $this->limitationService->getLimitationType($limitation->getIdentifier());

--- a/src/lib/Repository/Permission/PermissionResolver.php
+++ b/src/lib/Repository/Permission/PermissionResolver.php
@@ -19,7 +19,6 @@ use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\User\LookupLimitationResult;
 use Ibexa\Contracts\Core\Repository\Values\User\LookupPolicyLimitations;
 use Ibexa\Contracts\Core\Repository\Values\User\UserReference as APIUserReference;
-use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentValue;
 use Ibexa\Core\Repository\Mapper\RoleDomainMapper;

--- a/src/lib/Repository/Permission/PermissionResolver.php
+++ b/src/lib/Repository/Permission/PermissionResolver.php
@@ -167,7 +167,7 @@ class PermissionResolver implements PermissionResolverInterface
         return false; // No policies matching $module and $function, or they contained limitations
     }
 
-    public function canUser(string $module, string $function, ValueObject $object, array $targets = []): bool
+    public function canUser(string $module, string $function, object $object, array $targets = []): bool
     {
         $permissionSets = $this->hasAccess($module, $function);
         if ($permissionSets === false || $permissionSets === true) {
@@ -261,7 +261,7 @@ class PermissionResolver implements PermissionResolverInterface
     public function lookupLimitations(
         string $module,
         string $function,
-        ValueObject $object,
+        object $object,
         array $targets = [],
         array $limitationsIdentifiers = []
     ): LookupLimitationResult {
@@ -358,12 +358,7 @@ class PermissionResolver implements PermissionResolverInterface
     }
 
     /**
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation|null $limitation
-     * @param \Ibexa\Contracts\Core\Repository\Values\User\UserReference $currentUserReference
-     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject $object
      * @param array|null $targets
-     *
-     * @return bool
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
@@ -371,7 +366,7 @@ class PermissionResolver implements PermissionResolverInterface
     private function isDeniedByRoleLimitation(
         ?Limitation $limitation,
         APIUserReference $currentUserReference,
-        ValueObject $object,
+        object $object,
         ?array $targets
     ): bool {
         if (null === $limitation) {


### PR DESCRIPTION
| :ticket: Issue | [IBX-10129](https://issues.ibexa.co/browse/IBX-10129) |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/rector/pull/39

#### Description:
This will replace `ValueObject` with `object`, allowing more flexibility when using `PermissionResolver`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
