### PR TITLE
IBX-10167: Fixed translations export in abstract field type classes

### DIFF
--- a/src/bundle/Core/Resources/translations/ibexa_fieldtypes.en.xlf
+++ b/src/bundle/Core/Resources/translations/ibexa_fieldtypes.en.xlf
@@ -6,117 +6,117 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
-      <trans-unit id="06a34ac23ac86f7c4368380203e3dd4d91489fa0" resname="ibexa_author.name">
+      <trans-unit id="4ebf975167e11d223757e94939c78fd401d26613" resname="ibexa_author.name">
         <source>Authors</source>
         <target>Authors</target>
         <note>key: ibexa_author.name</note>
       </trans-unit>
-      <trans-unit id="e4ca4a21a1e442e6a1232320b2184b9e4105c73f" resname="ibexa_binaryfile.name">
+      <trans-unit id="8bc4e796189bb633598f9b552f3d175d9b75c2f0" resname="ibexa_binaryfile.name">
         <source>File</source>
         <target>File</target>
         <note>key: ibexa_binaryfile.name</note>
       </trans-unit>
-      <trans-unit id="129dd46eabe280c49a0e9d424d9cbf676621aec9" resname="ibexa_boolean.name">
+      <trans-unit id="d92a104de67f12a9e3765d89e0e3d7ef2d3038a0" resname="ibexa_boolean.name">
         <source>Checkbox</source>
         <target>Checkbox</target>
         <note>key: ibexa_boolean.name</note>
       </trans-unit>
-      <trans-unit id="c4c3e3c536a09969467c7c9bb584459b47317fed" resname="ibexa_country.name">
+      <trans-unit id="e87fb24d4b5451ff6b0a9bb507eb406a21fe7680" resname="ibexa_country.name">
         <source>Country</source>
         <target>Country</target>
         <note>key: ibexa_country.name</note>
       </trans-unit>
-      <trans-unit id="3bd547a05c5a7b5ee111cc5ca608df9199f04c51" resname="ibexa_date.name">
+      <trans-unit id="c29a3418379f739248c56a800e6e6ab68c61b344" resname="ibexa_date.name">
         <source>Date</source>
         <target>Date</target>
         <note>key: ibexa_date.name</note>
       </trans-unit>
-      <trans-unit id="42d9e26b6e8e65856f709461b589cb7925a9f43e" resname="ibexa_datetime.name">
+      <trans-unit id="32f442afdead4bd5bb6012ec207d554d0319bdb1" resname="ibexa_datetime.name">
         <source>Date and time</source>
         <target>Date and time</target>
         <note>key: ibexa_datetime.name</note>
       </trans-unit>
-      <trans-unit id="d772ac8909929964906cbefd41c468c9a5d2be26" resname="ibexa_email.name">
+      <trans-unit id="90d47524e7a0a88a178d853e6837edc22eb744ad" resname="ibexa_email.name">
         <source>Email address</source>
         <target>Email address</target>
         <note>key: ibexa_email.name</note>
       </trans-unit>
-      <trans-unit id="0a1f3297ccc08882f5a4610f9af8fc4148c74adc" resname="ibexa_float.name">
+      <trans-unit id="f7ea7154a9cc8053001cb86b1399e2b960ea18d6" resname="ibexa_float.name">
         <source>Float</source>
         <target>Float</target>
         <note>key: ibexa_float.name</note>
       </trans-unit>
-      <trans-unit id="fcabb29fdb097d916c88328daad461c1ea765121" resname="ibexa_gmap_location.name">
+      <trans-unit id="4db71d15e3b1cd9031129ad441eb6e5ff97d0837" resname="ibexa_gmap_location.name">
         <source>Map location</source>
         <target>Map location</target>
         <note>key: ibexa_gmap_location.name</note>
       </trans-unit>
-      <trans-unit id="6300f890f00d9999466b4abc478857b0d29022b4" resname="ibexa_image.name">
+      <trans-unit id="f20feb4213b18c3a89f6d67a50021005521553f9" resname="ibexa_image.name">
         <source>Image</source>
         <target>Image</target>
         <note>key: ibexa_image.name</note>
       </trans-unit>
-      <trans-unit id="3afdca17c734ecb3a077bcc4ba7f75a7544e845d" resname="ibexa_imageasset.name">
+      <trans-unit id="922fa9ce06fa28b293050aded90773559fa39306" resname="ibexa_image_asset.name">
         <source>Image Asset</source>
-        <target>Image Asset</target>
-        <note>key: ibexa_imageasset.name</note>
+        <target state="new">Image Asset</target>
+        <note>key: ibexa_image_asset.name</note>
       </trans-unit>
-      <trans-unit id="3b0f44cd332c71e78209a1a4b235bc6a1e6d374b" resname="ibexa_integer.name">
+      <trans-unit id="3aeb96f710ddccb1a12809d3bb6f3e604fc14f75" resname="ibexa_integer.name">
         <source>Integer</source>
         <target>Integer</target>
         <note>key: ibexa_integer.name</note>
       </trans-unit>
-      <trans-unit id="b55e4568224820cbddc794f6c2bd002baec6a5d0" resname="ibexa_isbn.name">
+      <trans-unit id="a3ec2b68e5b828e06b1da15b81a11cb946a7b61a" resname="ibexa_isbn.name">
         <source>ISBN</source>
         <target>ISBN</target>
         <note>key: ibexa_isbn.name</note>
       </trans-unit>
-      <trans-unit id="c564457bc5723491788fa3d0723e3716824b4a0d" resname="ibexa_keyword.name">
+      <trans-unit id="af9a6bab19321da9ca1a04f0ca027fa0e442f3da" resname="ibexa_keyword.name">
         <source>Keywords</source>
         <target>Keywords</target>
         <note>key: ibexa_keyword.name</note>
       </trans-unit>
-      <trans-unit id="fc0d2c8719e7c36f101ff6ddcbdfc804bf8f3da7" resname="ibexa_media.name">
+      <trans-unit id="c8b11d42f199954911c0b4e446b4b6be2499b5dc" resname="ibexa_media.name">
         <source>Media</source>
         <target>Media</target>
         <note>key: ibexa_media.name</note>
       </trans-unit>
-      <trans-unit id="feb25b24199466f077038c5e6e38209deae21471" resname="ibexa_object_relation.name">
+      <trans-unit id="680b747f8dfea9a58c4f1b4240b52c973dcf2184" resname="ibexa_object_relation.name">
         <source>Content relation (single)</source>
         <target>Content relation (single)</target>
         <note>key: ibexa_object_relation.name</note>
       </trans-unit>
-      <trans-unit id="44d2ac9ae83f6b73fa8f61fad66a77d76d2159f0" resname="ibexa_object_relation_list.name">
+      <trans-unit id="b86639bd93e51b2fb224d8f9d712b7a75f06a1d7" resname="ibexa_object_relation_list.name">
         <source>Content relations (multiple)</source>
         <target>Content relations (multiple)</target>
         <note>key: ibexa_object_relation_list.name</note>
       </trans-unit>
-      <trans-unit id="3229c3fc41a4af84f0fd1636f0678aac770359bc" resname="ibexa_selection.name">
+      <trans-unit id="a53c7d8f9605046dd87f34be6bc05638d090d9ef" resname="ibexa_selection.name">
         <source>Selection</source>
         <target>Selection</target>
         <note>key: ibexa_selection.name</note>
       </trans-unit>
-      <trans-unit id="d958019d9702d5e89f247c24563da97ea0205f58" resname="ibexa_string.name">
+      <trans-unit id="96dcf549200ee0296e6705f1b7dda3bedcb1abcf" resname="ibexa_string.name">
         <source>Text line</source>
         <target>Text line</target>
         <note>key: ibexa_string.name</note>
       </trans-unit>
-      <trans-unit id="e35280b88546fdd18c84ce9c401e17cbfca56e72" resname="ibexa_text.name">
+      <trans-unit id="78d7f7c4cfa2833e249408a683af5a465fc5b587" resname="ibexa_text.name">
         <source>Text block</source>
         <target>Text block</target>
         <note>key: ibexa_text.name</note>
       </trans-unit>
-      <trans-unit id="503c2801427b2d773d020ef953413d14c17968bd" resname="ibexa_time.name">
+      <trans-unit id="6f7c4d9029fe167cf148b73e207aa63afc14c7f3" resname="ibexa_time.name">
         <source>Time</source>
         <target>Time</target>
         <note>key: ibexa_time.name</note>
       </trans-unit>
-      <trans-unit id="69c0e446226061b7f2ca2b22fd4eb09e6b4e9518" resname="ibexa_url.name">
+      <trans-unit id="dadb1a22b7fc21684d47d6cf669a2a5c0ebee21d" resname="ibexa_url.name">
         <source>URL</source>
         <target>URL</target>
         <note>key: ibexa_url.name</note>
       </trans-unit>
-      <trans-unit id="0317c233c19b3c191acc92971bfb616c7fe298de" resname="ibexa_user.name">
+      <trans-unit id="e787483a1bfbe0e4df0e6bbcc9d0f444928c1291" resname="ibexa_user.name">
         <source>User account</source>
         <target>User account</target>
         <note>key: ibexa_user.name</note>

--- a/src/lib/FieldType/BaseNumericType.php
+++ b/src/lib/FieldType/BaseNumericType.php
@@ -10,9 +10,8 @@ namespace Ibexa\Core\FieldType;
 
 use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
-abstract class BaseNumericType extends FieldType implements TranslationContainerInterface
+abstract class BaseNumericType extends FieldType
 {
     /**
      * @return array<string, \Ibexa\Core\FieldType\Validator>

--- a/src/lib/FieldType/BaseTextType.php
+++ b/src/lib/FieldType/BaseTextType.php
@@ -12,14 +12,13 @@ use Ibexa\Contracts\Core\FieldType\Value as FieldTypeValueInterface;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\Value as BaseValue;
-use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * @internal
  *
  * Base implementation for TextLine\Type and TextBlock\Type which extends TextLine\Type.
  */
-abstract class BaseTextType extends FieldType implements TranslationContainerInterface
+abstract class BaseTextType extends FieldType
 {
     public function isSearchable(): bool
     {

--- a/src/lib/FieldType/Float/Type.php
+++ b/src/lib/FieldType/Float/Type.php
@@ -14,13 +14,14 @@ use Ibexa\Core\FieldType\BaseNumericType;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * Float field types.
  *
  * Represents floats.
  */
-class Type extends BaseNumericType
+class Type extends BaseNumericType implements TranslationContainerInterface
 {
     protected $validatorConfigurationSchema = [
         'FloatValueValidator' => [

--- a/src/lib/FieldType/Integer/Type.php
+++ b/src/lib/FieldType/Integer/Type.php
@@ -14,13 +14,14 @@ use Ibexa\Core\FieldType\BaseNumericType;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * Integer field types.
  *
  * Represents integers.
  */
-class Type extends BaseNumericType
+class Type extends BaseNumericType implements TranslationContainerInterface
 {
     protected $validatorConfigurationSchema = [
         'IntegerValueValidator' => [

--- a/src/lib/FieldType/TextBlock/Type.php
+++ b/src/lib/FieldType/TextBlock/Type.php
@@ -12,13 +12,14 @@ use Ibexa\Core\FieldType\BaseTextType;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * The TextBlock field type.
  *
  * Represents a larger body of text, such as text areas.
  */
-class Type extends BaseTextType
+class Type extends BaseTextType implements TranslationContainerInterface
 {
     protected $settingsSchema = [
         'textRows' => [

--- a/src/lib/FieldType/TextLine/Type.php
+++ b/src/lib/FieldType/TextLine/Type.php
@@ -14,13 +14,14 @@ use Ibexa\Core\FieldType\BaseTextType;
 use Ibexa\Core\FieldType\Validator\StringLengthValidator;
 use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 /**
  * The TextLine field type.
  *
  * This field type represents a simple string.
  */
-class Type extends BaseTextType
+class Type extends BaseTextType implements TranslationContainerInterface
 {
     protected $validatorConfigurationSchema = [
         'StringLengthValidator' => [


### PR DESCRIPTION
| :ticket: Issue | IBX-10167 |
|----------------|-----------|

#### Description:
It seems like `JMS\TranslationBundle\Translation\Extractor\File\TranslationContainerExtractor` doesn't work well with abstract classes that are part of the `TranslationContainerInterface` interface:

```
In TranslationContainerExtractor.php line 112:
                                                                                                                                                      
  call_user_func(): Argument #1 ($callback) must be a valid callback, cannot call abstract method Ibexa\Core\FieldType\BaseNumericType::getTranslati  
  onMessages()
```

therefore I moved the interface into concrete classes.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
