### PR TITLE
IBX-9845: Added test skipping for Solr doesn't support shard URL

### DIFF
--- a/tests/integration/Core/Repository/SearchServiceTranslationLanguageFallbackTest.php
+++ b/tests/integration/Core/Repository/SearchServiceTranslationLanguageFallbackTest.php
@@ -1523,11 +1523,11 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                                 ],
                                 [
                                     self::SETUP_DEDICATED => [
-                                        'searchHitIndex' => 2,
+                                        'searchHitIndex' => 1,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SHARED => [
-                                        'searchHitIndex' => 2,
+                                        'searchHitIndex' => 1,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SINGLE => [
@@ -1551,11 +1551,11 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                                 ],
                                 [
                                     self::SETUP_DEDICATED => [
-                                        'searchHitIndex' => 1,
+                                        'searchHitIndex' => 2,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SHARED => [
-                                        'searchHitIndex' => 1,
+                                        'searchHitIndex' => 2,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SINGLE => [
@@ -1591,8 +1591,8 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                                 ],
                                 [
                                     self::SETUP_DEDICATED => [
-                                        'searchHitIndex' => 2,
-                                        'preparedDataTestIndex' => 2,
+                                        'searchHitIndex' => 0,
+                                        'preparedDataTestIndex' => 1,
                                     ],
                                     self::SETUP_SHARED => [
                                         'searchHitIndex' => 0,
@@ -1619,11 +1619,11 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                                 ],
                                 [
                                     self::SETUP_DEDICATED => [
-                                        'searchHitIndex' => 2,
+                                        'searchHitIndex' => 1,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SHARED => [
-                                        'searchHitIndex' => 2,
+                                        'searchHitIndex' => 1,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SINGLE => [
@@ -1647,11 +1647,11 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                                 ],
                                 [
                                     self::SETUP_DEDICATED => [
-                                        'searchHitIndex' => 1,
+                                        'searchHitIndex' => 2,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SHARED => [
-                                        'searchHitIndex' => 1,
+                                        'searchHitIndex' => 2,
                                         'preparedDataTestIndex' => 2,
                                     ],
                                     self::SETUP_SINGLE => [


### PR DESCRIPTION
| :ticket: Issue | IBX-9845 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/solr/pull/95

#### Description:
This PR updates the SearchServiceTranslationLanguageFallbackTest integration test to address a breaking change introduced in [Solr 9.3.0](https://solr.apache.org/docs/9_3_0/changes/Changes.html#v9.3.0.other_changes) ([SOLR-9378](https://issues.apache.org/jira/browse/SOLR-9378)), where the shard.url parameter is no longer sent in shard requests.

In Solr 9.3.0+, it is no longer possible to check the shard name via the response, as the shard.url is not available ("not a shard request" is returned). The assertIndexName() test assertion now only runs for Solr versions before 9.3.0. For Solr 9.3.0 and above, the assertion is skipped to avoid false negatives.

##### Impact of the new search_field sort clause:
Previously, test expectations around which search hit appeared at which index were based on results ordered solely by a single sort field. That ordering meant, for example, content A always showed at position 3 under a shared setup. Content should also be ordered by a secondary field, specifically "search_field". That's why searchHitIndex needs to be adjusted.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
