### PR TITLE
IBX-10246: Made `FieldDefinitionCreateStruct` not translatable by default

### DIFF
--- a/src/contracts/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
+++ b/src/contracts/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
@@ -59,7 +59,7 @@ class FieldDefinitionCreateStruct extends ValueObject
     /**
      * Indicates if the field is translatable.
      */
-    public bool $isTranslatable = true;
+    public bool $isTranslatable = false;
 
     /**
      * Indicates if the field is required.


### PR DESCRIPTION
| :ticket: Issue | IBX-10246 |
|----------------|-----------|

#### Description:
As translatable field definition is not always fitting for all field types, and not translatable is fitting to all of them, I believe we should make it non translatable by default.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
