### PR TITLE
Added a condition to check whether script_filename is not empty

### DIFF
--- a/src/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListener.php
+++ b/src/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListener.php
@@ -37,11 +37,11 @@ class RejectExplicitFrontControllerRequestsListener implements EventSubscriberIn
         $request = $event->getRequest();
 
         // Not every symfony runtime provides SCRIPT_FILENAME
-        if (!$request->server->has('SCRIPT_FILENAME')) {
+        if (!$request->server->has('SCRIPT_FILENAME') || empty($scriptFileName = $request->server->get('SCRIPT_FILENAME'))) {
             return;
         }
 
-        $scriptFileName = preg_quote(basename($request->server->get('SCRIPT_FILENAME')), '\\');
+        $scriptFileName = preg_quote(basename($scriptFileName), '\\');
         // This pattern has to match with vhost.template files in meta repository
         $pattern = sprintf('<^/([^/]+/)*?%s([/?#]|$)>', $scriptFileName);
 

--- a/tests/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
+++ b/tests/bundle/Core/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
@@ -195,6 +195,19 @@ class RejectExplicitFrontControllerRequestsListenerTest extends TestCase
                     ]
                 ),
             ],
+            [
+                Request::create(
+                    'https://example.com/app.php/folder/folder/',
+                    Request::METHOD_GET,
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/folder/',
+                        'SCRIPT_FILENAME' => '',
+                    ]
+                ),
+            ],
         ];
     }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description:
During tests in the admin-UI - https://github.com/ibexa/admin-ui/actions/runs/16344808195/job/46175790991?pr=1643, it turned out that one URL returns a 404 after changing the pattern. During tests, SCRIPT_FILENAME exists in the request but is empty, and the URI at the end contained `/`, which caused it to fall into the pattern

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
