### PR TITLE
IBX-10159: Corrected generate dfs_database_url parameter for Ibexa Cloud

### DIFF
--- a/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
+++ b/src/bundle/Core/DependencyInjection/IbexaCoreExtension.php
@@ -861,12 +861,12 @@ class IbexaCoreExtension extends Extension implements PrependExtensionInterface
                     $container->setParameter(
                         'dfs_database_url',
                         sprintf(
-                            '%s://%s:%s:%d@%s/%s',
+                            '%s://%s:%s@%s:%d/%s',
                             $endpoint['scheme'],
                             $endpoint['username'],
                             $endpoint['password'],
-                            $endpoint['port'],
                             $endpoint['host'],
+                            $endpoint['port'],
                             $endpoint['path']
                         )
                     );

--- a/tests/bundle/Core/DependencyInjection/IbexaCoreExtensionTest.php
+++ b/tests/bundle/Core/DependencyInjection/IbexaCoreExtensionTest.php
@@ -911,6 +911,51 @@ class IbexaCoreExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
+     * @throws \JsonException
+     */
+    public function testConfigurePlatformShDFS(): void
+    {
+        $dsn = 'mysql://dfs:dfs@localhost:3306/dfs';
+        $parts = parse_url($dsn);
+
+        $relationship = [
+            'dfs_database' => [
+                [
+                    'host' => $parts['host'],
+                    'scheme' => $parts['scheme'],
+                    'username' => $parts['user'],
+                    'password' => $parts['pass'],
+                    'port' => $parts['port'],
+                    'path' => ltrim($parts['path'], '/'),
+                    'query' => [
+                        'is_master' => true,
+                    ],
+                ],
+            ],
+        ];
+
+        $_SERVER['PLATFORM_RELATIONSHIPS'] = base64_encode(json_encode($relationship, JSON_THROW_ON_ERROR));
+        $_SERVER['PLATFORMSH_DFS_NFS_PATH'] = '/';
+        $_SERVER['PLATFORM_ROUTES'] = base64_encode(json_encode([], JSON_THROW_ON_ERROR));
+        $_SERVER['PLATFORM_PROJECT_ENTROPY'] = '';
+
+        $this->container->setParameter('database_charset', 'utf8mb4');
+        $this->container->setParameter('database_collation', 'utf8mb4_general_ci');
+        $this->container->setParameter('kernel.project_dir', __DIR__ . '/../Resources');
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('dfs_database_url');
+        self::assertEquals($dsn, $this->container->getParameter('dfs_database_url'));
+
+        unset(
+            $_SERVER['PLATFORM_RELATIONSHIPS'],
+            $_SERVER['PLATFORMSH_DFS_NFS_PATH'],
+            $_SERVER['PLATFORM_ROUTES'],
+            $_SERVER['PLATFORM_PROJECT_ENTROPY']
+        );
+    }
+
+    /**
      * Prepare Core Container for compilation by mocking required parameters and compile it.
      */
     private function compileCoreContainer(): void

--- a/tests/bundle/Core/Resources/config/packages/dfs/dfs.yaml
+++ b/tests/bundle/Core/Resources/config/packages/dfs/dfs.yaml
@@ -1,0 +1,1 @@
+# dummy file for \Ibexa\Tests\Bundle\Core\DependencyInjection\IbexaCoreExtensionTest::testConfigurePlatformShDFS


### PR DESCRIPTION
| :ticket: Issue | IBX-10159 |
|----------------|-----------|

#### Description:
Improved building of the dfs_database_url parameter. Previously it generated `schema://user:password:port@host`, now it generates `schema://user:password@host:port`


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
