### PR TITLE
IBX-9727: Fixed strict types of `MultiLanguageName` contracts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20821,12 +20821,6 @@ parameters:
 			path: src/lib/Repository/Values/ContentType/ContentType.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Repository\\Values\\ContentType\\ContentType\:\:getName\(\) should return string\|null but returns string\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Repository/Values/ContentType/ContentType.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Repository\\Values\\ContentType\\ContentTypeDraft\:\:getProperties\(\) has parameter \$dynamicProperties with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -20846,12 +20840,6 @@ parameters:
 
 		-
 			message: '#^Method Ibexa\\Core\\Repository\\Values\\ContentType\\ContentTypeGroup\:\:getDescription\(\) should return string\|null but returns string\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Repository/Values/ContentType/ContentTypeGroup.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Repository\\Values\\ContentType\\ContentTypeGroup\:\:getName\(\) should return string\|null but returns string\|false\.$#'
 			identifier: return.type
 			count: 1
 			path: src/lib/Repository/Values/ContentType/ContentTypeGroup.php
@@ -20877,12 +20865,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Core\\Repository\\Values\\ContentType\\FieldDefinition\:\:getFieldSettings\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/Repository/Values/ContentType/FieldDefinition.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Repository\\Values\\ContentType\\FieldDefinition\:\:getName\(\) should return string\|null but returns string\|false\.$#'
-			identifier: return.type
 			count: 1
 			path: src/lib/Repository/Values/ContentType/FieldDefinition.php
 
@@ -20965,19 +20947,7 @@ parameters:
 			path: src/lib/Repository/Values/ObjectState/ObjectState.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Repository\\Values\\ObjectState\\ObjectState\:\:getName\(\) should return string\|null but returns string\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Repository/Values/ObjectState/ObjectState.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Repository\\Values\\ObjectState\\ObjectStateGroup\:\:getDescription\(\) should return string\|null but returns string\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Repository/Values/ObjectState/ObjectStateGroup.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Repository\\Values\\ObjectState\\ObjectStateGroup\:\:getName\(\) should return string\|null but returns string\|false\.$#'
 			identifier: return.type
 			count: 1
 			path: src/lib/Repository/Values/ObjectState/ObjectStateGroup.php

--- a/src/contracts/Repository/Values/MultiLanguageName.php
+++ b/src/contracts/Repository/Values/MultiLanguageName.php
@@ -13,22 +13,20 @@ namespace Ibexa\Contracts\Core\Repository\Values;
  * Provides a uniform way for API consuming logic to generate translated names / labels
  * for API objects.
  * Language logic is meant to also be used for description, fields, ... lookup as well.
- *
- * @todo Move to API, Repository is not a SPI concept.
  */
 interface MultiLanguageName
 {
     /**
-     * Return the human readable name in all provided languages.
+     * Return the human-readable name in all provided languages.
      *
      * The structure of the return value is:
-     * <code>
-     * array( 'eng' => '<name_eng>', 'de' => '<name_de>' );
-     * </code>
+     * ```
+     * ['eng' => '<name_eng>', 'de' => '<name_de>']
+     * ```
      *
      * @return string[]
      */
-    public function getNames();
+    public function getNames(): array;
 
     /**
      * Return the name of the domain object in a given language.
@@ -40,10 +38,8 @@ interface MultiLanguageName
      *      2. Main language if object is $alwaysAvailable
      *      3. Fallback to return in initial (version objects) or main language
      *
-     * @param string|null $languageCode
-     *
      * @return string|null The name for a given language, or null if $languageCode is not set
      *         or does not exist.
      */
-    public function getName($languageCode = null);
+    public function getName(?string $languageCode = null): ?string;
 }

--- a/src/lib/Repository/Values/Content/VersionInfo.php
+++ b/src/lib/Repository/Values/Content/VersionInfo.php
@@ -93,7 +93,7 @@ class VersionInfo extends APIVersionInfo
     /**
      * {@inheritdoc}
      */
-    public function getNames()
+    public function getNames(): array
     {
         return $this->names;
     }
@@ -101,7 +101,7 @@ class VersionInfo extends APIVersionInfo
     /**
      * {@inheritdoc}
      */
-    public function getName($languageCode = null)
+    public function getName(?string $languageCode = null): ?string
     {
         if ($languageCode) {
             return isset($this->names[$languageCode]) ? $this->names[$languageCode] : null;

--- a/src/lib/Repository/Values/ContentType/ContentTypeDraft.php
+++ b/src/lib/Repository/Values/ContentType/ContentTypeDraft.php
@@ -84,7 +84,7 @@ class ContentTypeDraft extends APIContentTypeDraft
     /**
      * {@inheritdoc}
      */
-    public function getNames()
+    public function getNames(): array
     {
         return $this->innerContentType->getNames();
     }
@@ -92,7 +92,7 @@ class ContentTypeDraft extends APIContentTypeDraft
     /**
      * {@inheritdoc}
      */
-    public function getName($languageCode = null)
+    public function getName(?string $languageCode = null): ?string
     {
         return $this->innerContentType->getName($languageCode);
     }

--- a/src/lib/Repository/Values/MultiLanguageNameTrait.php
+++ b/src/lib/Repository/Values/MultiLanguageNameTrait.php
@@ -40,8 +40,7 @@ trait MultiLanguageNameTrait
         if (isset($this->mainLanguageCode, $this->names[$this->mainLanguageCode])) {
               return $this->names[$this->mainLanguageCode];
         }
-        $defaultName = reset($this->names);
 
-        return $defaultName !== false ? $defaultName : null;
+        return $this->names[array_key_first($this->names)] ?? null;
     }
 }

--- a/src/lib/Repository/Values/MultiLanguageNameTrait.php
+++ b/src/lib/Repository/Values/MultiLanguageNameTrait.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\Repository\Values;
 
@@ -17,23 +18,17 @@ trait MultiLanguageNameTrait
      *
      * @var string[]
      */
-    protected $names = [];
+    protected array $names = [];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNames()
+    public function getNames(): array
     {
         return $this->names;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName($languageCode = null)
+    public function getName(?string $languageCode = null): ?string
     {
         if (!empty($languageCode)) {
-            return isset($this->names[$languageCode]) ? $this->names[$languageCode] : null;
+            return $this->names[$languageCode] ?? null;
         }
 
         foreach ($this->prioritizedLanguages as $prioritizedLanguageCode) {
@@ -42,8 +37,11 @@ trait MultiLanguageNameTrait
             }
         }
 
-        return isset($this->names[$this->mainLanguageCode])
-            ? $this->names[$this->mainLanguageCode]
-            : reset($this->names);
+        if (isset($this->mainLanguageCode, $this->names[$this->mainLanguageCode])) {
+              return $this->names[$this->mainLanguageCode];
+        }
+        $defaultName = reset($this->names);
+
+        return $defaultName !== false ? $defaultName : null;
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

 
#### Related PRs: 
- https://github.com/ibexa/content-forms/pull/92
- https://github.com/ibexa/core/pull/569

#### Description:

As uncovered by [content-forms#92 CI](https://github.com/ibexa/content-forms/actions/runs/15708641071/job/44260494873?pr=92#step:6:21), we need to ensure in `MultiLanguageNameTrait::getName` that `$this->mainLanguageCode` is initialized before accessing that.

This presents a good opportunity to add strict types to the  `MultiLanguageName` contracts tied to it.

_Note: The trait itself was not a very good design (e.g., references `mainLanguageCode` defined elsewhere), but let's tackle one issue at a time_

#### For QA:

Regression build: :green_circle:  https://github.com/ibexa/commerce/pull/1354
