### PR TITLE
IBX-9727: Fixed strict types for Encore ConfigurationDumper class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4777,48 +4777,6 @@ parameters:
 			path: src/contracts/Collection/MutableArrayList.php
 
 		-
-			message: '#^Binary operation "\." between array\|bool\|float\|int\|string\|null and ''/'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Container\\Encore\\ConfigurationDumper\:\:createFinder\(\) has parameter \$bundlesMetadata with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Container\\Encore\\ConfigurationDumper\:\:dumpConfigurationPaths\(\) has parameter \$paths with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Container\\Encore\\ConfigurationDumper\:\:locateConfigurationFiles\(\) has parameter \$bundlesMetadata with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Container\\Encore\\ConfigurationDumper\:\:locateConfigurationFiles\(\) has parameter \$configFiles with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
-			message: '#^Method Ibexa\\Contracts\\Core\\Container\\Encore\\ConfigurationDumper\:\:locateConfigurationFiles\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
-			message: '#^Parameter \#1 \$bundlesMetadata of method Ibexa\\Contracts\\Core\\Container\\Encore\\ConfigurationDumper\:\:locateConfigurationFiles\(\) expects array, array\|bool\|float\|int\|string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/contracts/Container/Encore/ConfigurationDumper.php
-
-		-
 			message: '#^Method Ibexa\\Contracts\\Core\\FieldType\\BinaryBase\\PathGeneratorInterface\:\:getStoragePathForField\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -41813,12 +41771,6 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: tests/lib/Collection/MutableArrayMapTest.php
-
-		-
-			message: '#^Parameter \#2 \$string of static method PHPUnit\\Framework\\Assert\:\:assertRegExp\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 2
-			path: tests/lib/Container/Encore/ConfigurationDumperTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\Event\\BookmarkServiceTest\:\:testCreateBookmarkEvents\(\) has no return type specified\.$#'

--- a/tests/lib/Container/Encore/ConfigurationDumperTest.php
+++ b/tests/lib/Container/Encore/ConfigurationDumperTest.php
@@ -18,8 +18,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class ConfigurationDumperTest extends TestCase
 {
-    private const PROJECT_DIR = '/var/io-tests/';
-    private const FOO_BAR_BUNDLE_DIR = 'foo-bar';
+    private const string PROJECT_DIR = '/var/io-tests/';
+    private const string FOO_BAR_BUNDLE_DIR = 'foo-bar';
 
     private Filesystem $filesystem;
 
@@ -64,11 +64,12 @@ final class ConfigurationDumperTest extends TestCase
         $compiledFilePath = $this->projectDir . '/var/encore/foo-bar.js';
         self::assertFileExists($compiledFilePath);
         $compiledFileContents = file_get_contents($compiledFilePath);
-        self::assertRegExp(
+        self::assertNotFalse($compiledFileContents, "Failed to read compiled file '$compiledFilePath' contents");
+        self::assertMatchesRegularExpression(
             '@^module\.exports = \[.*io-tests\\\/foo-bar\\\/Resources\\\/encore\\\/foo-bar\.js@',
             $compiledFileContents
         );
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             '@^module\.exports = \[.*io-tests\\\/encore\\\/foo-bar\.js@',
             $compiledFileContents
         );


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|----------|


#### Description:

Fixed strict types for Webpack Encore Configuration dumper class ran when warming up Symfony project cache.

#### For QA:

Regression run: https://github.com/ibexa/commerce/pull/1359