### PR TITLE
Conflict with ezsystems/ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,14 +77,12 @@
     },
     "conflict": {
         "doctrine/dbal": "2.7.0",
+        "ezsystems/ezplatform-kernel": "*",
         "ezsystems/ezpublish-legacy": "*",
         "friendsofphp/php-cs-fixer": "3.5.0",
         "phpunit/phpunit": "8.4.0",
         "symfony/dependency-injection": "5.3.7",
         "symfony/security-core": "5.3.0"
-    },
-    "replace": {
-        "ezsystems/ezplatform-kernel": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
#### Description:
This makes `ibexa/core` conflict with `ezsystems/ezplatform-kernel`.

While before, this made sense as it allowed the packages from eZ era installable on Ibexa 4, now with Ibexa 5 it does not make sense any more, since most, if not all, packages are not compatible with Ibexa 5 due to removed BC layer.

Instead denying installation, replacing the package like this actually allows installing older versions of packages. Conflicting stops the installation as expected.