### PR TITLE
Use Doctrine\DBAL\Connection instead of Doctrine\DBAL\Driver\Connection in NormalizeImagesPathsCommand

### DIFF
--- a/src/bundle/Core/Command/NormalizeImagesPathsCommand.php
+++ b/src/bundle/Core/Command/NormalizeImagesPathsCommand.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\Command;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Ibexa\Core\FieldType\Image\ImageStorage\Gateway as ImageStorageGateway;
 use Ibexa\Core\IO\Exception\BinaryFileNotFoundException;
 use Ibexa\Core\IO\FilePathNormalizerInterface;

--- a/src/bundle/Core/Command/NormalizeImagesPathsCommand.php
+++ b/src/bundle/Core/Command/NormalizeImagesPathsCommand.php
@@ -48,8 +48,7 @@ EOT;
     /** @var \Ibexa\Core\IO\FilePathNormalizerInterface */
     private $filePathNormalizer;
 
-    /** @var \Doctrine\DBAL\Driver\Connection */
-    private $connection;
+    private Connection $connection;
 
     /** @var \Ibexa\Core\IO\IOServiceInterface */
     private $ioService;


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Fixed the following error during from application logs:

```
[Application] Jun 10 19:05:31 |CRITICA| CONSOL Error thrown while running command "list --format=xml". Message: "Ibexa\Bundle\Core\Command\NormalizeImagesPathsCommand::__construct(): Argument #3 ($connection) must be of type Doctrine\DBAL\Driver\Connection, ContainerR7KxgMw\ConnectionProxy894022f given, called in /home/awojs/ibexa/v5-test/5.0-commerce-beta1/var/cache/dev/ContainerR7KxgMw/getNormalizeImagesPathsCommandService.php on line 24" command="list --format=xml" message="Ibexa\\Bundle\\Core\\Command\\NormalizeImagesPathsCommand::__construct(): Argument #3 ($connection) must be of type Doctrine\\DBAL\\Driver\\Connection, ContainerR7KxgMw\\ConnectionProxy894022f given, called in /home/awojs/ibexa/v5-test/5.0-commerce-beta1/var/cache/dev/ContainerR7KxgMw/getNormalizeImagesPathsCommandService.php on line 24"

```
#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
