### PR TITLE
IBX-10186 Add limits to count and subtree queries

### DIFF
--- a/src/contracts/Persistence/Content/Location/Handler.php
+++ b/src/contracts/Persistence/Content/Location/Handler.php
@@ -110,7 +110,7 @@ interface Handler
      */
     public function copySubtree($sourceId, $destinationParentId);
 
-    public function getSubtreeSize(string $path): int;
+    public function getSubtreeSize(string $path, ?int $limit = null): int;
 
     /**
      * Moves location identified by $sourceId into new parent identified by $destinationParentId.

--- a/src/contracts/Persistence/Filter/Content/Handler.php
+++ b/src/contracts/Persistence/Filter/Content/Handler.php
@@ -22,7 +22,7 @@ interface Handler
      */
     public function find(Filter $filter): iterable;
 
-    public function count(Filter $filter): int;
+    public function count(Filter $filter, ?int $limit = null): int;
 }
 
 class_alias(Handler::class, 'eZ\Publish\SPI\Persistence\Filter\Content\Handler');

--- a/src/contracts/Persistence/Filter/Location/Handler.php
+++ b/src/contracts/Persistence/Filter/Location/Handler.php
@@ -22,7 +22,7 @@ interface Handler
      */
     public function find(Filter $filter): iterable;
 
-    public function count(Filter $filter): int;
+    public function count(Filter $filter, ?int $limit = null): int;
 }
 
 class_alias(Handler::class, 'eZ\Publish\SPI\Persistence\Filter\Location\Handler');

--- a/src/contracts/Repository/ContentService.php
+++ b/src/contracts/Repository/ContentService.php
@@ -544,8 +544,10 @@ interface ContentService
      * @param array<int, string> $languages A list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
+     * @param int|null $limit If set, the count will be limited to first $limit items found.
+     *        In some cases it can significantly speed up a count operation for more complex filters.
      */
-    public function count(Filter $filter, ?array $languages = null): int;
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int;
 }
 
 class_alias(ContentService::class, 'eZ\Publish\API\Repository\ContentService');

--- a/src/contracts/Repository/Decorator/ContentServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/ContentServiceDecorator.php
@@ -286,9 +286,9 @@ abstract class ContentServiceDecorator implements ContentService
         return $this->innerService->find($filter, $languages);
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
-        return $this->innerService->count($filter, $languages);
+        return $this->innerService->count($filter, $languages, $limit);
     }
 }
 

--- a/src/contracts/Repository/Decorator/LocationServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/LocationServiceDecorator.php
@@ -82,14 +82,14 @@ abstract class LocationServiceDecorator implements LocationService
         return $this->innerService->loadParentLocationsForDraftContent($versionInfo, $prioritizedLanguages);
     }
 
-    public function getLocationChildCount(Location $location): int
+    public function getLocationChildCount(Location $location, ?int $limit = null ): int
     {
-        return $this->innerService->getLocationChildCount($location);
+        return $this->innerService->getLocationChildCount($location, $limit);
     }
 
-    public function getSubtreeSize(Location $location): int
+    public function getSubtreeSize(Location $location, ?int $limit = null): int
     {
-        return $this->innerService->getSubtreeSize($location);
+        return $this->innerService->getSubtreeSize($location, $limit);
     }
 
     public function createLocation(
@@ -160,9 +160,9 @@ abstract class LocationServiceDecorator implements LocationService
         return $this->innerService->find($filter, $languages);
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
-        return $this->innerService->count($filter, $languages);
+        return $this->innerService->count($filter, $languages, $limit);
     }
 }
 

--- a/src/contracts/Repository/LocationService.php
+++ b/src/contracts/Repository/LocationService.php
@@ -124,14 +124,14 @@ interface LocationService
      *
      * @return int
      */
-    public function getLocationChildCount(Location $location): int;
+    public function getLocationChildCount(Location $location, ?int $limit = null): int;
 
     /**
      * Return the subtree size of a given location.
      *
      * Warning! This method is not permission aware by design.
      */
-    public function getSubtreeSize(Location $location): int;
+    public function getSubtreeSize(Location $location, ?int $limit = null): int;
 
     /**
      * Creates the new $location in the content repository for the given content.
@@ -274,8 +274,10 @@ interface LocationService
      * @param array<int, string>|null $languages a list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
+     * @param int|null $limit If set, the count will be limited to first $limit items found.
+     *        In some cases it can significantly speed up a count operation for more complex filters.
      */
-    public function count(Filter $filter, ?array $languages = null): int;
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int;
 }
 
 class_alias(LocationService::class, 'eZ\Publish\API\Repository\LocationService');

--- a/src/lib/Persistence/Cache/LocationHandler.php
+++ b/src/lib/Persistence/Cache/LocationHandler.php
@@ -256,13 +256,13 @@ class LocationHandler extends AbstractInMemoryPersistenceHandler implements Loca
         return $this->persistenceHandler->locationHandler()->copySubtree($sourceId, $destinationParentId, $newOwnerId);
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
         $this->logger->logCall(__METHOD__, [
             'path' => $path,
         ]);
 
-        return $this->persistenceHandler->locationHandler()->getSubtreeSize($path);
+        return $this->persistenceHandler->locationHandler()->getSubtreeSize($path, $limit);
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Content/Location/Gateway.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Gateway.php
@@ -118,7 +118,7 @@ abstract class Gateway
      */
     abstract public function getSubtreeChildrenDraftContentIds(int $sourceId): array;
 
-    abstract public function getSubtreeSize(string $path): int;
+    abstract public function getSubtreeSize(string $path, ?int $limit = null): int;
 
     /**
      * Returns data for the first level children of the location identified by given $locationId.

--- a/src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -20,6 +20,7 @@ use Ibexa\Core\Base\Exceptions\NotFoundException as NotFound;
 use Ibexa\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use Ibexa\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use Ibexa\Core\Persistence\Legacy\Content\Location\Gateway;
+use Ibexa\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use Ibexa\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter;
 use PDO;
@@ -35,6 +36,8 @@ use function time;
  */
 final class DoctrineDatabase extends Gateway
 {
+    use LimitedCountQueryTrait;
+
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -260,7 +263,7 @@ final class DoctrineDatabase extends Gateway
         return $statement->fetchFirstColumn();
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
         $query = $this->createNodeQueryBuilder([$this->dbPlatform->getCountExpression('node_id')]);
         $query->andWhere(
@@ -270,6 +273,12 @@ final class DoctrineDatabase extends Gateway
                     $path . '%',
                 )
             )
+        );
+
+        $query = $this->wrapCountQuery(
+            $query,
+            't.node_id',
+            $limit
         );
 
         return (int) $query->execute()->fetchOne();

--- a/src/lib/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -118,10 +118,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
         try {
-            return $this->innerGateway->getSubtreeSize($path);
+            return $this->innerGateway->getSubtreeSize($path, $limit);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/src/lib/Persistence/Legacy/Content/Location/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Handler.php
@@ -332,9 +332,9 @@ class Handler implements BaseLocationHandler
         return $copiedSubtreeRootLocation;
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
-        return $this->locationGateway->getSubtreeSize($path);
+        return $this->locationGateway->getSubtreeSize($path, $limit);
     }
 
     /**

--- a/src/lib/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
+++ b/src/lib/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Core\Persistence\Legacy\Filter\Gateway\Content\Doctrine;
 
+use Ibexa\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 use function array_filter;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
@@ -31,6 +32,8 @@ use Traversable;
  */
 final class DoctrineGateway implements Gateway
 {
+    use LimitedCountQueryTrait;
+
     public const COLUMN_MAP = [
         // Content Info
         'content_id' => 'content.id',
@@ -87,11 +90,17 @@ final class DoctrineGateway implements Gateway
         }
     }
 
-    public function count(FilteringCriterion $criterion): int
+    public function count(FilteringCriterion $criterion, ?int $limit = null): int
     {
         $query = $this->buildQuery(
             [$this->getDatabasePlatform()->getCountExpression('DISTINCT content.id')],
             $criterion
+        );
+
+        $query = $this->wrapCountQuery(
+            $query,
+            'content.id',
+            $limit
         );
 
         return (int)$query->execute()->fetch(FetchMode::COLUMN);

--- a/src/lib/Persistence/Legacy/Filter/Gateway/Gateway.php
+++ b/src/lib/Persistence/Legacy/Filter/Gateway/Gateway.php
@@ -18,9 +18,9 @@ use Ibexa\Contracts\Core\Repository\Values\Filter\FilteringCriterion;
 interface Gateway
 {
     /**
-     * Return number of matched rows for the given Criteria (a total count w/o pagination constraints).
+     * Return number of matched rows for the given Criteria (a total count w/o pagination constraints, Unless a limit is passed).
      */
-    public function count(FilteringCriterion $criterion): int;
+    public function count(FilteringCriterion $criterion, ?int $limit = null): int;
 
     /**
      * Return iterator for raw Repository data for the given Query result filtered by the given Criteria,

--- a/src/lib/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
+++ b/src/lib/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
@@ -20,12 +20,15 @@ use Ibexa\Core\Base\Exceptions\DatabaseException;
 use Ibexa\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use Ibexa\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use Ibexa\Core\Persistence\Legacy\Filter\Gateway\Gateway;
+use Ibexa\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 
 /**
  * @internal for internal use by Legacy Storage
  */
 final class DoctrineGateway implements Gateway
 {
+    use LimitedCountQueryTrait;
+
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -54,11 +57,17 @@ final class DoctrineGateway implements Gateway
         }
     }
 
-    public function count(FilteringCriterion $criterion): int
+    public function count(FilteringCriterion $criterion, ?int $limit = null): int
     {
         $query = $this->buildQuery($criterion);
 
         $query->select($this->getDatabasePlatform()->getCountExpression('DISTINCT location.node_id'));
+
+        $query = $this->wrapCountQuery(
+            $query,
+            'location.node_id',
+            $limit
+        );
 
         return (int)$query->execute()->fetch(FetchMode::COLUMN);
     }

--- a/src/lib/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
+++ b/src/lib/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
@@ -73,9 +73,9 @@ final class ContentFilteringHandler implements Handler
         return $list;
     }
 
-    public function count(Filter $filter): int
+    public function count(Filter $filter, ?int $limit = null): int
     {
-        return $this->gateway->count($filter->getCriterion());
+        return $this->gateway->count($filter->getCriterion(), $limit);
     }
 }
 

--- a/src/lib/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
+++ b/src/lib/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
@@ -69,9 +69,9 @@ class LocationFilteringHandler implements Handler
         return $list;
     }
 
-    public function count(Filter $filter): int
+    public function count(Filter $filter, ?int $limit = null): int
     {
-        return $this->gateway->count($filter->getCriterion());
+        return $this->gateway->count($filter->getCriterion(), $limit);
     }
 }
 

--- a/src/lib/Persistence/Legacy/Traits/Doctrine/LimitedCountQueryTrait.php
+++ b/src/lib/Persistence/Legacy/Traits/Doctrine/LimitedCountQueryTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Persistence\Legacy\Traits\Doctrine;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * Limited Count count trait. Used to allow for proper limiting of count queries
+ * when using Doctrine DBAL QueryBuilder.
+ */
+trait LimitedCountQueryTrait
+{
+    /**
+     * Takes a QueryBuilder and wraps it in a count query.
+     * This performs the following transformation to the passed query
+     * SELECT DISTINCT COUNT(DISTINCT someField) FROM XXX WHERE YYY;
+     * To
+     * SELECT COUNT(*) FROM (SELECT DISTINCT someField FROM XXX WHERE YYY LIMIT N) AS csub;.
+     *
+     * @param \Doctrine\DBAL\Query\QueryBuilder $queryBuilder
+     * @param string $countableField
+     * @param mixed $limit
+     *
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    protected function wrapCountQuery(
+        QueryBuilder $queryBuilder,
+        string $countableField,
+        ?int $limit,
+    ): QueryBuilder {
+        $useLimit = $limit !== null && $limit > 0;
+
+        if (!$useLimit) {
+            return $queryBuilder;
+        }
+
+        $querySql = $queryBuilder->select($countableField)
+            ->setMaxResults($limit)
+            ->getSQL();
+
+        $countQuery = $this->connection->createQueryBuilder();
+
+        return $countQuery
+            ->select(
+                $queryBuilder->getConnection()->getDatabasePlatform()->getCountExpression('*')
+            )
+            ->from('(' . $querySql . ')', 'csub')
+            ->setParameters($queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
+    }
+}

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2713,7 +2713,7 @@ class ContentService implements ContentServiceInterface
         return new ContentList($contentItemsIterator->getTotalCount(), $contentItems);
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         $filter = clone $filter;
         if (!empty($languages)) {
@@ -2733,7 +2733,7 @@ class ContentService implements ContentServiceInterface
             $filter->andWithCriterion($permissionCriterion);
         }
 
-        return $this->contentFilteringHandler->count($filter);
+        return $this->contentFilteringHandler->count($filter, $limit);
     }
 }
 

--- a/src/lib/Repository/LocationService.php
+++ b/src/lib/Repository/LocationService.php
@@ -372,11 +372,11 @@ class LocationService implements LocationServiceInterface
     /**
      * Returns the number of children which are readable by the current user of a Location object.
      */
-    public function getLocationChildCount(APILocation $location): int
+    public function getLocationChildCount(Location $location, ?int $limit = null): int
     {
         $filter = $this->buildLocationChildrenFilter($location);
 
-        return $this->count($filter);
+        return $this->count($filter, null, $limit);
     }
 
     public function getSubtreeSize(APILocation $location): int
@@ -942,7 +942,7 @@ class LocationService implements LocationServiceInterface
         );
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         $filter = clone $filter;
         if (!empty($languages)) {
@@ -962,7 +962,7 @@ class LocationService implements LocationServiceInterface
             $filter->andWithCriterion($permissionCriterion);
         }
 
-        return $this->locationFilteringHandler->count($filter);
+        return $this->locationFilteringHandler->count($filter, $limit);
     }
 
     /**

--- a/src/lib/Repository/SiteAccessAware/ContentService.php
+++ b/src/lib/Repository/SiteAccessAware/ContentService.php
@@ -297,11 +297,12 @@ class ContentService implements ContentServiceInterface
         );
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         return $this->service->count(
             $filter,
-            $this->languageResolver->getPrioritizedLanguages($languages)
+            $this->languageResolver->getPrioritizedLanguages($languages),
+            $limit
         );
     }
 }

--- a/src/lib/Repository/SiteAccessAware/LocationService.php
+++ b/src/lib/Repository/SiteAccessAware/LocationService.php
@@ -104,14 +104,14 @@ class LocationService implements LocationServiceInterface
         );
     }
 
-    public function getLocationChildCount(Location $location): int
+    public function getLocationChildCount(Location $location, ?int $limit = null ): int
     {
-        return $this->service->getLocationChildCount($location);
+        return $this->service->getLocationChildCount($location, $limit);
     }
 
-    public function getSubtreeSize(Location $location): int
+    public function getSubtreeSize(Location $location, ?int $limit = null): int
     {
-        return $this->service->getSubtreeSize($location);
+        return $this->service->getSubtreeSize($location, $limit);
     }
 
     public function createLocation(ContentInfo $contentInfo, LocationCreateStruct $locationCreateStruct): Location
@@ -192,11 +192,12 @@ class LocationService implements LocationServiceInterface
         );
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         return $this->service->count(
             $filter,
-            $this->languageResolver->getPrioritizedLanguages($languages)
+            $this->languageResolver->getPrioritizedLanguages($languages),
+            $limit
         );
     }
 }

--- a/tests/integration/Core/Repository/LocationServiceTest.php
+++ b/tests/integration/Core/Repository/LocationServiceTest.php
@@ -1115,6 +1115,26 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test for the getLocationChildCount() method with a limitation on the number of children.
+     *
+     * @covers \Ibexa\Contracts\Core\Repository\LocationService::getLocationChildCount()
+     * @depends testLoadLocation
+     */
+    public function testGetLocationChildCountWithLimitation()
+    {
+        // $locationId is the ID of an existing location
+        $locationService = $this->getRepository()->getLocationService();
+
+        $this->assertSame(
+            2,
+            $locationService->getLocationChildCount(
+                $locationService->loadLocation($this->generateId('location', 5)),
+                2
+            )
+        );
+    }
+
+    /**
      * Test for the loadLocationChildren() method.
      *
      * @covers \Ibexa\Contracts\Core\Repository\LocationService::loadLocationChildren()
@@ -3552,6 +3572,42 @@ class LocationServiceTest extends BaseTest
         $this->createFolder(['eng-GB' => 'Child 2'], $location->id);
 
         self::assertSame(3, $locationService->getSubtreeSize($location));
+
+        return $location;
+    }
+
+    public function testGetSubtreeSizeWithLimit(): Location
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Parent Folder'], 2);
+        $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
+        self::assertSame(1, $locationService->getSubtreeSize($location));
+
+        for ($i = 1; $i <= 10; ++$i) {
+            $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
+        }
+
+        self::assertSame(3, $locationService->getSubtreeSize($location, 3));
+
+        return $location;
+    }
+
+    public function testGetSubtreeSizeWithInvalidLimitHasNoEffect(): Location
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Parent Folder'], 2);
+        $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
+        self::assertSame(1, $locationService->getSubtreeSize($location));
+
+        for ($i = 1; $i <= 10; ++$i) {
+            $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
+        }
+
+        self::assertSame(11, $locationService->getSubtreeSize($location, -2));
 
         return $location;
     }

--- a/tests/lib/Repository/Decorator/LocationServiceDecoratorTest.php
+++ b/tests/lib/Repository/Decorator/LocationServiceDecoratorTest.php
@@ -151,7 +151,7 @@ class LocationServiceDecoratorTest extends TestCase
         $serviceMock = $this->createServiceMock();
         $decoratedService = $this->createDecorator($serviceMock);
 
-        $parameters = [$this->createMock(Location::class)];
+        $parameters = [$this->createMock(Location::class), 8];
 
         $serviceMock->expects($this->once())->method('getLocationChildCount')->with(...$parameters);
 


### PR DESCRIPTION
| :ticket: Issue | IBX-10186 |
|----------------|-----------|

>[!WARNING]
> Please check https://github.com/ezsystems/ezplatform-kernel/pull/413 for detailed reasons for this PR. Though the TLDR is count queries cause disproportionate impact on Ibexa Platform instances with large amounts of content (100,000+ content objects)

#### Related PRs: 
- https://github.com/ezsystems/ezplatform-kernel/pull/413
- 
#### Description:
This is a forward facing patch from issues present in Ibexa 3.3 (The version we are still using) to port the fixes and public API updates into 4.6.

Understandably considering this PR makes changes to Contracts it might need to go into 4.7 (If a release is planned beyond LTS) or v5 given implementing clients will break. I am not sure on the release cadence for contracts so this might be somewhat problematic. For reference 

#### For QA:
TBC

#### Documentation:
Check  https://github.com/ezsystems/ezplatform-kernel/pull/413  for relevant details.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
