### PR TITLE
IBX-10229: Made old field type alias fallback to new one in searchable field map

### DIFF
--- a/src/lib/Persistence/Legacy/Content/Type/Handler.php
+++ b/src/lib/Persistence/Legacy/Content/Type/Handler.php
@@ -18,6 +18,7 @@ use Ibexa\Contracts\Core\Persistence\Content\Type\UpdateStruct;
 use Ibexa\Core\Base\Exceptions\BadStateException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
+use Ibexa\Core\FieldType\FieldTypeAliasResolverInterface;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Update\Handler as UpdateHandler;
 use Ibexa\Core\Persistence\Legacy\Exception;
@@ -54,7 +55,8 @@ class Handler implements BaseContentTypeHandler
         Gateway $contentTypeGateway,
         Mapper $mapper,
         UpdateHandler $updateHandler,
-        StorageDispatcherInterface $storageDispatcher
+        StorageDispatcherInterface $storageDispatcher,
+        private readonly FieldTypeAliasResolverInterface $fieldTypeAliasResolver
     ) {
         $this->contentTypeGateway = $contentTypeGateway;
         $this->mapper = $mapper;
@@ -653,8 +655,11 @@ class Handler implements BaseContentTypeHandler
         $rows = $this->contentTypeGateway->getSearchableFieldMapData();
 
         foreach ($rows as $row) {
+            $fieldTypeIdentifier = $row['field_type_identifier'];
+            $fieldTypeIdentifier = $this->fieldTypeAliasResolver->resolveIdentifier($fieldTypeIdentifier);
+
             $fieldMap[$row['content_type_identifier']][$row['field_definition_identifier']] = [
-                'field_type_identifier' => $row['field_type_identifier'],
+                'field_type_identifier' => $fieldTypeIdentifier,
                 'field_definition_id' => $row['field_definition_id'],
             ];
         }

--- a/src/lib/Resources/settings/storage_engines/legacy/content_type.yml
+++ b/src/lib/Resources/settings/storage_engines/legacy/content_type.yml
@@ -51,6 +51,7 @@ services:
             - '@Ibexa\Core\Persistence\Legacy\Content\Type\Mapper'
             - '@ibexa.persistence.legacy.content_type.update_handler'
             - '@Ibexa\Core\Persistence\Legacy\Content\Type\StorageDispatcherInterface'
+            - '@Ibexa\Core\FieldType\FieldTypeAliasResolverInterface'
 
     Ibexa\Core\Persistence\Legacy\Content\Type\MemoryCachingHandler:
         class: Ibexa\Core\Persistence\Legacy\Content\Type\MemoryCachingHandler

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -752,7 +752,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTestCase
                 'descriptions' => [],
                 'fieldGroup' => null,
                 'position' => null,
-                'isTranslatable' => false,
+                'isTranslatable' => true,
                 'isRequired' => false,
                 'isInfoCollector' => false,
                 'validatorConfiguration' => null,

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -752,7 +752,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTestCase
                 'descriptions' => [],
                 'fieldGroup' => null,
                 'position' => null,
-                'isTranslatable' => true,
+                'isTranslatable' => false,
                 'isRequired' => false,
                 'isInfoCollector' => false,
                 'validatorConfiguration' => null,

--- a/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Type/ContentTypeHandlerTest.php
@@ -15,6 +15,9 @@ use Ibexa\Contracts\Core\Persistence\Content\Type\Group\CreateStruct as GroupCre
 use Ibexa\Contracts\Core\Persistence\Content\Type\Group\UpdateStruct as GroupUpdateStruct;
 use Ibexa\Contracts\Core\Persistence\Content\Type\UpdateStruct;
 use Ibexa\Contracts\Core\Repository\Exceptions\BadStateException;
+use Ibexa\Core\FieldType\FieldTypeAliasRegistry;
+use Ibexa\Core\FieldType\FieldTypeAliasResolver;
+use Ibexa\Core\FieldType\FieldTypeAliasResolverInterface;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Gateway;
 use Ibexa\Core\Persistence\Legacy\Content\Type\Handler;
@@ -117,6 +120,7 @@ class ContentTypeHandlerTest extends TestCase
                 $mapperMock,
                 $this->getUpdateHandlerMock(),
                 $this->getStorageDispatcherMock(),
+                $this->getFieldTypeAliasResolver(),
             ])
             ->getMock();
 
@@ -554,6 +558,7 @@ class ContentTypeHandlerTest extends TestCase
                 $this->getMapperMock(),
                 $this->getUpdateHandlerMock(),
                 $this->getStorageDispatcherMock(),
+                $this->getFieldTypeAliasResolver(),
             ])
             ->getMock();
 
@@ -653,6 +658,7 @@ class ContentTypeHandlerTest extends TestCase
                 $mapperMock,
                 $this->getUpdateHandlerMock(),
                 $this->getStorageDispatcherMock(),
+                $this->getFieldTypeAliasResolver(),
             ])
             ->getMock();
 
@@ -706,6 +712,7 @@ class ContentTypeHandlerTest extends TestCase
                 $mapperMock,
                 $this->getUpdateHandlerMock(),
                 $this->getStorageDispatcherMock(),
+                $this->getFieldTypeAliasResolver(),
             ])
             ->getMock();
 
@@ -1073,7 +1080,8 @@ class ContentTypeHandlerTest extends TestCase
             $this->getGatewayMock(),
             $this->getMapperMock(),
             $this->getUpdateHandlerMock(),
-            $this->getStorageDispatcherMock()
+            $this->getStorageDispatcherMock(),
+            $this->getFieldTypeAliasResolver(),
         );
     }
 
@@ -1094,6 +1102,7 @@ class ContentTypeHandlerTest extends TestCase
                     $this->getMapperMock(),
                     $this->getUpdateHandlerMock(),
                     $this->getStorageDispatcherMock(),
+                    $this->getFieldTypeAliasResolver(),
                 ]
             )
             ->getMock();
@@ -1163,6 +1172,13 @@ class ContentTypeHandlerTest extends TestCase
         return $this->storageDispatcherMock;
     }
 
+    protected function getFieldTypeAliasResolver(): FieldTypeAliasResolverInterface
+    {
+        $fieldTypeAliasRegistry = new FieldTypeAliasRegistry();
+
+        return new FieldTypeAliasResolver($fieldTypeAliasRegistry);
+    }
+
     /**
      * Returns a CreateStruct fixture.
      *
@@ -1211,6 +1227,7 @@ class ContentTypeHandlerTest extends TestCase
                 $mapperMock,
                 $this->getUpdateHandlerMock(),
                 $this->getStorageDispatcherMock(),
+                $this->getFieldTypeAliasResolver(),
             ])
             ->getMock();
 

--- a/tests/lib/Search/Legacy/Content/AbstractTestCase.php
+++ b/tests/lib/Search/Legacy/Content/AbstractTestCase.php
@@ -101,7 +101,8 @@ class AbstractTestCase extends LanguageAwareTestCase
                     $this->getFieldTypeAliasResolver(),
                 ),
                 $this->createMock(ContentTypeUpdateHandler::class),
-                $this->createMock(StorageDispatcherInterface::class)
+                $this->createMock(StorageDispatcherInterface::class),
+                $this->getFieldTypeAliasResolver(),
             );
         }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-10229 |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/core/pull/604

#### Description:
This PR follows the pattern of gracefully handling old field type aliases and converting them to new ones directly after fetching them from a database i.e. https://github.com/ibexa/core/blob/main/src/lib/Persistence/Legacy/Content/Type/Mapper.php#L251

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
