### PR TITLE
IBX-4143: [Contracts] Exposed `sudo` method on PermissionResolver

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19735,20 +19735,8 @@ parameters:
 			path: src/lib/Repository/ObjectStateService.php
 
 		-
-			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver\:\:sudo\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/lib/Repository/Permission/CachedPermissionService.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Repository\\Permission\\CachedPermissionService\:\:getPermissionsCriterion\(\) has parameter \$targets with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Repository/Permission/CachedPermissionService.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Repository\\Permission\\CachedPermissionService\:\:sudo\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/Repository/Permission/CachedPermissionService.php
 
@@ -19809,12 +19797,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Core\\Repository\\Permission\\PermissionResolver\:\:prepareTargetsForType\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Repository/Permission/PermissionResolver.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$callback contains unresolvable type\.$#'
-			identifier: parameter.unresolvableType
 			count: 1
 			path: src/lib/Repository/Permission/PermissionResolver.php
 
@@ -20051,12 +20033,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Repository/ProxyFactory/ProxyGeneratorInterface.php
-
-		-
-			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver\:\:sudo\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/lib/Repository/Repository.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Repository\\Repository\:\:__construct\(\) has parameter \$serviceSettings with no value type specified in iterable type array\.$#'
@@ -60861,13 +60837,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Persistence\\User\\Handler\:\:expects\(\)\.$#'
 			identifier: method.notFound
-			count: 11
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
-			message: '#^Call to an undefined method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver&PHPUnit\\Framework\\MockObject\\MockObject\:\:sudo\(\)\.$#'
-			identifier: method.notFound
-			count: 1
+			count: 10
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
 
 		-
@@ -61015,12 +60985,6 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Service\\Mock\\PermissionTest\:\:testHasAccessReturnsFalseButSudoSoTrue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Service/Mock/PermissionTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Service\\Mock\\PermissionTest\:\:testHasAccessReturnsInvalidArgumentValueException\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -61149,7 +61113,7 @@ parameters:
 		-
 			message: '#^PHPDoc tag @var has invalid value \(\$userHandlerMock \\PHPUnit\\Framework\\MockObject\\MockObject\)\: Unexpected token "\$userHandlerMock", expected type at offset 9 on line 1$#'
 			identifier: phpDoc.parseError
-			count: 6
+			count: 5
 			path: tests/lib/Repository/Service/Mock/PermissionTest.php
 
 		-

--- a/phpstan-baseline.sudo.neon
+++ b/phpstan-baseline.sudo.neon
@@ -1,0 +1,25 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver\:\:sudo\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/lib/Repository/Permission/CachedPermissionService.php
+
+		-
+			message: '#^Callable callable\(\)\: T invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/lib/Repository/Permission/PermissionResolver.php
+
+		-
+			message: '#^Method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver\:\:sudo\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/lib/Repository/Repository.php
+
+		-
+			message: '#^Parameter \#1 \$callback of method Ibexa\\Contracts\\Core\\Repository\\PermissionResolver\:\:sudo\(\) expects callable\(\)\: T, callable\(Ibexa\\Contracts\\Core\\Repository\\Repository\)\: T given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/lib/Repository/Repository.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,7 @@ includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
     - phpstan-baseline.neon
     - phpstan-baseline.pagerfanta.neon
+    - phpstan-baseline.sudo.neon
 
 parameters:
     level: 8

--- a/src/contracts/Repository/PermissionResolver.php
+++ b/src/contracts/Repository/PermissionResolver.php
@@ -93,4 +93,32 @@ interface PermissionResolver
         array $targets = [],
         array $limitationsIdentifiers = []
     ): LookupLimitationResult;
+
+    /**
+     * Executes the given callback with elevated permissions, bypassing the current user's limitations.
+     *
+     * Example usage:
+     * ```
+     * $content = $permissionResolver->sudo(
+     *      function () use ($contentId): Content {
+     *          return $this->contentService->loadContent($contentId);
+     *      }
+     * );
+     * ```
+     * or:
+     * ```
+     *  $content = $permissionResolver->sudo(
+     *       static fn (): Content => $contentService->loadContent($contentId);
+     *  );
+     * ```
+     *
+     * @phpstan-template T
+     *
+     * @phpstan-param callable(): T $callback
+     *
+     * @phpstan-return T
+     *
+     * @throws \Throwable
+     */
+    public function sudo(callable $callback): mixed;
 }

--- a/src/lib/Repository/Permission/CachedPermissionService.php
+++ b/src/lib/Repository/Permission/CachedPermissionService.php
@@ -135,7 +135,7 @@ class CachedPermissionService implements PermissionService
     /**
      * @internal For internal use only, do not depend on this method.
      */
-    public function sudo(callable $callback, RepositoryInterface $outerRepository)
+    public function sudo(callable $callback, ?RepositoryInterface $outerRepository = null): mixed
     {
         ++$this->sudoNestingLevel;
         try {

--- a/src/lib/Repository/Permission/PermissionResolver.php
+++ b/src/lib/Repository/Permission/PermissionResolver.php
@@ -380,30 +380,21 @@ class PermissionResolver implements PermissionResolverInterface
 
     /**
      * @internal For internal use only, do not depend on this method.
-     *
-     * Allows API execution to be performed with full access sand-boxed.
-     *
-     * The closure sandbox will do a catch all on exceptions and rethrow after
-     * re-setting the sudo flag.
-     *
-     * Example use:
-     *     $location = $repository->sudo(
-     *         function ( Repository $repo ) use ( $locationId )
-     *         {
-     *             return $repo->getLocationService()->loadLocation( $locationId )
-     *         }
-     *     );
-     *
-     * @param \callable(\Ibexa\Contracts\Core\Repository\Repository): mixed $callback
-     * @param \Ibexa\Contracts\Core\Repository\Repository $outerRepository
-     *
-     * @throws \RuntimeException Thrown on recursive sudo() use.
-     * @throws \Exception Re throws exceptions thrown inside $callback
-     *
-     * @return mixed
      */
-    public function sudo(callable $callback, RepositoryInterface $outerRepository)
+    public function sudo(callable $callback, ?RepositoryInterface $outerRepository = null): mixed
     {
+        if (null !== $outerRepository) {
+            trigger_deprecation(
+                'ibexa/core',
+                '5.0',
+                sprintf(
+                    'Calling either Repository::sudo or %s() method with outer repository as the 2nd argument is deprecated, will be removed in 6.0. ' .
+                    'Use `PermissionResolver::sudo()` method and inject required Repository services through DI container instead',
+                    __METHOD__
+                )
+            );
+        }
+
         ++$this->sudoNestingLevel;
         try {
             $returnValue = $callback($outerRepository);

--- a/tests/lib/Repository/Service/Mock/PermissionTest.php
+++ b/tests/lib/Repository/Service/Mock/PermissionTest.php
@@ -201,27 +201,21 @@ class PermissionTest extends BaseServiceMockTest
 
     /**
      * Test for the sudo() & hasAccess() method.
+     *
+     * @throws \Throwable
      */
-    public function testHasAccessReturnsFalseButSudoSoTrue()
+    public function testHasAccessReturnsFalseButSudoSoTrue(): void
     {
-        /** @var $userHandlerMock \PHPUnit\Framework\MockObject\MockObject */
+        /** @var \Ibexa\Contracts\Core\Persistence\User\Handler&\PHPUnit\Framework\MockObject\MockObject $userHandlerMock */
         $userHandlerMock = $this->getPersistenceMock()->userHandler();
-        $service = $this->getPermissionResolverMock(null);
-        $repositoryMock = $this->getRepositoryMock();
-        $repositoryMock
-            ->expects(self::any())
-            ->method('getPermissionResolver')
-            ->will(self::returnValue($service));
+        $permissionResolverMock = $this->getPermissionResolverMock(null);
 
         $userHandlerMock
             ->expects(self::never())
             ->method(self::anything());
 
-        $result = $service->sudo(
-            static function (Repository $repo) {
-                return $repo->getPermissionResolver()->hasAccess('dummy-module', 'dummy-function');
-            },
-            $repositoryMock
+        $result = $permissionResolverMock->sudo(
+            static fn (): bool|array => $permissionResolverMock->hasAccess('dummy-module', 'dummy-function')
         );
 
         self::assertTrue($result);


### PR DESCRIPTION
| :ticket: Issue | IBX-4143 |
|----------------|-----------|


#### Related PRs: 
 - TBD

#### Description:

Let's see first in which direction it's gonna explode.

Affected 1st party packages:
- admin-ui
- fieldtype-address
- scheduler
- workflow

#### For QA:

Regressions and maybe some manual testing related to features relying on sudo (TBD)

#### Documentation:

Updates to https://doc.ibexa.co/en/latest/api/php_api/php_api/#using-sudo if the changes get accepted.

