### PR TITLE
[CI] Moved Stub namespace to autoload from dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,8 @@
             "Ibexa\\Core\\": "src/lib",
             "Ibexa\\Tests\\Core\\": "tests/lib",
             "Ibexa\\Tests\\Integration\\Core\\": "tests/integration/Core",
-            "Ibexa\\Tests\\Bundle\\Core\\": "tests/bundle/Core"
+            "Ibexa\\Tests\\Bundle\\Core\\": "tests/bundle/Core",
+            "Ibexa\\Tests\\Integration\\Stub\\": "tests/integration/Stub"
         }
     },
     "autoload-dev": {
@@ -112,7 +113,6 @@
             "Ibexa\\Tests\\Integration\\IO\\": "tests/integration/IO",
             "Ibexa\\Tests\\Integration\\RepositoryInstaller\\": "tests/integration/RepositoryInstaller",
             "Ibexa\\Tests\\Integration\\LegacySearchEngine\\": "tests/integration/LegacySearchEngine",
-            "Ibexa\\Tests\\Integration\\Stub\\": "tests/integration/Stub",
             "Ibexa\\Tests\\Core\\": "tests/lib"
         }
     },


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Stubs are used outside Core CI pipline.

https://github.com/ibexa/fieldtype-richtext/actions/runs/16070520749/job/45549906318
#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
