### PR TITLE
IBX-9980: Fixed displaying search engine in `ibexa:reindex` command

### DIFF
--- a/src/bundle/Core/Resources/config/commands.yml
+++ b/src/bundle/Core/Resources/config/commands.yml
@@ -43,6 +43,7 @@ services:
             $projectDir: '%kernel.project_dir%'
             $isDebug: '%kernel.debug%'
             $contentIdListGeneratorStrategy: '@Ibexa\Bundle\Core\Command\Indexer\ContentIdList\ContentTypeInputGeneratorStrategy'
+            $repositoryConfigurationProvider: '@Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface'
         tags:
             - { name: console.command }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9980 |
|----------------|-----------|

### Description:
It seems indexers can extend one of the following classes:
- `Ibexa\Core\Search\Common\Indexer`
- `Ibexa\Core\Search\Common\IncrementalIndexer`

Despite all our indexers (Legacy/Solr/Elastic) extending the latter which already contains proper `getName()` method, I found `SearchEngineIndexerFactory` which looks like an EP accepting implementation of both mentioned services. 

I decided to handle those two cases within `getSearchEngineAlias` method - custom indexers (implementing `Ibexa\Core\Search\Common\Indexer`) should be handled the same way as in System info `Services` tab. 

Additional change: `SymfonyStyle::confirm` second parameter is `true` by default, adjusted as such.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
