### PR TITLE
IBX-10263: Allowed hyphens in HostText and UriText siteaccess matchers

### DIFF
--- a/src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
+++ b/src/lib/MVC/Symfony/SiteAccess/Matcher/HostText.php
@@ -32,7 +32,7 @@ class HostText extends Regex implements VersatileMatcher
         $this->prefix = isset($siteAccessesConfiguration['prefix']) ? $siteAccessesConfiguration['prefix'] : '';
         $this->suffix = isset($siteAccessesConfiguration['suffix']) ? $siteAccessesConfiguration['suffix'] : '';
         parent::__construct(
-            '^' . preg_quote($this->prefix, '@') . "(\w+)" . preg_quote($this->suffix, '@') . '$',
+            '^' . preg_quote($this->prefix, '@') . "([\w-]+)" . preg_quote($this->suffix, '@') . '$',
             1
         );
         $this->siteAccessesConfiguration = $siteAccessesConfiguration;

--- a/src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
+++ b/src/lib/MVC/Symfony/SiteAccess/Matcher/URIText.php
@@ -36,7 +36,7 @@ class URIText extends Regex implements VersatileMatcher, URILexer
         $this->suffix = isset($siteAccessesConfiguration['suffix']) ? $siteAccessesConfiguration['suffix'] : '';
 
         parent::__construct(
-            '^(/' . preg_quote($this->prefix, '@') . '(\w+)' . preg_quote($this->suffix, '@') . ')',
+            '^(/' . preg_quote($this->prefix, '@') . '([\w-]+)' . preg_quote($this->suffix, '@') . ')',
             2
         );
         $this->siteAccessesConfiguration = $siteAccessesConfiguration;

--- a/tests/lib/MVC/Symfony/SiteAccess/RouterHostTextTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/RouterHostTextTest.php
@@ -33,6 +33,7 @@ class RouterHostTextTest extends RouterBaseTest
             [SimplifiedRequest::fromUrl('http://example.com/test/foo/bar/'), 'default_sa'],
             [SimplifiedRequest::fromUrl('http://example.com/test/foo/bar/first_sa'), 'default_sa'],
             [SimplifiedRequest::fromUrl('http://example.com/default_sa'), 'default_sa'],
+            [SimplifiedRequest::fromUrl('http://example.com/sa-with-hyphen'), 'sa-with-hyphen'],
 
             [SimplifiedRequest::fromUrl('http://example.com/first_sa'), 'first_sa'],
             [SimplifiedRequest::fromUrl('http://example.com/first_sa/'), 'first_sa'],
@@ -58,6 +59,7 @@ class RouterHostTextTest extends RouterBaseTest
             [SimplifiedRequest::fromUrl('http://www.example.com:82/'), 'example'],
             [SimplifiedRequest::fromUrl('https://www.example.com:83/'), 'example'],
             [SimplifiedRequest::fromUrl('http://www.example.com/foo/'), 'example'],
+            [SimplifiedRequest::fromUrl('http://www.sa-with-hyphen.com'), 'sa-with-hyphen'],
 
             [SimplifiedRequest::fromUrl('http://example.com/second_sa'), 'second_sa'],
             [SimplifiedRequest::fromUrl('http://example.com/second_sa/'), 'second_sa'],
@@ -108,10 +110,12 @@ class RouterHostTextTest extends RouterBaseTest
                 'Map\\URI' => [
                     'first_sa' => 'first_sa',
                     'second_sa' => 'second_sa',
+                    'sa-with-hyphen' => 'sa-with-hyphen',
                 ],
                 'Map\\Host' => [
                     'first_sa' => 'first_sa',
                     'first_siteaccess' => 'first_sa',
+                    'sa-with-hyphen' => 'sa-with-hyphen',
                 ],
             ],
             $this->siteAccessProvider
@@ -131,6 +135,8 @@ class RouterHostTextTest extends RouterBaseTest
             new SiteAccessSetting('fifth_sa', true),
             new SiteAccessSetting('example', true),
             new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
+            new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting('sa-with-hyphen', true),
         ];
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-10263 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

CI issues fixed in: https://github.com/ibexa/core/pull/624
#### Description:
(Or we need documentation about possible characters in siteaccess name).

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
