### PR TITLE
IBX-8697: Added validation for Keyword field type values in content and tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -53443,18 +53443,6 @@ parameters:
 			path: tests/lib/FieldType/KeywordTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\KeywordTest\:\:provideValidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/FieldType/KeywordTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\KeywordTest\:\:provideInvalidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/FieldType/KeywordTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\MapLocationTest\:\:getSettingsSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -53443,6 +53443,18 @@ parameters:
 			path: tests/lib/FieldType/KeywordTest.php
 
 		-
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\KeywordTest\:\:provideValidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/lib/FieldType/KeywordTest.php
+
+		-
+			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\KeywordTest\:\:provideInvalidDataForValidate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/lib/FieldType/KeywordTest.php
+
+		-
 			message: '#^Method Ibexa\\Tests\\Core\\FieldType\\MapLocationTest\:\:getSettingsSchemaExpectation\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/lib/FieldType/Keyword/Type.php
+++ b/src/lib/FieldType/Keyword/Type.php
@@ -119,7 +119,7 @@ class Type extends FieldType implements TranslationContainerInterface
                 );
             } elseif (mb_strlen($keyword) > self::MAX_KEYWORD_LENGTH) {
                 $validationErrors[] = new ValidationError(
-                    'Each keyword must be at most ' . self::MAX_KEYWORD_LENGTH . ' characters long.',
+                    'Keyword value must be less than or equal to ' . self::MAX_KEYWORD_LENGTH . ' characters.',
                     null,
                     [],
                     'values'

--- a/src/lib/FieldType/Keyword/Type.php
+++ b/src/lib/FieldType/Keyword/Type.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\FieldType;
+use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
@@ -22,6 +23,8 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
  */
 class Type extends FieldType implements TranslationContainerInterface
 {
+    public const MAX_KEYWORD_LENGTH = 255;
+
     /**
      * Returns the field type identifier for this field type.
      *
@@ -87,6 +90,44 @@ class Type extends FieldType implements TranslationContainerInterface
                 $value->values
             );
         }
+
+        foreach ($value->values as $keyword) {
+            if (!is_string($keyword) || mb_strlen($keyword) > self::MAX_KEYWORD_LENGTH) {
+                throw new InvalidArgumentType(
+                    '$value->values[]',
+                    'string up to ' . self::MAX_KEYWORD_LENGTH . ' characters',
+                    $keyword
+                );
+            }
+        }
+    }
+
+    /**
+     * @param \Ibexa\Core\FieldType\Keyword\Value $fieldValue
+     */
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue): array
+    {
+        $validationErrors = [];
+
+        foreach ($fieldValue->values as $keyword) {
+            if (!is_string($keyword)) {
+                $validationErrors[] = new ValidationError(
+                    'Each keyword must be a string.',
+                    null,
+                    [],
+                    'values'
+                );
+            } elseif (mb_strlen($keyword) > self::MAX_KEYWORD_LENGTH) {
+                $validationErrors[] = new ValidationError(
+                    'Each keyword must be at most ' . self::MAX_KEYWORD_LENGTH . ' characters long.',
+                    null,
+                    [],
+                    'values'
+                );
+            }
+        }
+
+        return $validationErrors;
     }
 
     /**

--- a/tests/lib/FieldType/KeywordTest.php
+++ b/tests/lib/FieldType/KeywordTest.php
@@ -9,6 +9,7 @@ namespace Ibexa\Tests\Core\FieldType;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\FieldType\Keyword\Type as KeywordType;
 use Ibexa\Core\FieldType\Keyword\Value as KeywordValue;
+use Ibexa\Core\FieldType\ValidationError;
 
 /**
  * @group fieldType
@@ -236,6 +237,76 @@ class KeywordTest extends FieldTypeTest
         return [
             [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
             [new KeywordValue(['foo', 'bar']), 'foo, bar', [], 'en_GB'],
+        ];
+    }
+
+    /**
+     * @return iterable<array{array, \Ibexa\Core\FieldType\Keyword\Value}>
+     */
+    public function provideValidDataForValidate(): iterable
+    {
+        yield 'multiple keywords' => [
+            [],
+            new KeywordValue(['foo', 'bar']),
+        ];
+
+        yield 'empty string keyword' => [
+            [],
+            new KeywordValue(['']),
+        ];
+
+        yield 'empty keyword list' => [
+            [],
+            new KeywordValue([]),
+        ];
+    }
+
+    /**
+     * @return iterable<array{0: array, 1: \Ibexa\Core\FieldType\Keyword\Value, 2: array<\Ibexa\Contracts\Core\FieldType\ValidationError>}>
+     */
+    public function provideInvalidDataForValidate(): iterable
+    {
+        $maxLen = KeywordType::MAX_KEYWORD_LENGTH;
+
+        yield 'non-string keyword (int)' => [
+            [],
+            // @phpstan-ignore-next-line
+            new KeywordValue(['valid', 123]),
+            [
+                new ValidationError(
+                    'Each keyword must be a string.',
+                    null,
+                    [],
+                    'values'
+                ),
+            ],
+        ];
+
+        yield 'non-string keyword (null)' => [
+            [],
+            // @phpstan-ignore-next-line
+            new KeywordValue(['valid', null]),
+            [
+                new ValidationError(
+                    'Each keyword must be a string.',
+                    null,
+                    [],
+                    'values'
+                ),
+            ],
+        ];
+
+        yield 'too long keyword' => [
+            [],
+            new KeywordValue(['valid', str_repeat('a', $maxLen + 1)]),
+            [
+                new ValidationError(
+                    'Each keyword must be at most ' . $maxLen . ' characters long.',
+                    null,
+                    [],
+                    'values'
+                ),
+            ],
         ];
     }
 }

--- a/tests/lib/FieldType/KeywordTest.php
+++ b/tests/lib/FieldType/KeywordTest.php
@@ -241,7 +241,7 @@ class KeywordTest extends FieldTypeTest
     }
 
     /**
-     * @return iterable<array{array, \Ibexa\Core\FieldType\Keyword\Value}>
+     * @return iterable<string, array{0: array<string, mixed>, 1: \Ibexa\Core\FieldType\Keyword\Value}>
      */
     public function provideValidDataForValidate(): iterable
     {
@@ -262,7 +262,11 @@ class KeywordTest extends FieldTypeTest
     }
 
     /**
-     * @return iterable<array{0: array, 1: \Ibexa\Core\FieldType\Keyword\Value, 2: array<\Ibexa\Contracts\Core\FieldType\ValidationError>}>
+     * @return iterable<string, array{
+     *     0: array<string, mixed>,
+     *     1: \Ibexa\Core\FieldType\Keyword\Value,
+     *     2: array<\Ibexa\Contracts\Core\FieldType\ValidationError>
+     * }>
      */
     public function provideInvalidDataForValidate(): iterable
     {

--- a/tests/lib/FieldType/KeywordTest.php
+++ b/tests/lib/FieldType/KeywordTest.php
@@ -305,7 +305,7 @@ class KeywordTest extends FieldTypeTest
             new KeywordValue(['valid', str_repeat('a', $maxLen + 1)]),
             [
                 new ValidationError(
-                    'Each keyword must be at most ' . $maxLen . ' characters long.',
+                    'Keyword value must be less than or equal to ' . $maxLen . ' characters.',
                     null,
                     [],
                     'values'


### PR DESCRIPTION
| :ticket: Issue | IBX-8697 |
|----------------|----------|


#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/1610

#### Description:
This PR introduces validation rules for the Keyword field type values to ensure data integrity within content entries. Specifically:
- Validates that each keyword is a string.
- Enforces maximum length constraints on keywords.
- Adds comprehensive unit tests covering valid and invalid cases for KeywordValue.
- Improves error reporting by returning clear ValidationError instances on validation failure.



<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
