### PR TITLE
[WiP] IBX-9727: Fixed strict types of field type layer

### DIFF
--- a/src/contracts/FieldType/FieldType.php
+++ b/src/contracts/FieldType/FieldType.php
@@ -4,10 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\FieldType;
 
 use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
+use Ibexa\Contracts\Core\Repository\Values\Content\RelationType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 
 /**
@@ -37,105 +39,86 @@ abstract class FieldType
      * to prefix the field-type identifier by a unique string that identifies
      * the implementer. A good identifier could for example take your companies main
      * domain name as a prefix in reverse order.
-     *
-     * @return string
      */
-    abstract public function getFieldTypeIdentifier();
+    abstract public function getFieldTypeIdentifier(): string;
 
     /**
-     * Returns a human readable string representation from a given value.
+     * Returns a human-readable string representation from a given value.
      *
-     * It will be used to generate content name and url alias if current field
+     * It will be used to generate content name and url alias if the current field
      * is designated to be used in the content name/urlAlias pattern.
      *
      * The used $value can be assumed to be already accepted by {@see FieldType::acceptValue()}.
-     *
-     * @param \Ibexa\Contracts\Core\FieldType\Value $value
-     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition
-     * @param string $languageCode
-     *
-     * @return string
      */
     abstract public function getName(Value $value, FieldDefinition $fieldDefinition, string $languageCode): string;
 
     /**
      * Returns a schema for the settings expected by the FieldType.
      *
-     * Returns an arbitrary value, representing a schema for the settings of
+     * Returns an arbitrary hash map, representing a schema for the settings of
      * the FieldType.
      *
-     * Explanation: There are no possible generic schemas for defining settings
-     * input, which is why no schema for the return value of this method is
-     * defined. It is up to the implementer to define and document a schema for
-     * the return value and document it. In addition, it is necessary that all
-     * consumers of this interface (e.g. Public API, REST API, GUIs, ...)
-     * provide plugin mechanisms to hook adapters for the specific FieldType
+     * It is up to the implementer to define and document an array shape of a schema hash map for
+     * the return value. In addition, it is necessary that all consumers of this interface
+     * (e.g., Public API, REST API, GUIs, ...) provide plugin mechanisms to hook adapters for the specific FieldType
      * into. These adapters then need to be either shipped with the FieldType
      * or need to be implemented by a third party. If there is no adapter
      * available for a specific FieldType, it will not be usable with the
      * consumer.
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    abstract public function getSettingsSchema();
+    abstract public function getSettingsSchema(): array;
 
     /**
      * Returns a schema for the validator configuration expected by the FieldType.
      *
-     * Returns an arbitrary value, representing a schema for the validator
-     * configuration of the FieldType.
+     * Schema has to be a hash map (an `array<string, mixed>`), which contains
+     * rudimentary settings structures, like e.g., for the "ibexa_string" FieldType:
      *
-     * Explanation: There are no possible generic schemas for defining settings
-     * input, which is why no schema for the return value of this method is
-     * defined. It is up to the implementer to define and document a schema for
-     * the return value and document it. In addition, it is necessary that all
-     * consumers of this interface (e.g. Public API, REST API, GUIs, ...)
-     * provide plugin mechanisms to hook adapters for the specific FieldType
+     * ```
+     * [
+     *      'stringLength' => [
+     *          'minStringLength' => [
+     *              'type'    => 'int',
+     *              'default' => 0,
+     *          ],
+     *          'maxStringLength' => [
+     *              'type'    => 'int'
+     *              'default' => null,
+     *          ],
+     *      ],
+     *  ];
+     *  ```
+     *
+     * It is up to the implementer to define and document an array shape of a schema for
+     * the return value. In addition, it is necessary that all consumers of this interface
+     * (e.g., Public API, REST API, GUIs, ...) provide plugin mechanisms to hook adapters for the specific FieldType
      * into. These adapters then need to be either shipped with the FieldType
      * or need to be implemented by a third party. If there is no adapter
      * available for a specific FieldType, it will not be usable with the
      * consumer.
      *
-     * Best practice:
-     *
-     * It is considered best practice to return a hash map, which contains
-     * rudimentary settings structures, like e.g. for the "ibexa_string" FieldType
-     *
-     * ```
-     * [
-     *     'stringLength' => [
-     *         'minStringLength' => [
-     *             'type'    => 'int',
-     *             'default' => 0,
-     *         ],
-     *         'maxStringLength' => [
-     *             'type'    => 'int'
-     *             'default' => null,
-     *         ],
-     *     ],
-     * ];
-     * ```
-     *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    abstract public function getValidatorConfigurationSchema();
+    abstract public function getValidatorConfigurationSchema(): array;
 
     /**
      * Validates a field based on the validator configuration in the field definition.
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
      * @param \Ibexa\Contracts\Core\FieldType\Value $value The field value for which an action is performed
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    abstract public function validate(FieldDefinition $fieldDef, Value $value);
+    abstract public function validate(FieldDefinition $fieldDef, Value $value): array;
 
     /**
      * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
      *
-     * This methods determines if the given $validatorConfiguration is
+     * This method determines if the given $validatorConfiguration is
      * structurally correct and complies to the validator configuration schema
      * returned by {@see FieldType::getValidatorConfigurationSchema()}.
      *
@@ -143,70 +126,60 @@ abstract class FieldType
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    abstract public function validateValidatorConfiguration($validatorConfiguration);
+    abstract public function validateValidatorConfiguration(mixed $validatorConfiguration): array;
 
     /**
      * Applies the default values to the given $validatorConfiguration of a FieldDefinitionCreateStruct.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
-     * @param mixed $validatorConfiguration
      */
-    abstract public function applyDefaultValidatorConfiguration(&$validatorConfiguration);
+    abstract public function applyDefaultValidatorConfiguration(mixed &$validatorConfiguration): void;
 
     /**
      * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
      *
-     * This methods determines if the given $fieldSettings are structurally
+     * This method determines if the given $fieldSettings are structurally
      * correct and comply to the settings schema returned by {@see FieldType::getSettingsSchema()}.
      *
-     * @param mixed $fieldSettings
+     * @param array<string, mixed> $fieldSettings
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    abstract public function validateFieldSettings($fieldSettings);
+    abstract public function validateFieldSettings(array $fieldSettings): array;
 
     /**
      * Applies the default values to the fieldSettings of a FieldDefinitionCreateStruct.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @param array<string, mixed> $fieldSettings
      *
-     * @param mixed $fieldSettings
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    abstract public function applyDefaultSettings(&$fieldSettings);
+    abstract public function applyDefaultSettings(array &$fieldSettings): void;
 
     /**
      * Indicates if the field type supports indexing and sort keys for searching.
-     *
-     * @return bool
      */
-    abstract public function isSearchable();
+    abstract public function isSearchable(): bool;
 
     /**
      * Indicates if the field definition of this type can appear only once in the same ContentType.
-     *
-     * @return bool
      */
-    abstract public function isSingular();
+    abstract public function isSingular(): bool;
 
     /**
      * Indicates if the field definition of this type can be added to a ContentType with Content instances.
-     *
-     * @return bool
      */
-    abstract public function onlyEmptyInstance();
+    abstract public function onlyEmptyInstance(): bool;
 
     /**
      * Returns the empty value for this field type.
      *
-     * This value will be used, if no value was provided for a field of this
+     * This value will be used if no value was provided for a field of this
      * type and no default value was specified in the field definition. It is
      * also used to determine that a user intentionally (or unintentionally) did not
      * set a non-empty value.
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\Value
      */
-    abstract public function getEmptyValue();
+    abstract public function getEmptyValue(): Value;
 
     /**
      * Returns if the given $value is considered empty by the field type.
@@ -214,17 +187,13 @@ abstract class FieldType
      * Usually, only the value returned by {@see FieldType::getEmptyValue()} is
      * considered empty. The given $value can be safely assumed to have already
      * been processed by {@see FieldType::acceptValue()}.
-     *
-     * @param \Ibexa\Contracts\Core\FieldType\Value $value
-     *
-     * @return bool
      */
-    abstract public function isEmptyValue(Value $value);
+    abstract public function isEmptyValue(Value $value): bool;
 
     /**
      * Potentially builds and checks the type and structure of the $inputValue.
      *
-     * This method first inspects $inputValue and convert it into a dedicated
+     * This method first inspects $inputValue and converts it into a dedicated
      * value object.
      *
      * After that, the value is checked for structural validity.
@@ -233,55 +202,43 @@ abstract class FieldType
      * format.
      *
      * Note that this method must also cope with the empty value for the field
-     * type as e.g. returned by {@see FieldType::getEmptyValue()}.
+     * type as e.g., returned by {@see FieldType::getEmptyValue()}.
+     *
+     * @return \Ibexa\Contracts\Core\FieldType\Value The potentially converted and structurally plausible value.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the parameter is not of the supported value sub type
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if the value does not match the expected structure
-     *
-     * @param mixed $inputValue
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\Value The potentially converted and structurally plausible value.
      */
-    abstract public function acceptValue($inputValue);
+    abstract public function acceptValue(mixed $inputValue): Value;
 
     /**
-     * Converts an $hash to the Value defined by the field type.
+     * Converts a $hash to the Value defined by the field type.
      *
      * This is the reverse operation to {@see FieldType::toHash()}. At least the hash
      * format generated by {@see FieldType::toHash()} must be converted in reverse.
      * Additional formats might be supported in the rare case that this is
      * necessary. See the class description for more details on a hash format.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\Value
      */
-    abstract public function fromHash($hash);
+    abstract public function fromHash(mixed $hash): Value;
 
     /**
      * Converts the given $value into a plain hash format.
      *
      * Converts the given $value into a plain hash format, which can be used to
-     * transfer the value through plain text formats, e.g. XML, which do not
+     * transfer the value through plain text formats, e.g., XML, which do not
      * support complex structures like objects. See the class level doc block
      * for additional information. See the class description for more details on a hash format.
-     *
-     * @param \Ibexa\Contracts\Core\FieldType\Value $value
-     *
-     * @return mixed
      */
-    abstract public function toHash(Value $value);
+    abstract public function toHash(Value $value): mixed;
 
     /**
      * Converts the given $fieldSettings to a simple hash format.
      *
      * See the class description for more details on a hash format.
      *
-     * @param mixed $fieldSettings
-     *
-     * @return array|scalar|null
+     * @return array<string, mixed>|scalar|null
      */
-    abstract public function fieldSettingsToHash($fieldSettings);
+    abstract public function fieldSettingsToHash(mixed $fieldSettings): mixed;
 
     /**
      * Converts the given $fieldSettingsHash to field settings of the type.
@@ -289,22 +246,20 @@ abstract class FieldType
      * This is the reverse operation of {@see FieldType::fieldSettingsToHash()}.
      * See the class description for more details on a hash format.
      *
-     * @param array|scalar|null $fieldSettingsHash
+     * @param array<string, mixed>|scalar|null $fieldSettingsHash
      *
      * @return mixed
      */
-    abstract public function fieldSettingsFromHash($fieldSettingsHash);
+    abstract public function fieldSettingsFromHash(mixed $fieldSettingsHash): mixed;
 
     /**
      * Converts the given $validatorConfiguration to a simple hash format.
      *
      * See the class description for more details on a hash format.
      *
-     * @param mixed $validatorConfiguration
-     *
-     * @return array|scalar|null
+     * @return array<string, mixed>|scalar|null
      */
-    abstract public function validatorConfigurationToHash($validatorConfiguration);
+    abstract public function validatorConfigurationToHash(mixed $validatorConfiguration): mixed;
 
     /**
      * Converts the given $validatorConfigurationHash to a validator
@@ -312,16 +267,14 @@ abstract class FieldType
      *
      * See the class description for more details on a hash format.
      *
-     * @param array|scalar|null $validatorConfigurationHash
-     *
-     * @return mixed
+     * @param array<string, mixed>|scalar|null $validatorConfigurationHash
      */
-    abstract public function validatorConfigurationFromHash($validatorConfigurationHash);
+    abstract public function validatorConfigurationFromHash(mixed $validatorConfigurationHash): mixed;
 
     /**
      * Converts a $value to a persistence value.
      *
-     * In this method the field type puts the data which is stored in the field of content in the repository
+     * In this method, the field type puts the data which is stored in the field of content in the repository
      * into the property FieldValue::data. The format of $data is a primitive, an array (map) or an object, which
      * is then canonically converted to e.g. json/xml structures by future storage engines without
      * further conversions. For mapping the $data to the legacy database an appropriate Converter
@@ -340,43 +293,33 @@ abstract class FieldType
      *
      * @return \Ibexa\Contracts\Core\Persistence\Content\FieldValue the value processed by the storage engine
      */
-    abstract public function toPersistenceValue(Value $value);
+    abstract public function toPersistenceValue(Value $value): FieldValue;
 
     /**
      * Converts a persistence $value to a Value.
      *
      * This method builds a field type value from the $data and $externalData properties.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\Value
      */
-    abstract public function fromPersistenceValue(FieldValue $fieldValue);
+    abstract public function fromPersistenceValue(FieldValue $fieldValue): Value;
 
     /**
-     * Returns relation data extracted from value.
+     * Returns relation data extracted from the given Value.
      *
-     * Not intended for \Ibexa\Contracts\Core\Repository\Values\Content\Relation::COMMON type relations,
+     * Not intended for {@see \Ibexa\Contracts\Core\Repository\Values\Content\Relation::COMMON} type relations,
      * there is an API for handling those.
      *
-     * @param \Ibexa\Contracts\Core\FieldType\Value $value
-     *
-     * @return array Hash with relation type as key and array of destination content IDs as value.
+     * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\RelationType, int[]> Hash with a relation type as key and an array of destination content IDs as value.
      *
      * Example:
      * ```
      * [
-     *     \Ibexa\Contracts\Core\Repository\Values\Content\Relation::LINK => [
-     *         'contentIds' => [12, 13, 14],
-     *         'locationIds' => [24]
-     *     ],
-     *     \Ibexa\Contracts\Core\Repository\Values\Content\Relation::EMBED => [
-     *         'contentIds" => [12],
-     *         'locationIds' => [24, 45]
-     *     ],
-     *     \Ibexa\Contracts\Core\Repository\Values\Content\Relation::FIELD => [12]
+     *     RelationType::LINK->value => [12, 13, 14],
+     *     RelationType::EMBED->value => [12],
+     *     RelationType::FIELD->value => [12]
      * ]
      * ```
+     *
+     * @see \Ibexa\Contracts\Core\Repository\Values\Content\RelationType
      */
-    abstract public function getRelations(Value $value);
+    abstract public function getRelations(Value $value): array;
 }

--- a/src/contracts/FieldType/Value.php
+++ b/src/contracts/FieldType/Value.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\FieldType;
 
@@ -14,8 +15,6 @@ interface Value
 {
     /**
      * Returns a string representation of the field value.
-     *
-     * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/contracts/Persistence/Content/FieldValue.php
+++ b/src/contracts/Persistence/Content/FieldValue.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Persistence\Content;
 
@@ -16,12 +17,14 @@ class FieldValue extends ValueObject
      *
      * Either a scalar (primitive), null or an array (map) of scalar values.
      *
-     * Note: For the legacy storage engine we will need adaptors to map them to
+     * Note: For the legacy storage engine, we will need adaptors to map them to
      * the existing database fields, like data_int, data_float, data_text.
      *
-     * @var int|float|bool|string|array|null
+     * @var int|float|bool|string|array<mixed>|null
+     *
+     * @phpstan-var scalar|array<mixed>|null
      */
-    public $data;
+    public mixed $data;
 
     /**
      * Mixed external field data.
@@ -35,15 +38,17 @@ class FieldValue extends ValueObject
      *
      * @var mixed
      */
-    public $externalData;
+    public mixed $externalData;
 
     /**
      * A value which can be used for sorting.
      *
-     * Note: For the "old" storage engine we will need adaptors to map them to
+     * Note: For the "old" storage engine, we will need adaptors to map them to
      * the existing database fields, like sort_key_int, sort_key_string
      *
      * @var int|float|bool|string|null
+     *
+     * @phpstan-var scalar|null
      */
-    public $sortKey;
+    public mixed $sortKey;
 }

--- a/src/contracts/Repository/FieldType.php
+++ b/src/contracts/Repository/FieldType.php
@@ -26,30 +26,16 @@ interface FieldType
     public function getFieldTypeIdentifier(): string;
 
     /**
-     * Returns a human readable string representation from the given $value.
+     * Returns a human-readable string representation from the given $value.
      */
     public function getName(Value $value, FieldDefinition $fieldDefinition, string $languageCode): string;
 
     /**
-     * Returns a schema for the settings expected by the FieldType.
+     * @see \Ibexa\Contracts\Core\FieldType\FieldType::getSettingsSchema
      *
-     * Returns an arbitrary value, representing a schema for the settings of
-     * the FieldType.
-     *
-     * Explanation: There are no possible generic schemas for defining settings
-     * input, which is why no schema for the return value of this method is
-     * defined. It is up to the implementer to define and document a schema for
-     * the return value and document it. In addition, it is necessary that all
-     * consumers of this interface (e.g. Public API, REST API, GUIs, ...)
-     * provide plugin mechanisms to hook adapters for the specific FieldType
-     * into. These adapters then need to be either shipped with the FieldType
-     * or need to be implemented by a third party. If there is no adapter
-     * available for a specific FieldType, it will not be usable with the
-     * consumer.
-     *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    public function getSettingsSchema();
+    public function getSettingsSchema(): array;
 
     /**
      * Returns a schema for the validator configuration expected by the FieldType.

--- a/src/lib/FieldType/Author/AuthorCollection.php
+++ b/src/lib/FieldType/Author/AuthorCollection.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Author;
 

--- a/src/lib/FieldType/Author/Type.php
+++ b/src/lib/FieldType/Author/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Author;
 
@@ -38,7 +39,7 @@ class Type extends FieldType implements TranslationContainerInterface
      */
     public const DEFAULT_CURRENT_USER = 1;
 
-    protected $settingsSchema = [
+    protected array $settingsSchema = [
         'defaultAuthor' => [
             'type' => 'choice',
             'default' => self::DEFAULT_VALUE_EMPTY,
@@ -60,13 +61,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return $value->authors[0]->name ?? '';
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Author\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
@@ -105,10 +100,7 @@ class Type extends FieldType implements TranslationContainerInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): string|false
     {
         if (empty($value->authors)) {
             return false;
@@ -125,13 +117,9 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $hash to the Value defined by the field type.
-     *
      * @phpstan-param TAuthorHash $hash
-     *
-     * @return \Ibexa\Core\FieldType\Author\Value $value
      */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         return new Value(
             array_map(
@@ -144,8 +132,6 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Author\Value $value
      *
      * @phpstan-return TAuthorHash
@@ -160,24 +146,12 @@ class Type extends FieldType implements TranslationContainerInterface
         );
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;
     }
 
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param array $fieldSettings
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings(array $fieldSettings): array
     {
         $validationErrors = [];
 
@@ -188,13 +162,11 @@ class Type extends FieldType implements TranslationContainerInterface
                 $validationErrors[] = $settingNameError;
             }
 
-            switch ($name) {
-                case 'defaultAuthor':
-                    $settingValueError = $this->validateDefaultAuthorSetting($name, $value);
-                    if ($settingValueError instanceof ValidationError) {
-                        $validationErrors[] = $settingValueError;
-                    }
-                    break;
+            if ($name === 'defaultAuthor') {
+                $settingValueError = $this->validateDefaultAuthorSetting($name, $value);
+                if ($settingValueError instanceof ValidationError) {
+                    $validationErrors[] = $settingValueError;
+                }
             }
         }
 

--- a/src/lib/FieldType/Author/Value.php
+++ b/src/lib/FieldType/Author/Value.php
@@ -4,22 +4,21 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Author;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Author field type.
+ * Value for the Author field type.
  */
 class Value extends BaseValue
 {
     /**
      * List of authors.
-     *
-     * @var \Ibexa\Core\FieldType\Author\AuthorCollection
      */
-    public $authors;
+    public readonly AuthorCollection $authors;
 
     /**
      * Construct a new Value object and initialize with $authors.
@@ -29,20 +28,19 @@ class Value extends BaseValue
     public function __construct(array $authors = [])
     {
         $this->authors = new AuthorCollection($authors);
+
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
-        if (empty($this->authors)) {
+        if ($this->authors->count() <= 0) {
             return '';
         }
 
         $authorNames = [];
-
-        if ($this->authors instanceof AuthorCollection) {
-            foreach ($this->authors as $author) {
-                $authorNames[] = $author->name;
-            }
+        foreach ($this->authors as $author) {
+            $authorNames[] = $author->name;
         }
 
         return implode(', ', $authorNames);

--- a/src/lib/FieldType/BaseNumericType.php
+++ b/src/lib/FieldType/BaseNumericType.php
@@ -26,11 +26,11 @@ abstract class BaseNumericType extends FieldType
     /**
      * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
      *
-     * @param array<string, mixed> $validatorConfiguration
+     * @param mixed $validatorConfiguration
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validateValidatorConfiguration($validatorConfiguration): array
+    public function validateValidatorConfiguration(mixed $validatorConfiguration): array
     {
         $validationErrors = [];
         $validatorValidationErrors = [];

--- a/src/lib/FieldType/BaseTextType.php
+++ b/src/lib/FieldType/BaseTextType.php
@@ -41,7 +41,7 @@ abstract class BaseTextType extends FieldType
      */
     public function isEmptyValue(FieldTypeValueInterface $value): bool
     {
-        return $value->text === null || trim($value->text) === '';
+        return trim($value->text) === '';
     }
 
     /**

--- a/src/lib/FieldType/BinaryBase/Type.php
+++ b/src/lib/FieldType/BinaryBase/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\BinaryBase;
 
@@ -22,7 +23,7 @@ use Ibexa\Core\FieldType\Value as BaseValue;
  */
 abstract class Type extends FieldType
 {
-    protected $validatorConfigurationSchema = [
+    protected array $validatorConfigurationSchema = [
         'FileSizeValidator' => [
             'maxFileSize' => [
                 'type' => 'int',
@@ -169,24 +170,13 @@ abstract class Type extends FieldType
 
     /**
      * BinaryBase does not support sorting, yet.
-     *
-     * @param \Ibexa\Core\FieldType\BinaryBase\Value $value
-     *
-     * @return mixed
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): false
     {
         return false;
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\BinaryBase\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -196,13 +186,11 @@ abstract class Type extends FieldType
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\BinaryBase\Value $value
      *
-     * @return mixed
+     * @return array<string, mixed>|null
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?array
     {
         return [
             'id' => $value->id,
@@ -216,7 +204,7 @@ abstract class Type extends FieldType
         ];
     }
 
-    public function toPersistenceValue(SPIValue $value)
+    public function toPersistenceValue(SPIValue $value): PersistenceValue
     {
         // Store original data as external (to indicate they need to be stored)
         return new PersistenceValue(
@@ -228,16 +216,7 @@ abstract class Type extends FieldType
         );
     }
 
-    /**
-     * Converts a persistence $fieldValue to a Value.
-     *
-     * This method builds a field type value from the $data and $externalData properties.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
-     *
-     * @return \Ibexa\Core\FieldType\BinaryBase\Value
-     */
-    public function fromPersistenceValue(PersistenceValue $fieldValue)
+    public function fromPersistenceValue(PersistenceValue $fieldValue): SPIValue
     {
         // Restored data comes in $data, since it has already been processed
         // there might be more data in the persistence value than needed here
@@ -263,14 +242,14 @@ abstract class Type extends FieldType
     /**
      * Validates a field based on the validators in the field definition.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
      * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
      * @param \Ibexa\Core\FieldType\BinaryBase\Value $fieldValue The field value for which an action is performed
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue): array
     {
         $errors = [];
 
@@ -318,7 +297,7 @@ abstract class Type extends FieldType
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validateValidatorConfiguration($validatorConfiguration)
+    public function validateValidatorConfiguration(mixed $validatorConfiguration): array
     {
         $validationErrors = [];
 
@@ -365,12 +344,7 @@ abstract class Type extends FieldType
         return $validationErrors;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
-    public function isSearchable()
+    public function isSearchable(): bool
     {
         return true;
     }

--- a/src/lib/FieldType/BinaryBase/Value.php
+++ b/src/lib/FieldType/BinaryBase/Value.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\BinaryBase;
 
@@ -12,7 +13,7 @@ use Ibexa\Core\FieldType\Value as BaseValue;
 /**
  * Base value for binary field types.
  *
- * @property string $path Used for BC with 5.0 (EZP-20948). Equivalent to $id.
+ * @property string $path Used for BC with legacy 5.0 (EZP-20948). Equivalent to $id.
  * @property-read string $id Unique file ID, set by storage. Read only since 5.3 (EZP-22808).
  */
 abstract class Value extends BaseValue
@@ -20,61 +21,59 @@ abstract class Value extends BaseValue
     /**
      * Unique file ID, set by storage.
      *
-     * Since 5.3 this is not used for input, use self::$inputUri instead
+     * Since legacy 5.3 this is not used for input, use self::$inputUri instead
      *
      * @var string|null
      */
-    protected $id;
+    protected ?string $id = null;
 
     /**
      * Input file URI, as a path to a file on a disk.
      *
      * @var string|null
      */
-    public $inputUri;
+    public ?string $inputUri = null;
 
     /**
      * Display file name.
-     *
-     * @var string|null
      */
-    public $fileName;
+    public ?string $fileName = null;
 
     /**
      * Size of the image file.
-     *
-     * @var int|null
      */
-    public $fileSize;
+    public ?int $fileSize = null;
 
     /**
      * Mime type of the file.
-     *
-     * @var string|null
      */
-    public $mimeType;
+    public ?string $mimeType = null;
 
     /**
      * HTTP URI.
-     *
-     * @var string|null
      */
-    public $uri;
+    public ?string $uri = null;
 
     /**
-     * Construct a new Value object.
-     *
-     * @param array $fileData
+     * @param array{
+     *     inputUri?: string|null,
+     *     fileName?: string|null,
+     *     fileSize?: int|null,
+     *     mimeType?: string|null,
+     *     uri?: string|null,
+     *     id?: string|null,
+     *     path?: string|null
+     * } $fileData
      */
     public function __construct(array $fileData = [])
     {
-        // BC with 5.0 (EZP-20948)
+        // BC with legacy 5.0 (EZP-20948)
         if (isset($fileData['path'])) {
             $fileData['id'] = $fileData['path'];
             unset($fileData['path']);
         }
 
-        // BC with 5.2 (EZP-22808)
+        // BC with legacy 5.2 (EZP-22808)
         if (isset($fileData['id']) && file_exists($fileData['id'])) {
             $fileData['inputUri'] = $fileData['id'];
             unset($fileData['id']);
@@ -85,15 +84,13 @@ abstract class Value extends BaseValue
 
     /**
      * Returns a string representation of the field value.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->uri;
     }
 
-    public function __get($propertyName)
+    public function __get($propertyName): mixed
     {
         if ($propertyName === 'path') {
             return $this->inputUri;
@@ -102,7 +99,7 @@ abstract class Value extends BaseValue
         return parent::__get($propertyName);
     }
 
-    public function __set($propertyName, $propertyValue)
+    public function __set($propertyName, $propertyValue): void
     {
         // BC with 5.0 (EZP-20948)
         if ($propertyName === 'path') {
@@ -114,7 +111,7 @@ abstract class Value extends BaseValue
         }
     }
 
-    public function __isset($propertyName)
+    public function __isset($propertyName): bool
     {
         if ($propertyName === 'path') {
             return true;

--- a/src/lib/FieldType/BinaryFile/Type.php
+++ b/src/lib/FieldType/BinaryFile/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\BinaryFile;
 
@@ -31,13 +32,7 @@ class Type extends BinaryBaseType implements TranslationContainerInterface
         return 'ibexa_binaryfile';
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\BinaryFile\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
@@ -71,13 +66,9 @@ class Type extends BinaryBaseType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\BinaryFile\Value $value
-     *
-     * @return mixed
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?array
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -90,26 +81,16 @@ class Type extends BinaryBaseType implements TranslationContainerInterface
         return $hash;
     }
 
-    /**
-     * Converts a persistence $fieldValue to a Value.
-     *
-     * This method builds a field type value from the $data and $externalData properties.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
-     *
-     * @return \Ibexa\Core\FieldType\BinaryFile\Value
-     */
-    public function fromPersistenceValue(FieldValue $fieldValue)
+    public function fromPersistenceValue(FieldValue $fieldValue): SPIValue
     {
         if ($fieldValue->externalData === null) {
             return $this->getEmptyValue();
         }
 
+        /** @var \Ibexa\Core\FieldType\BinaryFile\Value $result */
         $result = parent::fromPersistenceValue($fieldValue);
 
-        $result->downloadCount = (isset($fieldValue->externalData['downloadCount'])
-            ? $fieldValue->externalData['downloadCount']
-            : 0);
+        $result->downloadCount = (int)($fieldValue->externalData['downloadCount'] ?? 0);
 
         return $result;
     }

--- a/src/lib/FieldType/BinaryFile/Value.php
+++ b/src/lib/FieldType/BinaryFile/Value.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\BinaryFile;
 
@@ -16,8 +17,6 @@ class Value extends BaseValue
 {
     /**
      * Number of times the file has been downloaded through content/download module.
-     *
-     * @var int
      */
-    public $downloadCount = 0;
+    public int $downloadCount = 0;
 }

--- a/src/lib/FieldType/Checkbox/Type.php
+++ b/src/lib/FieldType/Checkbox/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Checkbox;
 
@@ -40,13 +41,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return $value->bool ? '1' : '0';
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Checkbox\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value(false);
     }
@@ -99,46 +94,26 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns information for FieldValue->$sortKey relevant to the field type.
-     *
      * @param \Ibexa\Core\FieldType\Checkbox\Value $value
-     *
-     * @return int
      */
-    protected function getSortInfo(BaseValue $value): int
+    protected function getSortInfo(SPIValue $value): int
     {
         return (int)$value->bool;
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\Checkbox\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         return new Value($hash);
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Checkbox\Value $value
-     *
-     * @return mixed
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): bool
     {
         return $value->bool;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;

--- a/src/lib/FieldType/Checkbox/Value.php
+++ b/src/lib/FieldType/Checkbox/Value.php
@@ -4,37 +4,23 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Checkbox;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Checkbox field type.
+ * Value for the Checkbox field type.
  */
 class Value extends BaseValue
 {
-    /**
-     * Boolean value.
-     *
-     * @var bool
-     */
-    public $bool;
-
-    /**
-     * Construct a new Value object and initialize it $boolValue.
-     *
-     * @param bool $boolValue
-     */
-    public function __construct($boolValue = false)
+    public function __construct(public readonly bool $bool = false)
     {
-        $this->bool = $boolValue;
+        parent::__construct();
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->bool ? '1' : '0';
     }

--- a/src/lib/FieldType/Country/Value.php
+++ b/src/lib/FieldType/Country/Value.php
@@ -4,46 +4,40 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Country;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Country field type.
+ * Value for a Country field type.
+ *
+ * @phpstan-type TCountriesHash array<string, array{Name: string, Alpha2: string, Alpha3: string, IDC: int}>
  */
 class Value extends BaseValue
 {
     /**
-     * Associative array with Alpha2 codes as keys and countries data as values.
+     * @phpstan-param TCountriesHash $countries
      *
-     * Example:
-     * <code>
-     *  array(
-     *      "JP" => array(
-     *          "Name" => "Japan",
-     *          "Alpha2" => "JP",
-     *          "Alpha3" => "JPN",
-     *          "IDC" => 81
-     *      )
-     *  )
-     * </code>
-     *
-     * @var array[]
+     * Example Country hash entry:
+     * ```
+     *    [
+     *        "JP" => [
+     *            "Name" => "Japan",
+     *            "Alpha2" => "JP",
+     *            "Alpha3" => "JPN",
+     *            "IDC" => 81
+     *        ]
+     *    ]
+     * ```
      */
-    public $countries = [];
-
-    /**
-     * Construct a new Value object and initialize it with given $data.
-     *
-     * @param array[] $countries
-     */
-    public function __construct(array $countries = [])
+    public function __construct(public readonly array $countries = [])
     {
-        $this->countries = $countries;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return implode(', ', array_column($this->countries, 'Name'));
     }

--- a/src/lib/FieldType/Date/Type.php
+++ b/src/lib/FieldType/Date/Type.php
@@ -4,10 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Date;
 
 use DateTime;
+use DateTimeInterface;
 use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
@@ -29,7 +31,7 @@ class Type extends FieldType implements TranslationContainerInterface
      */
     public const DEFAULT_CURRENT_DATE = 1;
 
-    protected $settingsSchema = [
+    protected array $settingsSchema = [
         // One of the DEFAULT_* class constants
         'defaultType' => [
             'type' => 'choice',
@@ -59,13 +61,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return $value->date->format('l d F Y');
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Date\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
@@ -113,32 +109,22 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns information for FieldValue->$sortKey relevant to the field type.
-     *
      * @param \Ibexa\Core\FieldType\Date\Value $value
-     *
-     * @return mixed
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): int|null
     {
-        if ($value->date === null) {
-            return null;
-        }
-
-        return $value->date->getTimestamp();
+        return $value->date?->getTimestamp();
     }
 
     /**
-     * Converts an $hash to the Value defined by the field type.
-     *
      * @param mixed $hash Null or associative array containing one of the following (first value found in the order below is picked):
      *                    'rfc850': Date in RFC 850 format (DateTime::RFC850)
      *                    'timestring': Date in parseable string format supported by DateTime (e.g. 'now', '+3 days')
      *                    'timestamp': Unix timestamp
      *
-     * @return \Ibexa\Core\FieldType\Date\Value $value
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -156,13 +142,11 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Date\Value $value
      *
-     * @return mixed
+     * @return array{timestamp: int, rfc850: string|null}|null
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?array
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -171,7 +155,7 @@ class Type extends FieldType implements TranslationContainerInterface
         if ($value->date instanceof DateTime) {
             return [
                 'timestamp' => $value->date->getTimestamp(),
-                'rfc850' => $value->date->format(DateTime::RFC850),
+                'rfc850' => $value->date->format(DateTimeInterface::RFC850),
             ];
         }
 
@@ -181,24 +165,12 @@ class Type extends FieldType implements TranslationContainerInterface
         ];
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;
     }
 
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings(array $fieldSettings): array
     {
         $validationErrors = [];
 

--- a/src/lib/FieldType/Date/Value.php
+++ b/src/lib/FieldType/Date/Value.php
@@ -4,86 +4,72 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Date;
 
 use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentValue;
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Date field type.
+ * Value for the Date field type.
  * Date should always be represented in UTC.
  */
 class Value extends BaseValue
 {
     /**
      * Date content.
-     *
-     * @var \DateTime|null
      */
-    public $date;
+    public readonly ?DateTimeInterface $date;
 
     /**
      * Date format to be used by {@link __toString()}.
-     *
-     * @var string
      */
-    public $stringFormat = 'l d F Y';
+    public string $stringFormat = 'l d F Y';
 
     /**
-     * Construct a new Value object and initialize with $dateTime.
-     *
      * @param \DateTime|null $dateTime Date as a DateTime object
      */
-    public function __construct(DateTime $dateTime = null)
+    public function __construct(?DateTimeInterface $dateTime = null)
     {
         if ($dateTime !== null) {
             $dateTime = clone $dateTime;
             $dateTime->setTime(0, 0, 0);
         }
         $this->date = $dateTime;
+
+        parent::__construct();
     }
 
     /**
-     * Creates a Value from the given $dateString.
-     *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
-     * @param string $dateString
-     *
-     * @return \Ibexa\Core\FieldType\Date\Value
      */
-    public static function fromString($dateString)
+    public static function fromString(string $dateString): Value
     {
         try {
-            return new static(new DateTime($dateString, new DateTimeZone('UTC')));
+            return new self(new DateTime($dateString, new DateTimeZone('UTC')));
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$dateString', $dateString, __CLASS__, $e);
         }
     }
 
     /**
-     * Creates a Value from the given $timestamp.
-     *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
-     * @param int $timestamp
-     *
-     * @return \Ibexa\Core\FieldType\Date\Value
      */
-    public static function fromTimestamp($timestamp)
+    public static function fromTimestamp(int $timestamp): Value
     {
         try {
-            return new static(new DateTime("@{$timestamp}"));
+            return new self(new DateTime("@{$timestamp}"));
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$timestamp', $timestamp, __CLASS__, $e);
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         if (!$this->date instanceof DateTime) {
             return '';

--- a/src/lib/FieldType/DateAndTime/Type.php
+++ b/src/lib/FieldType/DateAndTime/Type.php
@@ -4,11 +4,13 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\DateAndTime;
 
 use DateInterval;
 use DateTime;
+use DateTimeInterface;
 use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
@@ -27,7 +29,7 @@ class Type extends FieldType implements TranslationContainerInterface
     public const DEFAULT_CURRENT_DATE = 1;
     public const DEFAULT_CURRENT_DATE_ADJUSTED = 2;
 
-    protected $settingsSchema = [
+    protected array $settingsSchema = [
         'useSeconds' => [
             'type' => 'bool',
             'default' => false,
@@ -69,13 +71,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return $value->value->format('D Y-d-m H:i:s');
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\DateAndTime\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
@@ -123,32 +119,20 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns information for FieldValue->$sortKey relevant to the field type.
-     *
      * @param \Ibexa\Core\FieldType\DateAndTime\Value $value
-     *
-     * @return int|null
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): int|null
     {
-        if ($value->value === null) {
-            return null;
-        }
-
-        return $value->value->getTimestamp();
+        return $value->value?->getTimestamp();
     }
 
     /**
-     * Converts an $hash to the Value defined by the field type.
-     *
      * @param mixed $hash Null or associative array containing one of the following (first value found in the order below is picked):
      *                    'rfc850': Date in RFC 850 format (DateTime::RFC850)
      *                    'timestring': Date in parseable string format supported by DateTime (e.g. 'now', '+3 days')
      *                    'timestamp': Unix timestamp
-     *
-     * @return \Ibexa\Core\FieldType\DateAndTime\Value $value
      */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -166,13 +150,11 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\DateAndTime\Value $value
      *
-     * @return mixed
+     * @return array{timestamp: int, rfc850: string|null}|null
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?array
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -181,7 +163,7 @@ class Type extends FieldType implements TranslationContainerInterface
         if ($value->value instanceof DateTime) {
             return [
                 'timestamp' => $value->value->getTimestamp(),
-                'rfc850' => $value->value->format(DateTime::RFC850),
+                'rfc850' => $value->value->format(DateTimeInterface::RFC850),
             ];
         }
 
@@ -191,24 +173,12 @@ class Type extends FieldType implements TranslationContainerInterface
         ];
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;
     }
 
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings(array $fieldSettings): array
     {
         $validationErrors = [];
 
@@ -289,9 +259,9 @@ class Type extends FieldType implements TranslationContainerInterface
      *
      * @param mixed $fieldSettings
      *
-     * @return array|scalar|null
+     * @return mixed
      */
-    public function fieldSettingsToHash($fieldSettings)
+    public function fieldSettingsToHash(mixed $fieldSettings): mixed
     {
         $fieldSettingsHash = parent::fieldSettingsToHash($fieldSettings);
 
@@ -314,11 +284,11 @@ class Type extends FieldType implements TranslationContainerInterface
      * a hash format. Overwrite this in your specific implementation, if
      * necessary.
      *
-     * @param array|scalar|null $fieldSettingsHash
+     * @param mixed $fieldSettingsHash
      *
      * @return mixed
      */
-    public function fieldSettingsFromHash($fieldSettingsHash)
+    public function fieldSettingsFromHash(mixed $fieldSettingsHash): mixed
     {
         $fieldSettings = parent::fieldSettingsFromHash($fieldSettingsHash);
 

--- a/src/lib/FieldType/DateAndTime/Value.php
+++ b/src/lib/FieldType/DateAndTime/Value.php
@@ -4,78 +4,70 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\DateAndTime;
 
 use DateTime;
+use DateTimeInterface;
 use Exception;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentValue;
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for DateAndTime field type.
+ * Value for the DateAndTime field type.
  */
 class Value extends BaseValue
 {
     /**
      * Date content.
-     *
-     * @var \DateTime|null
      */
-    public $value;
+    public readonly ?DateTimeInterface $value;
 
     /**
      * Date format to be used by {@link __toString()}.
-     *
-     * @var string
      */
-    public $stringFormat = 'U';
+    public string $stringFormat = 'U';
 
     /**
      * Construct a new Value object and initialize with $dateTime.
      *
      * @param \DateTime|null $dateTime Date/Time as a DateTime object
      */
-    public function __construct(DateTime $dateTime = null)
+    public function __construct(?DateTimeInterface $dateTime = null)
     {
         $this->value = $dateTime;
+
+        parent::__construct();
     }
 
     /**
-     * Creates a Value from the given $dateString.
-     *
-     * @param string $dateString
-     *
-     * @return \Ibexa\Core\FieldType\DateAndTime\Value
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public static function fromString($dateString)
+    public static function fromString(string $dateString): Value
     {
         try {
-            return new static(new DateTime($dateString));
+            return new self(new DateTime($dateString));
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$dateString', $dateString, __CLASS__, $e);
         }
     }
 
     /**
-     * Creates a Value from the given $timestamp.
-     *
-     * @param int $timestamp
-     *
-     * @return \Ibexa\Core\FieldType\DateAndTime\Value
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public static function fromTimestamp($timestamp)
+    public static function fromTimestamp(int $timestamp): Value
     {
         try {
-            return new static(new DateTime("@{$timestamp}"));
+            return new self(new DateTime("@$timestamp"));
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$timestamp', $timestamp, __CLASS__, $e);
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
-        if (!$this->value instanceof DateTime) {
+        if (null === $this->value) {
             return '';
         }
 

--- a/src/lib/FieldType/EmailAddress/Type.php
+++ b/src/lib/FieldType/EmailAddress/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\EmailAddress;
 
@@ -24,7 +25,7 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
  */
 class Type extends FieldType implements TranslationContainerInterface
 {
-    protected $validatorConfigurationSchema = [
+    protected array $validatorConfigurationSchema = [
         'EmailAddressValidator' => [],
     ];
 
@@ -43,7 +44,7 @@ class Type extends FieldType implements TranslationContainerInterface
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validateValidatorConfiguration($validatorConfiguration)
+    public function validateValidatorConfiguration(mixed $validatorConfiguration): array
     {
         $validationErrors = [];
         $validator = new EmailAddressValidator();
@@ -69,29 +70,29 @@ class Type extends FieldType implements TranslationContainerInterface
     /**
      * Validates a field based on the validators in the field definition.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
-     * @param \Ibexa\Core\FieldType\EmailAddress\Value $fieldValue The field value for which an action is performed
+     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
+     * @param \Ibexa\Core\FieldType\EmailAddress\Value $value The field value for which an action is performed
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    public function validate(FieldDefinition $fieldDef, SPIValue $value): array
     {
         $errors = [];
 
-        if ($this->isEmptyValue($fieldValue)) {
+        if ($this->isEmptyValue($value)) {
             return $errors;
         }
 
-        $validatorConfiguration = $fieldDefinition->getValidatorConfiguration();
+        $validatorConfiguration = $fieldDef->getValidatorConfiguration();
         $constraints = isset($validatorConfiguration['EmailAddressValidator']) ?
             $validatorConfiguration['EmailAddressValidator'] :
             [];
         $validator = new EmailAddressValidator();
         $validator->initializeWithConstraints($constraints);
 
-        if (!$validator->validate($fieldValue)) {
+        if (!$validator->validate($value)) {
             return $validator->getMessage();
         }
 
@@ -108,13 +109,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return 'ibexa_email';
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\EmailAddress\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
@@ -154,27 +149,16 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns information for FieldValue->$sortKey relevant to the field type.
-     *
-     * @todo String normalization should occur here.
-     *
      * @param \Ibexa\Core\FieldType\EmailAddress\Value $value
      *
-     * @return string
+     * @todo String normalization should occur here.
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): string
     {
         return $value->email;
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\EmailAddress\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -184,13 +168,9 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\EmailAddress\Value $value
-     *
-     * @return mixed
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?string
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -199,11 +179,6 @@ class Type extends FieldType implements TranslationContainerInterface
         return $value->email;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;

--- a/src/lib/FieldType/EmailAddress/Value.php
+++ b/src/lib/FieldType/EmailAddress/Value.php
@@ -4,35 +4,27 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\EmailAddress;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for EMailAddress field type.
+ * Value for the EmailAddress field type.
  */
 class Value extends BaseValue
 {
     /**
-     * Email address.
-     *
-     * @var string
-     */
-    public $email;
-
-    /**
      * Construct a new Value object and initialize its $email.
-     *
-     * @param string $email
      */
-    public function __construct($email = '')
+    public function __construct(public readonly string $email = '')
     {
-        $this->email = $email;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
-        return (string)$this->email;
+        return $this->email;
     }
 }

--- a/src/lib/FieldType/Float/Type.php
+++ b/src/lib/FieldType/Float/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Float;
 
@@ -23,7 +24,7 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
  */
 class Type extends BaseNumericType implements TranslationContainerInterface
 {
-    protected $validatorConfigurationSchema = [
+    protected array $validatorConfigurationSchema = [
         'FloatValueValidator' => [
             'minFloatValue' => [
                 'type' => 'float',
@@ -59,10 +60,6 @@ class Type extends BaseNumericType implements TranslationContainerInterface
         return (string)$value;
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     */
     public function getEmptyValue(): Value
     {
         return new Value();
@@ -112,23 +109,14 @@ class Type extends BaseNumericType implements TranslationContainerInterface
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @param \Ibexa\Core\FieldType\Float\Value $value
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): ?float
     {
         return $value->value;
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\Float\Value $value
-     */
-    public function fromHash($hash): Value
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -138,13 +126,9 @@ class Type extends BaseNumericType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Float\Value $value
-     *
-     * @return mixed
      */
-    public function toHash(SPIValue $value): mixed
+    public function toHash(SPIValue $value): ?float
     {
         if ($this->isEmptyValue($value)) {
             return null;

--- a/src/lib/FieldType/Float/Value.php
+++ b/src/lib/FieldType/Float/Value.php
@@ -4,34 +4,23 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Float;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Float field type.
+ * Value for the Float field type.
  */
 class Value extends BaseValue
 {
-    /**
-     * Float content.
-     *
-     * @var float|null
-     */
-    public $value;
-
-    /**
-     * Construct a new Value object and initialize with $value.
-     *
-     * @param float|null $value
-     */
-    public function __construct($value = null)
+    public function __construct(public readonly ?float $value = null)
     {
-        $this->value = $value;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->value;
     }

--- a/src/lib/FieldType/ISBN/Type.php
+++ b/src/lib/FieldType/ISBN/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\ISBN;
 
@@ -29,7 +30,7 @@ class Type extends FieldType implements TranslationContainerInterface
     public const ISBN13_PREFIX_978 = '978';
     public const ISBN13_PREFIX_979 = '979';
 
-    protected $settingsSchema = [
+    protected array $settingsSchema = [
         'isISBN13' => [
             'type' => 'boolean',
             'default' => true,
@@ -56,23 +57,13 @@ class Type extends FieldType implements TranslationContainerInterface
         return (string)$value->isbn;
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\ISBN\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
 
     /**
-     * Returns if the given $value is considered empty by the field type.
-     *
-     * @param mixed $value
-     *
-     * @return bool
+     * @param \Ibexa\Core\FieldType\ISBN\Value $value
      */
     public function isEmptyValue(SPIValue $value): bool
     {
@@ -118,22 +109,22 @@ class Type extends FieldType implements TranslationContainerInterface
      *
      * Does not use validators.
      *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
-     * @param \Ibexa\Core\FieldType\ISBN\Value $fieldValue The field value for which an action is performed
+     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
+     * @param \Ibexa\Core\FieldType\ISBN\Value $value The field value for which an action is performed
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
+     *
+     *@throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    public function validate(FieldDefinition $fieldDef, SPIValue $value): array
     {
         $validationErrors = [];
-        if ($this->isEmptyValue($fieldValue)) {
+        if ($this->isEmptyValue($value)) {
             return $validationErrors;
         }
 
-        $fieldSettings = $fieldDefinition->getFieldSettings();
-        $isbnTestNumber = preg_replace("/[\s|\-]/", '', trim($fieldValue->isbn));
+        $fieldSettings = $fieldDef->getFieldSettings();
+        $isbnTestNumber = preg_replace("/[\s|\-]/", '', trim($value->isbn));
 
         // Check if value and settings are inline
         if ((!isset($fieldSettings['isISBN13']) || $fieldSettings['isISBN13'] === false)
@@ -170,25 +161,14 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns information for FieldValue->$sortKey relevant to the field type.
-     *
      * @param \Ibexa\Core\FieldType\ISBN\Value $value
-     *
-     * @return string
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): string
     {
         return $this->transformationProcessor->transformByGroup((string)$value, 'lowercase');
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\ISBN\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null || $hash === '') {
             return $this->getEmptyValue();
@@ -198,13 +178,9 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\ISBN\Value $value
-     *
-     * @return mixed
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?string
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -213,24 +189,12 @@ class Type extends FieldType implements TranslationContainerInterface
         return $value->isbn;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;
     }
 
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings(array $fieldSettings): array
     {
         $validationErrors = [];
 

--- a/src/lib/FieldType/ISBN/Value.php
+++ b/src/lib/FieldType/ISBN/Value.php
@@ -4,35 +4,24 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\ISBN;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for ISBN field type.
+ * Value for the ISBN field type.
  */
 class Value extends BaseValue
 {
-    /**
-     * ISBN content.
-     *
-     * @var string
-     */
-    public $isbn;
-
-    /**
-     * Construct a new Value object and initialize it with its $isbn.
-     *
-     * @param string $isbn
-     */
-    public function __construct($isbn = '')
+    public function __construct(public readonly string $isbn = '')
     {
-        $this->isbn = $isbn;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
-        return (string)$this->isbn;
+        return $this->isbn;
     }
 }

--- a/src/lib/FieldType/Image/Value.php
+++ b/src/lib/FieldType/Image/Value.php
@@ -4,39 +4,34 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Image;
 
-use Ibexa\Contracts\Core\Repository\Exceptions\PropertyNotFoundException;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 class Value extends BaseValue
 {
     /**
-     * Image id.
+     * Image binary file string id.
      *
      * Required.
-     *
-     * @var mixed|null
      */
-    public $id;
+    public ?string $id = null;
 
     /**
-     * The alternative image text (for example "Picture of an apple.").
-     *
-     * @var string|null
+     * The alternative image text (for example, "Picture of an apple.").
      */
-    public $alternativeText;
+    public ?string $alternativeText = null;
 
     /**
      * Display file name of the image.
      *
      * Required.
-     *
-     * @var string|null
      */
-    public $fileName;
+    public ?string $fileName = null;
 
     /**
      * Size of the image file.
@@ -45,57 +40,63 @@ class Value extends BaseValue
      *
      * @var int|null
      */
-    public $fileSize;
+    public ?int $fileSize = null;
 
     /**
      * The image's HTTP URI.
      *
      * @var string|null
      */
-    public $uri;
+    public ?string $uri = null;
 
     /**
      * External image ID (required by REST for now, see https://issues.ibexa.co/browse/EZP-20831).
-     *
-     * @var mixed|null
      */
-    public $imageId;
+    public ?string $imageId = null;
 
     /**
      * Input image file URI.
-     *
-     * @var string|null
      */
-    public $inputUri;
+    public ?string $inputUri = null;
 
     /**
      * Original image width.
-     *
-     * @var int|null
      */
-    public $width;
+    public ?int $width = null;
 
     /**
      * Original image height.
      *
      * @var int|null
      */
-    public $height;
+    public ?int $height = null;
 
     /** @var string[] */
-    public $additionalData = [];
+    public array $additionalData = [];
 
     public ?string $mime = null;
 
     /**
-     * Construct a new Value object.
+     * @param array{
+     *     id?: string|null,
+     *     alternativeText?: string|null,
+     *     fileName?: string|null,
+     *     fileSize?: int|null,
+     *     uri?: string|null,
+     *     imageId?: string|null,
+     *     inputUri?: string|null,
+     *     width?: int|null,
+     *     height?: int|null,
+     *     additionalData?: string[],
+     *     mime?: string|null
+     * } $imageData
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException if input data contains unknown property
      */
     public function __construct(array $imageData = [])
     {
         foreach ($imageData as $key => $value) {
-            try {
-                $this->$key = $value;
-            } catch (PropertyNotFoundException $e) {
+            if (!property_exists($this, $key)) {
                 throw new InvalidArgumentType(
                     sprintf('Image\Value::$%s', $key),
                     'Existing property',
@@ -103,6 +104,8 @@ class Value extends BaseValue
                 );
             }
         }
+
+        parent::__construct($imageData);
     }
 
     public function isAlternativeTextEmpty(): bool
@@ -113,7 +116,7 @@ class Value extends BaseValue
     /**
      * Creates a value only from a file path.
      *
-     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
     public static function fromString(string $path): self
     {
@@ -125,26 +128,29 @@ class Value extends BaseValue
             );
         }
 
-        return new static(
+        $filesize = filesize($path);
+        if (false === $filesize) {
+            throw new InvalidArgumentException('$path', "Failed to get file size of '$path' file");
+        }
+
+        return new self(
             [
                 'inputUri' => $path,
                 'fileName' => basename($path),
-                'fileSize' => filesize($path),
+                'fileSize' => $filesize,
             ]
         );
     }
 
     /**
      * Returns the image file size in byte.
-     *
-     * @return int
      */
-    public function getFileSize()
+    public function getFileSize(): ?int
     {
         return $this->fileSize;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->fileName;
     }

--- a/src/lib/FieldType/ImageAsset/Type.php
+++ b/src/lib/FieldType/ImageAsset/Type.php
@@ -49,8 +49,8 @@ class Type extends FieldType implements TranslationContainerInterface
     /**
      * Validates a field based on the validators in the field definition.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
-     * @param \Ibexa\Core\FieldType\ImageAsset\Value $fieldValue The field value for which an action is performed
+     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
+     * @param \Ibexa\Core\FieldType\ImageAsset\Value $value The field value for which an action is performed
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      *
@@ -58,16 +58,16 @@ class Type extends FieldType implements TranslationContainerInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue): array
+    public function validate(FieldDefinition $fieldDef, SPIValue $value): array
     {
         $errors = [];
 
-        if ($this->isEmptyValue($fieldValue)) {
+        if ($this->isEmptyValue($value)) {
             return $errors;
         }
 
         $content = $this->contentService->loadContent(
-            (int)$fieldValue->destinationContentId
+            (int)$value->destinationContentId
         );
 
         if (!$this->assetMapper->isAsset($content)) {
@@ -120,24 +120,11 @@ class Type extends FieldType implements TranslationContainerInterface
         return $versionInfo->names[$languageCode] ?? $versionInfo->names[$contentInfo->mainLanguageCode];
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\ImageAsset\Value
-     */
     public function getEmptyValue(): Value
     {
         return new Value();
     }
 
-    /**
-     * Returns if the given $value is considered empty by the field type.
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
     public function isEmptyValue(SPIValue $value): bool
     {
         return null === $value->destinationContentId;
@@ -188,26 +175,14 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns information for FieldValue->$sortKey relevant to the field type.
-     * For this FieldType, the related object's name is returned.
-     *
-     * @param \Ibexa\Core\FieldType\Relation\Value $value
-     *
-     * @return bool
+     * @param \Ibexa\Core\FieldType\ImageAsset\Value $value
      */
-    protected function getSortInfo(BaseValue $value): bool
+    protected function getSortInfo(SPIValue $value): false
     {
         return false;
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\ImageAsset\Value $value
-     */
-    public function fromHash($hash): Value
+    public function fromHash(mixed $hash): Value
     {
         if (!$hash) {
             return new Value();
@@ -222,11 +197,9 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\ImageAsset\Value $value
      *
-     * @return array
+     * @return array{destinationContentId: int|null, alternativeText: string|null}
      */
     public function toHash(SPIValue $value): array
     {
@@ -242,45 +215,18 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns relation data extracted from value.
-     *
-     * Not intended for \Ibexa\Contracts\Core\Repository\Values\Content\Relation::COMMON type relations,
-     * there is an API for handling those.
-     *
-     * @param \Ibexa\Core\FieldType\ImageAsset\Value $fieldValue
-     *
-     * @return array Hash with relation type as key and array of destination content ids as value.
-     *
-     * Example:
-     * <code>
-     *  array(
-     *      \Ibexa\Contracts\Core\Repository\Values\Content\Relation::LINK => array(
-     *          "contentIds" => array( 12, 13, 14 ),
-     *          "locationIds" => array( 24 )
-     *      ),
-     *      \Ibexa\Contracts\Core\Repository\Values\Content\Relation::EMBED => array(
-     *          "contentIds" => array( 12 ),
-     *          "locationIds" => array( 24, 45 )
-     *      ),
-     *      \Ibexa\Contracts\Core\Repository\Values\Content\Relation::FIELD => array( 12 )
-     *  )
-     * </code>
+     * @param \Ibexa\Core\FieldType\ImageAsset\Value $value
      */
-    public function getRelations(SPIValue $fieldValue): array
+    public function getRelations(SPIValue $value): array
     {
         $relations = [];
-        if ($fieldValue->destinationContentId !== null) {
-            $relations[RelationType::ASSET->value] = [$fieldValue->destinationContentId];
+        if ($value->destinationContentId !== null) {
+            $relations[RelationType::ASSET->value] = [$value->destinationContentId];
         }
 
         return $relations;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;

--- a/src/lib/FieldType/ImageAsset/Value.php
+++ b/src/lib/FieldType/ImageAsset/Value.php
@@ -13,35 +13,17 @@ use Ibexa\Core\FieldType\Value as BaseValue;
 class Value extends BaseValue
 {
     /**
-     * Related content id's.
-     *
-     * @var mixed|null
+     * @param int|null $destinationContentId Related content's ID.
+     * @param string|null $alternativeText The alternative image text (for example, "Picture of an apple.").
      */
-    public $destinationContentId;
-
-    /**
-     * The alternative image text (for example "Picture of an apple.").
-     *
-     * @var string|null
-     */
-    public $alternativeText;
-
-    /**
-     * @param mixed|null $destinationContentId
-     * @param string|null $alternativeText
-     */
-    public function __construct($destinationContentId = null, ?string $alternativeText = null)
-    {
-        parent::__construct([
-            'destinationContentId' => $destinationContentId,
-            'alternativeText' => $alternativeText,
-        ]);
+    public function __construct(
+        public readonly ?int $destinationContentId = null,
+        public readonly ?string $alternativeText = null
+    ) {
+        parent::__construct();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->destinationContentId;
     }

--- a/src/lib/FieldType/Integer/Type.php
+++ b/src/lib/FieldType/Integer/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Integer;
 
@@ -23,7 +24,7 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
  */
 class Type extends BaseNumericType implements TranslationContainerInterface
 {
-    protected $validatorConfigurationSchema = [
+    protected array $validatorConfigurationSchema = [
         'IntegerValueValidator' => [
             'minIntegerValue' => [
                 'type' => 'int',
@@ -59,18 +60,12 @@ class Type extends BaseNumericType implements TranslationContainerInterface
         return (string)$value;
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     */
     public function getEmptyValue(): Value
     {
         return new Value();
     }
 
     /**
-     * Returns if the given $value is considered empty by the field type.
-     *
      * @param \Ibexa\Core\FieldType\Integer\Value $value
      */
     public function isEmptyValue(SPIValue $value): bool
@@ -115,19 +110,12 @@ class Type extends BaseNumericType implements TranslationContainerInterface
     /**
      * @param \Ibexa\Core\FieldType\Integer\Value $value
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): ?int
     {
         return $value->value;
     }
 
-    /**
-     * Converts a <code>$hash</code> to the Value defined by the field type.
-     *
-     * @param int|string|null $hash
-     *
-     * @return \Ibexa\Core\FieldType\Integer\Value $value
-     */
-    public function fromHash($hash): Value
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -137,8 +125,6 @@ class Type extends BaseNumericType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Integer\Value $value
      */
     public function toHash(SPIValue $value): ?int
@@ -150,11 +136,6 @@ class Type extends BaseNumericType implements TranslationContainerInterface
         return $value->value;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;

--- a/src/lib/FieldType/Integer/Value.php
+++ b/src/lib/FieldType/Integer/Value.php
@@ -4,34 +4,23 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Integer;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Integer field type.
+ * Value for the Integer field type.
  */
 class Value extends BaseValue
 {
-    /**
-     * Content of the value.
-     *
-     * @var int|null
-     */
-    public $value;
-
-    /**
-     * Construct a new Value object and initialize with $value.
-     *
-     * @param int|null $value
-     */
-    public function __construct($value = null)
+    public function __construct(public readonly ?int $value = null)
     {
-        $this->value = $value;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->value;
     }

--- a/src/lib/FieldType/Keyword/Type.php
+++ b/src/lib/FieldType/Keyword/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Keyword;
 
@@ -44,13 +45,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return implode(', ', $value->values);
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Keyword\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value([]);
     }
@@ -104,13 +99,13 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * @param \Ibexa\Core\FieldType\Keyword\Value $fieldValue
+     * @param \Ibexa\Core\FieldType\Keyword\Value $value
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue): array
+    public function validate(FieldDefinition $fieldDef, SPIValue $value): array
     {
         $validationErrors = [];
 
-        foreach ($fieldValue->values as $keyword) {
+        foreach ($value->values as $keyword) {
             if (!is_string($keyword)) {
                 $validationErrors[] = new ValidationError(
                     'Each keyword must be a string.',
@@ -132,55 +127,37 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param \Ibexa\Core\FieldType\Keyword\Value $value
      */
-    protected function getSortInfo(BaseValue $value): string
+    protected function getSortInfo(SPIValue $value): string
     {
         return implode(',', $value->values);
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\Keyword\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         return new Value($hash);
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Keyword\Value $value
      *
-     * @return mixed
+     * @return string[]
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): array
     {
         return $value->values;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;
     }
 
     /**
-     * Converts a $value to a persistence value.
-     *
      * @param \Ibexa\Core\FieldType\Keyword\Value $value
-     *
-     * @return \Ibexa\Contracts\Core\Persistence\Content\FieldValue
      */
-    public function toPersistenceValue(SPIValue $value)
+    public function toPersistenceValue(SPIValue $value): FieldValue
     {
         return new FieldValue(
             [
@@ -191,14 +168,7 @@ class Type extends FieldType implements TranslationContainerInterface
         );
     }
 
-    /**
-     * Converts a persistence $fieldValue to a Value.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
-     *
-     * @return \Ibexa\Core\FieldType\Keyword\Value
-     */
-    public function fromPersistenceValue(FieldValue $fieldValue)
+    public function fromPersistenceValue(FieldValue $fieldValue): Value
     {
         return new Value($fieldValue->externalData);
     }

--- a/src/lib/FieldType/Keyword/Value.php
+++ b/src/lib/FieldType/Keyword/Value.php
@@ -4,13 +4,14 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Keyword;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Keyword field type.
+ * Value for the Keyword field type.
  */
 class Value extends BaseValue
 {
@@ -19,21 +20,21 @@ class Value extends BaseValue
      *
      * @var string[]
      */
-    public $values = [];
+    public readonly array $values;
 
     /**
      * Construct a new Value object and initialize with $values.
      *
-     * @param string[]|string $values
+     * @param string[]|string $values either an array of keywords or a comma-separated list of keywords
      */
-    public function __construct($values = null)
+    public function __construct(array|string|null $values = null)
     {
         if ($values !== null) {
             if (!is_array($values)) {
                 $tags = [];
                 foreach (explode(',', $values) as $tag) {
                     $tag = trim($tag);
-                    if ($tag) {
+                    if (!empty($tag)) {
                         $tags[] = $tag;
                     }
                 }
@@ -41,7 +42,11 @@ class Value extends BaseValue
             }
 
             $this->values = array_unique($values);
+        } else {
+            $this->values = [];
         }
+
+        parent::__construct();
     }
 
     /**
@@ -49,7 +54,7 @@ class Value extends BaseValue
      *
      * @return string A comma separated list of tags, eg: "php, Ibexa, html5"
      */
-    public function __toString()
+    public function __toString(): string
     {
         return implode(', ', $this->values);
     }

--- a/src/lib/FieldType/MapLocation/Type.php
+++ b/src/lib/FieldType/MapLocation/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\MapLocation;
 
@@ -41,23 +42,13 @@ class Type extends FieldType implements TranslationContainerInterface
         return (string)$value->address;
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\MapLocation\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
 
     /**
-     * Returns if the given $value is considered empty by the field type.
-     *
-     * @param mixed $value
-     *
-     * @return bool
+     * @param \Ibexa\Core\FieldType\MapLocation\Value $value
      */
     public function isEmptyValue(SPIValue $value): bool
     {
@@ -116,22 +107,13 @@ class Type extends FieldType implements TranslationContainerInterface
      * Returns information for FieldValue->$sortKey relevant to the field type.
      *
      * @param \Ibexa\Core\FieldType\MapLocation\Value $value
-     *
-     * @return string
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): string
     {
         return $this->transformationProcessor->transformByGroup((string)$value, 'lowercase');
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\MapLocation\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -141,13 +123,11 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\MapLocation\Value $value
      *
-     * @return mixed
+     * @return array{latitude: float|null, longitude: float|null, address: string|null}|null
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?array
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -160,24 +140,15 @@ class Type extends FieldType implements TranslationContainerInterface
         ];
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;
     }
 
     /**
-     * Converts a $value to a persistence value.
-     *
      * @param \Ibexa\Core\FieldType\MapLocation\Value $value
-     *
-     * @return \Ibexa\Contracts\Core\Persistence\Content\FieldValue
      */
-    public function toPersistenceValue(SPIValue $value)
+    public function toPersistenceValue(SPIValue $value): FieldValue
     {
         return new FieldValue(
             [
@@ -188,14 +159,7 @@ class Type extends FieldType implements TranslationContainerInterface
         );
     }
 
-    /**
-     * Converts a persistence $fieldValue to a Value.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
-     *
-     * @return \Ibexa\Core\FieldType\MapLocation\Value
-     */
-    public function fromPersistenceValue(FieldValue $fieldValue)
+    public function fromPersistenceValue(FieldValue $fieldValue): Value
     {
         if ($fieldValue->externalData === null) {
             return $this->getEmptyValue();

--- a/src/lib/FieldType/MapLocation/Value.php
+++ b/src/lib/FieldType/MapLocation/Value.php
@@ -4,60 +4,52 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\MapLocation;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for MapLocation field type.
+ * Value for the MapLocation field type.
  */
 class Value extends BaseValue
 {
     /**
      * Latitude of the location.
-     *
-     * @var float|null
      */
-    public $latitude;
+    public readonly ?float $latitude;
 
     /**
      * Longitude of the location.
-     *
-     * @var float|null
      */
-    public $longitude;
+    public readonly ?float $longitude;
 
     /**
      * Display address for the location.
-     *
-     * @var string|null
      */
-    public $address;
+    public readonly ?string $address;
 
     /**
-     * Construct a new Value object and initialize with $values.
-     *
-     * @param string[]|string $values
+     * @param array{latitude: float|null, longitude: float|null, address: string|string[]|null}|null $values
      */
-    public function __construct(array $values = null)
+    public function __construct(?array $values = null)
     {
-        foreach ((array)$values as $key => $value) {
-            $this->$key = $value;
+        if (null !== $values) {
+            $this->latitude = $values['latitude'] ?? null;
+            $this->longitude = $values['longitude'] ?? null;
+
+            $address = is_array($values['address'] ?? null)
+                ? implode(', ', $values['address'])
+                : ($values['address'] ?? null);
+            $this->address = $address;
         }
+
+        parent::__construct();
     }
 
-    /**
-     * Returns a string representation of the keyword value.
-     *
-     * @return string A comma separated list of tags, eg: "php, Ibexa, html5"
-     */
-    public function __toString()
+    public function __toString(): string
     {
-        if (is_array($this->address)) {
-            return implode(', ', $this->address);
-        }
-
         return (string)$this->address;
     }
 }

--- a/src/lib/FieldType/Media/Type.php
+++ b/src/lib/FieldType/Media/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Media;
 
@@ -26,18 +27,18 @@ class Type extends BaseType implements TranslationContainerInterface
     /**
      * List of possible media type settings.
      */
-    public const TYPE_FLASH = 'flash';
-    public const TYPE_QUICKTIME = 'quick_time';
-    public const TYPE_REALPLAYER = 'real_player';
-    public const TYPE_SILVERLIGHT = 'silverlight';
-    public const TYPE_WINDOWSMEDIA = 'windows_media_player';
-    public const TYPE_HTML5_VIDEO = 'html5_video';
-    public const TYPE_HTML5_AUDIO = 'html5_audio';
+    public const string TYPE_FLASH = 'flash';
+    public const string TYPE_QUICKTIME = 'quick_time';
+    public const string TYPE_REALPLAYER = 'real_player';
+    public const string TYPE_SILVERLIGHT = 'silverlight';
+    public const string TYPE_WINDOWSMEDIA = 'windows_media_player';
+    public const string TYPE_HTML5_VIDEO = 'html5_video';
+    public const string TYPE_HTML5_AUDIO = 'html5_audio';
 
     /**
      * Type constants for validation.
      */
-    private static $availableTypes = [
+    private static array $availableTypes = [
         self::TYPE_FLASH,
         self::TYPE_QUICKTIME,
         self::TYPE_REALPLAYER,
@@ -48,7 +49,7 @@ class Type extends BaseType implements TranslationContainerInterface
     ];
 
     /** @var array */
-    protected $settingsSchema = [
+    protected array $settingsSchema = [
         'mediaType' => [
             'type' => 'choice',
             'default' => self::TYPE_HTML5_VIDEO,
@@ -65,43 +66,26 @@ class Type extends BaseType implements TranslationContainerInterface
         return 'ibexa_media';
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Media\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
 
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings(array $fieldSettings): array
     {
         $validationErrors = [];
 
         foreach ($fieldSettings as $name => $value) {
             if (isset($this->settingsSchema[$name])) {
-                switch ($name) {
-                    case 'mediaType':
-                        if (!in_array($value, self::$availableTypes)) {
-                            $validationErrors[] = new ValidationError(
-                                "Setting '%setting%' is of unknown type",
-                                null,
-                                [
-                                    '%setting%' => $name,
-                                ],
-                                "[$name]"
-                            );
-                        }
-                        break;
+                if ($name === 'mediaType' && !in_array($value, self::$availableTypes, true)) {
+                    $validationErrors[] = new ValidationError(
+                        "Setting '%setting%' is of unknown type",
+                        null,
+                        [
+                            '%setting%' => $name,
+                        ],
+                        "[$name]"
+                    );
                 }
             } else {
                 $validationErrors[] = new ValidationError(
@@ -209,13 +193,11 @@ class Type extends BaseType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Media\Value $value
      *
-     * @return mixed
+     * @return array<string, mixed>|null
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?array
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -232,21 +214,13 @@ class Type extends BaseType implements TranslationContainerInterface
         return $hash;
     }
 
-    /**
-     * Converts a persistence $fieldValue to a Value.
-     *
-     * This method builds a field type value from the $data and $externalData properties.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
-     *
-     * @return \Ibexa\Core\FieldType\Media\Value
-     */
-    public function fromPersistenceValue(FieldValue $fieldValue)
+    public function fromPersistenceValue(FieldValue $fieldValue): Value
     {
         if ($fieldValue->externalData === null) {
             return $this->getEmptyValue();
         }
 
+        /** @var \Ibexa\Core\FieldType\Media\Value $result */
         $result = parent::fromPersistenceValue($fieldValue);
 
         $result->hasController = $fieldValue->externalData['hasController'] ?? false;
@@ -258,11 +232,6 @@ class Type extends BaseType implements TranslationContainerInterface
         return $result;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return false;

--- a/src/lib/FieldType/Media/Value.php
+++ b/src/lib/FieldType/Media/Value.php
@@ -4,48 +4,39 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Media;
 
 use Ibexa\Core\FieldType\BinaryBase\Value as BaseValue;
 
 /**
- * Value for Media field type.
+ * Value for the Media field type.
  */
 class Value extends BaseValue
 {
     /**
      * If the media has a controller when being displayed.
-     *
-     * @var bool
      */
-    public $hasController = false;
+    public bool $hasController = false;
 
     /**
      * If the media should be automatically played.
-     *
-     * @var bool
      */
-    public $autoplay = false;
+    public bool $autoplay = false;
 
     /**
      * If the media should be played in a loop.
-     *
-     * @var bool
      */
-    public $loop = false;
+    public bool $loop = false;
 
     /**
      * Height of the media.
-     *
-     * @var int
      */
-    public $height = 0;
+    public int $height = 0;
 
     /**
      * Width of the media.
-     *
-     * @var int
      */
-    public $width = 0;
+    public int $width = 0;
 }

--- a/src/lib/FieldType/Null/Type.php
+++ b/src/lib/FieldType/Null/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Null;
 
@@ -18,45 +19,29 @@ use Ibexa\Core\FieldType\Value as BaseValue;
 class Type extends FieldType
 {
     /**
-     * Identifier for the field type this stuff is mocking.
-     *
-     * @var string
+     * @param string $fieldTypeIdentifier Identifier for the field type that is being mocked.
      */
-    protected $fieldTypeIdentifier;
-
-    /**
-     * @param string $fieldTypeIdentifier
-     */
-    public function __construct($fieldTypeIdentifier)
+    public function __construct(protected readonly string $fieldTypeIdentifier)
     {
-        $this->fieldTypeIdentifier = $fieldTypeIdentifier;
     }
 
     /**
      * Returns the field type identifier for this field type.
-     *
-     * @return string
      */
-    public function getFieldTypeIdentifier()
+    public function getFieldTypeIdentifier(): string
     {
         return $this->fieldTypeIdentifier;
     }
 
     /**
-     * @param \Ibexa\Core\FieldType\Null\Value|\Ibexa\Contracts\Core\FieldType\Value $value
+     * @param \Ibexa\Core\FieldType\Null\Value $value
      */
     public function getName(SPIValue $value, FieldDefinition $fieldDefinition, string $languageCode): string
     {
         return (string)$value->value;
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Null\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value(null);
     }
@@ -68,7 +53,7 @@ class Type extends FieldType
      *
      * @return \Ibexa\Core\FieldType\Null\Value The potentially converted and structurally plausible value.
      */
-    protected function createValueFromInput($inputValue)
+    protected function createValueFromInput($inputValue): Value
     {
         return $inputValue;
     }
@@ -85,47 +70,19 @@ class Type extends FieldType
         // Does nothing
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getSortInfo(BaseValue $value)
-    {
-        return null;
-    }
-
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\Null\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         return new Value($hash);
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Null\Value $value
-     *
-     * @return mixed
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): null
     {
-        if (isset($value->value)) {
-            return $value->value;
-        }
-
         return null;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;

--- a/src/lib/FieldType/Null/Value.php
+++ b/src/lib/FieldType/Null/Value.php
@@ -4,35 +4,24 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Null;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Null field type.
+ * Value for the Null field type.
  */
 class Value extends BaseValue
 {
-    /**
-     * Content of the value.
-     *
-     * @var mixed
-     */
-    public $value = null;
-
-    /**
-     * Construct a new Value object and initialize with $value.
-     *
-     * @param int $value
-     */
-    public function __construct($value = null)
+    public function __construct(public readonly null $value = null)
     {
-        $this->value = $value;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
-        return (string)$this->value;
+        return 'null';
     }
 }

--- a/src/lib/FieldType/Relation/Value.php
+++ b/src/lib/FieldType/Relation/Value.php
@@ -4,37 +4,31 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Relation;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Relation field type.
+ * Value for the Relation field type.
  */
 class Value extends BaseValue
 {
     /**
-     * Related content.
-     *
-     * @var mixed|null
-     */
-    public $destinationContentId;
-
-    /**
      * Construct a new Value object and initialize it $destinationContent.
      *
-     * @param mixed $destinationContentId Content id the relation is to
+     * @param int|null $destinationContentId Content id the relation is to
      */
-    public function __construct($destinationContentId = null)
+    public function __construct(public readonly ?int $destinationContentId = null)
     {
-        $this->destinationContentId = $destinationContentId;
+        parent::__construct();
     }
 
     /**
-     * Returns the related content's name.
+     * Returns the related content item ID as a string.
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->destinationContentId;
     }

--- a/src/lib/FieldType/RelationList/Value.php
+++ b/src/lib/FieldType/RelationList/Value.php
@@ -4,34 +4,26 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\RelationList;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for RelationList field type.
+ * Value for the RelationList field type.
  */
 class Value extends BaseValue
 {
     /**
-     * Related content id's.
-     *
-     * @var mixed[]
+     * @param int[] $destinationContentIds
      */
-    public $destinationContentIds;
-
-    /**
-     * Construct a new Value object and initialize it $text.
-     *
-     * @param mixed[] $destinationContentIds
-     */
-    public function __construct(array $destinationContentIds = [])
+    public function __construct(public readonly array $destinationContentIds = [])
     {
-        $this->destinationContentIds = $destinationContentIds;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return implode(',', $this->destinationContentIds);
     }

--- a/src/lib/FieldType/Selection/Value.php
+++ b/src/lib/FieldType/Selection/Value.php
@@ -4,34 +4,26 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Selection;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Selection field type.
+ * Value for a Selection field type.
  */
 class Value extends BaseValue
 {
     /**
-     * Selection content.
-     *
-     * @var int[]
-     */
-    public $selection;
-
-    /**
-     * Construct a new Value object and initialize it $selection.
-     *
      * @param int[] $selection
      */
-    public function __construct(array $selection = [])
+    public function __construct(public readonly array $selection = [])
     {
-        $this->selection = $selection;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return implode(',', $this->selection);
     }

--- a/src/lib/FieldType/TextBlock/Type.php
+++ b/src/lib/FieldType/TextBlock/Type.php
@@ -4,13 +4,14 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\TextBlock;
 
+use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\BaseTextType;
 use Ibexa\Core\FieldType\ValidationError;
-use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
@@ -21,14 +22,14 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
  */
 class Type extends BaseTextType implements TranslationContainerInterface
 {
-    protected $settingsSchema = [
+    protected array $settingsSchema = [
         'textRows' => [
             'type' => 'int',
             'default' => 10,
         ],
     ];
 
-    protected $validatorConfigurationSchema = [];
+    protected array $validatorConfigurationSchema = [];
 
     public function getFieldTypeIdentifier(): string
     {
@@ -62,13 +63,9 @@ class Type extends BaseTextType implements TranslationContainerInterface
     }
 
     /**
-     * Returns information for FieldValue->$sortKey relevant to the field type.
-     *
      * @param \Ibexa\Core\FieldType\TextBlock\Value $value
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    protected function getSortInfo(BaseValue $value): string
+    protected function getSortInfo(SPIValue $value): string
     {
         $tokens = strtok(trim($value->text), "\r\n");
 
@@ -77,10 +74,7 @@ class Type extends BaseTextType implements TranslationContainerInterface
             : '';
     }
 
-    /**
-     * @param string $hash
-     */
-    public function fromHash($hash): Value
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -89,14 +83,7 @@ class Type extends BaseTextType implements TranslationContainerInterface
         return new Value($hash);
     }
 
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings): array
+    public function validateFieldSettings(array $fieldSettings): array
     {
         $validationErrors = [];
 

--- a/src/lib/FieldType/TextBlock/Value.php
+++ b/src/lib/FieldType/TextBlock/Value.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\TextBlock;
 

--- a/src/lib/FieldType/TextLine/Type.php
+++ b/src/lib/FieldType/TextLine/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\TextLine;
 
@@ -12,7 +13,6 @@ use Ibexa\Contracts\Core\FieldType\Value as SPIValue;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\BaseTextType;
 use Ibexa\Core\FieldType\Validator\StringLengthValidator;
-use Ibexa\Core\FieldType\Value as BaseValue;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
@@ -23,7 +23,7 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
  */
 class Type extends BaseTextType implements TranslationContainerInterface
 {
-    protected $validatorConfigurationSchema = [
+    protected array $validatorConfigurationSchema = [
         'StringLengthValidator' => [
             'minStringLength' => [
                 'type' => 'int',
@@ -39,11 +39,11 @@ class Type extends BaseTextType implements TranslationContainerInterface
     /**
      * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
      *
-     * @param array<string, mixed> $validatorConfiguration
+     * @param mixed $validatorConfiguration
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
-    public function validateValidatorConfiguration($validatorConfiguration): array
+    public function validateValidatorConfiguration(mixed $validatorConfiguration): array
     {
         $validationErrors = [];
         $validators = ['StringLengthValidator' => new StringLengthValidator()];
@@ -62,27 +62,27 @@ class Type extends BaseTextType implements TranslationContainerInterface
     /**
      * Validates a field based on the validators in the field definition.
      *
-     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
-     * @param \Ibexa\Core\FieldType\TextLine\Value $fieldValue The field value for which an action is performed
+     * @param \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
+     * @param \Ibexa\Core\FieldType\TextLine\Value $value The field value for which an action is performed
      *
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\PropertyNotFoundException
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue): array
+    public function validate(FieldDefinition $fieldDef, SPIValue $value): array
     {
         $validationErrors = [];
 
-        if ($this->isEmptyValue($fieldValue)) {
+        if ($this->isEmptyValue($value)) {
             return $validationErrors;
         }
 
-        $validatorConfiguration = $fieldDefinition->getValidatorConfiguration();
+        $validatorConfiguration = $fieldDef->getValidatorConfiguration();
         $constraints = $validatorConfiguration['StringLengthValidator'] ?? [];
         $validator = new StringLengthValidator();
         $validator->initializeWithConstraints($constraints);
 
-        return false === $validator->validate($fieldValue, $fieldDefinition) ? $validator->getMessage() : [];
+        return false === $validator->validate($value, $fieldDef) ? $validator->getMessage() : [];
     }
 
     public function getFieldTypeIdentifier(): string
@@ -90,9 +90,6 @@ class Type extends BaseTextType implements TranslationContainerInterface
         return 'ibexa_string';
     }
 
-    /**
-     * @return \Ibexa\Core\FieldType\TextLine\Value
-     */
     public function getEmptyValue(): Value
     {
         return new Value();
@@ -124,15 +121,12 @@ class Type extends BaseTextType implements TranslationContainerInterface
      *
      * @param \Ibexa\Core\FieldType\TextLine\Value $value
      */
-    protected function getSortInfo(BaseValue $value): string
+    protected function getSortInfo(SPIValue $value): string
     {
         return $this->transformationProcessor->transformByGroup((string)$value, 'lowercase');
     }
 
-    /**
-     * @param string $hash
-     */
-    public function fromHash($hash): Value
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();

--- a/src/lib/FieldType/TextLine/Value.php
+++ b/src/lib/FieldType/TextLine/Value.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\TextLine;
 
@@ -14,19 +15,12 @@ use Ibexa\Core\FieldType\Value as BaseValue;
  */
 class Value extends BaseValue
 {
-    /**
-     * Text content.
-     */
-    public string $text;
-
-    public function __construct(?string $text = '')
+    public function __construct(public readonly string $text = '')
     {
         parent::__construct();
-
-        $this->text = (string)$text;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->text;
     }

--- a/src/lib/FieldType/Time/Type.php
+++ b/src/lib/FieldType/Time/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Time;
 
@@ -29,7 +30,7 @@ class Type extends FieldType implements TranslationContainerInterface
      */
     public const DEFAULT_CURRENT_TIME = 1;
 
-    protected $settingsSchema = [
+    protected array $settingsSchema = [
         'useSeconds' => [
             'type' => 'bool',
             'default' => false,
@@ -67,13 +68,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return $dateTime->format('g:i:s a');
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Time\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
@@ -124,22 +119,13 @@ class Type extends FieldType implements TranslationContainerInterface
      * Returns information for FieldValue->$sortKey relevant to the field type.
      *
      * @param \Ibexa\Core\FieldType\Time\Value $value
-     *
-     * @return int
      */
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(SPIValue $value): ?int
     {
         return $value->time;
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param int $hash Number of seconds since Unix Epoch
-     *
-     * @return \Ibexa\Core\FieldType\Time\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -149,30 +135,17 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Returns if the given $value is considered empty by the field type.
-     *
-     *
-     * @param \Ibexa\Core\FieldType\Value $value
-     *
-     * @return bool
+     * @param \Ibexa\Core\FieldType\Time\Value $value
      */
     public function isEmptyValue(SPIValue $value): bool
     {
-        if ($value->time === null) {
-            return true;
-        }
-
-        return false;
+        return $value->time === null;
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Time\Value $value
-     *
-     * @return mixed
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?int
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -181,24 +154,12 @@ class Type extends FieldType implements TranslationContainerInterface
         return $value->time;
     }
 
-    /**
-     * Returns whether the field type is searchable.
-     *
-     * @return bool
-     */
     public function isSearchable(): bool
     {
         return true;
     }
 
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings)
+    public function validateFieldSettings(array $fieldSettings): array
     {
         $validationErrors = [];
 

--- a/src/lib/FieldType/Time/Value.php
+++ b/src/lib/FieldType/Time/Value.php
@@ -4,67 +4,57 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Time;
 
 use DateTime;
+use DateTimeInterface;
 use Exception;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentValue;
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Time field type.
+ * Value for the Time field type.
  */
 class Value extends BaseValue
 {
     /**
      * Time of day as number of seconds.
-     *
-     * @var int|null
      */
-    public $time;
+    public readonly ?int $time;
 
     /**
      * Time format to be used by {@link __toString()}.
-     *
-     * @var string
      */
-    public $stringFormat = 'H:i:s';
+    public string $stringFormat = 'H:i:s';
 
     /**
-     * Construct a new Value object and initialize it with $seconds as number of seconds from beginning of day.
-     *
-     * @param mixed $seconds
+     * Construct a new Value object and initialize it with $seconds as number of seconds from the beginning of a day.
      */
-    public function __construct($seconds = null)
+    public function __construct(?int $seconds = null)
     {
         $this->time = $seconds;
+
+        parent::__construct();
     }
 
     /**
      * Creates a Value from the given $dateTime.
-     *
-     * @param \DateTime $dateTime
-     *
-     * @return \Ibexa\Core\FieldType\Time\Value
      */
-    public static function fromDateTime(DateTime $dateTime)
+    public static function fromDateTime(DateTimeInterface $dateTime): Value
     {
         $dateTime = clone $dateTime;
 
-        return new static($dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp());
+        return new self($dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp());
     }
 
     /**
      * Creates a Value from the given $timeString.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
-     * @param string $timeString
-     *
-     * @return \Ibexa\Core\FieldType\Time\Value
      */
-    public static function fromString($timeString)
+    public static function fromString(string $timeString): Value
     {
         try {
             return static::fromDateTime(new DateTime($timeString));
@@ -77,12 +67,8 @@ class Value extends BaseValue
      * Creates a Value from the given $timestamp.
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     *
-     * @param int $timestamp
-     *
-     * @return static
      */
-    public static function fromTimestamp($timestamp)
+    public static function fromTimestamp(int $timestamp): Value
     {
         try {
             $dateTime = new DateTime("@{$timestamp}");
@@ -93,14 +79,12 @@ class Value extends BaseValue
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->time === null) {
             return '';
         }
 
-        $dateTime = new DateTime("@{$this->time}");
-
-        return $dateTime->format($this->stringFormat);
+        return (new DateTime("@{$this->time}"))->format($this->stringFormat);
     }
 }

--- a/src/lib/FieldType/Url/Type.php
+++ b/src/lib/FieldType/Url/Type.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Url;
 
@@ -41,13 +42,7 @@ class Type extends FieldType implements TranslationContainerInterface
         return (string)$value->text;
     }
 
-    /**
-     * Returns the fallback default value of field type when no such default
-     * value is provided in the field definition in content types.
-     *
-     * @return \Ibexa\Core\FieldType\Url\Value
-     */
-    public function getEmptyValue()
+    public function getEmptyValue(): Value
     {
         return new Value();
     }
@@ -94,22 +89,12 @@ class Type extends FieldType implements TranslationContainerInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getSortInfo(BaseValue $value): bool
+    protected function getSortInfo(SPIValue $value): false
     {
         return false;
     }
 
-    /**
-     * Converts an $hash to the Value defined by the field type.
-     *
-     * @param mixed $hash
-     *
-     * @return \Ibexa\Core\FieldType\Url\Value $value
-     */
-    public function fromHash($hash)
+    public function fromHash(mixed $hash): Value
     {
         if ($hash === null) {
             return $this->getEmptyValue();
@@ -123,13 +108,11 @@ class Type extends FieldType implements TranslationContainerInterface
     }
 
     /**
-     * Converts a $Value to a hash.
-     *
      * @param \Ibexa\Core\FieldType\Url\Value $value
      *
-     * @return mixed
+     * @return array{link: string|null, text: string|null}|null
      */
-    public function toHash(SPIValue $value)
+    public function toHash(SPIValue $value): ?array
     {
         if ($this->isEmptyValue($value)) {
             return null;
@@ -138,18 +121,11 @@ class Type extends FieldType implements TranslationContainerInterface
         return ['link' => $value->link, 'text' => $value->text];
     }
 
-    public function toPersistenceValue(SPIValue $value)
+    /**
+     * @param \Ibexa\Core\FieldType\Url\Value $value
+     */
+    public function toPersistenceValue(SPIValue $value): FieldValue
     {
-        if ($value === null) {
-            return new FieldValue(
-                [
-                    'data' => [],
-                    'externalData' => null,
-                    'sortKey' => null,
-                ]
-            );
-        }
-
         return new FieldValue(
             [
                 'data' => [
@@ -162,16 +138,7 @@ class Type extends FieldType implements TranslationContainerInterface
         );
     }
 
-    /**
-     * Converts a persistence $fieldValue to a Value.
-     *
-     * This method builds a field type value from the $data and $externalData properties.
-     *
-     * @param \Ibexa\Contracts\Core\Persistence\Content\FieldValue $fieldValue
-     *
-     * @return \Ibexa\Core\FieldType\Url\Value
-     */
-    public function fromPersistenceValue(FieldValue $fieldValue)
+    public function fromPersistenceValue(FieldValue $fieldValue): Value
     {
         if ($fieldValue->externalData === null) {
             return $this->getEmptyValue();
@@ -179,7 +146,7 @@ class Type extends FieldType implements TranslationContainerInterface
 
         return new Value(
             $fieldValue->externalData,
-            $fieldValue->data['text']
+            $fieldValue->data['text'] ?? null
         );
     }
 

--- a/src/lib/FieldType/Url/Value.php
+++ b/src/lib/FieldType/Url/Value.php
@@ -4,43 +4,25 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\Url;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for Url field type.
+ * Value for the Url field type.
  */
 class Value extends BaseValue
 {
-    /**
-     * Link content.
-     *
-     * @var string|null
-     */
-    public $link;
-
-    /**
-     * Text content.
-     *
-     * @var string|null
-     */
-    public $text;
-
-    /**
-     * Construct a new Value object and initialize it with its $link and optional $text.
-     *
-     * @param string $link
-     * @param string $text
-     */
-    public function __construct($link = null, $text = null)
-    {
-        $this->link = $link;
-        $this->text = $text;
+    public function __construct(
+        public readonly ?string $link = null,
+        public readonly ?string $text = null
+    ) {
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->link;
     }

--- a/src/lib/FieldType/User/Value.php
+++ b/src/lib/FieldType/User/Value.php
@@ -4,84 +4,52 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType\User;
 
+use DateTimeImmutable;
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for User field type.
+ * Value for the User field type.
  */
 class Value extends BaseValue
 {
     /**
      * Has stored login.
-     *
-     * @var bool
      */
-    public $hasStoredLogin;
+    public bool $hasStoredLogin;
 
-    /**
-     * Contentobject id.
-     *
-     * @var mixed
-     */
-    public $contentId;
+    public int $contentId;
 
-    /**
-     * Login.
-     *
-     * @var string
-     */
-    public $login;
+    public string $login;
 
     /**
      * Email.
-     *
-     * @var string
      */
-    public $email;
+    public string $email;
 
-    /**
-     * Password hash.
-     *
-     * @var string
-     */
-    public $passwordHash;
+    public string $passwordHash;
 
-    /**
-     * Password hash type.
-     *
-     * @var mixed
-     */
-    public $passwordHashType;
+    public int $passwordHashType;
 
-    /**
-     * @var \DateTimeImmutable|null
-     */
-    public $passwordUpdatedAt;
+    public ?DateTimeImmutable $passwordUpdatedAt;
 
-    /**
-     * Is enabled.
-     *
-     * @var bool
-     */
-    public $enabled;
+    public bool $enabled;
 
     /**
      * Max login.
-     *
-     * @var int
      */
-    public $maxLogin;
+    public int $maxLogin;
 
     /**
-     * @var string Write only property, takes a plain password for use when creating user or updating password.
+     * @var string Write-only property, takes a plain password for use when creating user or updating password.
      */
-    public $plainPassword;
+    public string $plainPassword;
 
-    public function __toString()
+    public function __toString(): string
     {
-        return (string)$this->login;
+        return $this->login;
     }
 }

--- a/src/lib/FieldType/Value.php
+++ b/src/lib/FieldType/Value.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\FieldType;
 
@@ -12,14 +13,13 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 /**
  * Abstract class for all field value classes.
- * A field value object is to be understood with associated field type.
+ *
+ * A field value object is associated with its field type.
  */
 abstract class Value extends ValueObject implements ValueInterface
 {
     /**
      * Returns a string representation of the field value.
-     *
-     * @return string
      */
-    abstract public function __toString();
+    abstract public function __toString(): string;
 }

--- a/src/lib/Repository/Values/ContentType/FieldType.php
+++ b/src/lib/Repository/Values/ContentType/FieldType.php
@@ -52,26 +52,7 @@ class FieldType implements FieldTypeInterface
         return $this->internalFieldType->getName($value, $fieldDefinition, $languageCode);
     }
 
-    /**
-     * Returns a schema for the settings expected by the FieldType.
-     *
-     * Returns an arbitrary value, representing a schema for the settings of
-     * the FieldType.
-     *
-     * Explanation: There are no possible generic schemas for defining settings
-     * input, which is why no schema for the return value of this method is
-     * defined. It is up to the implementer to define and document a schema for
-     * the return value and document it. In addition, it is necessary that all
-     * consumers of this interface (e.g. Public API, REST API, GUIs, ...)
-     * provide plugin mechanisms to hook adapters for the specific FieldType
-     * into. These adapters then need to be either shipped with the FieldType
-     * or need to be implemented by a third party. If there is no adapter
-     * available for a specific FieldType, it will not be usable with the
-     * consumer.
-     *
-     * @return mixed
-     */
-    public function getSettingsSchema()
+    public function getSettingsSchema(): array
     {
         return $this->internalFieldType->getSettingsSchema();
     }

--- a/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldType.php
+++ b/tests/integration/Core/FieldType/FieldConstraintsStorage/Stub/ExampleFieldType.php
@@ -14,7 +14,7 @@ use Ibexa\Core\FieldType\FieldType;
 
 final class ExampleFieldType extends FieldType
 {
-    public const FIELD_TYPE_IDENTIFIER = 'example';
+    public const string FIELD_TYPE_IDENTIFIER = 'example';
 
     protected function createValueFromInput($inputValue): ExampleFieldTypeValue
     {
@@ -31,12 +31,12 @@ final class ExampleFieldType extends FieldType
         return '';
     }
 
-    public function getEmptyValue(): ExampleFieldTypeValue
+    public function getEmptyValue(): Value
     {
         return new ExampleFieldTypeValue();
     }
 
-    public function fromHash($hash): ExampleFieldTypeValue
+    public function fromHash(mixed $hash): Value
     {
         return new ExampleFieldTypeValue();
     }
@@ -46,7 +46,7 @@ final class ExampleFieldType extends FieldType
         // Nothing to do here.
     }
 
-    public function toHash(Value $value)
+    public function toHash(Value $value): null
     {
         return null;
     }
@@ -56,12 +56,12 @@ final class ExampleFieldType extends FieldType
         // Nothing to do here.
     }
 
-    public function validateFieldSettings($fieldSettings): array
+    public function validateFieldSettings(array $fieldSettings): array
     {
         return [];
     }
 
-    public function validateValidatorConfiguration($validatorConfiguration): array
+    public function validateValidatorConfiguration(mixed $validatorConfiguration): array
     {
         return [];
     }

--- a/tests/lib/FieldType/Generic/Stubs/Value.php
+++ b/tests/lib/FieldType/Generic/Stubs/Value.php
@@ -12,19 +12,19 @@ use Ibexa\Contracts\Core\FieldType\Value as ValueInterface;
 
 final class Value implements ValueInterface
 {
-    private $value;
+    private mixed $value;
 
-    public function __construct($value = null)
+    public function __construct(mixed $value = null)
     {
         $this->value = $value;
     }
 
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->value;
     }

--- a/tests/lib/Repository/Service/Mock/ValueStub.php
+++ b/tests/lib/Repository/Service/Mock/ValueStub.php
@@ -4,31 +4,24 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Tests\Core\Repository\Service\Mock;
 
 use Ibexa\Core\FieldType\Value as BaseValue;
 
 /**
- * Value for TextLine field type.
+ * Value for the TextLine field type.
  */
 class ValueStub extends BaseValue
 {
-    /** @var string */
-    public $value;
-
-    /**
-     * Construct a new Value object and initialize it $value.
-     *
-     * @param string $value
-     */
-    public function __construct($value)
+    public function __construct(public readonly string $value)
     {
-        $this->value = $value;
+        parent::__construct();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
-        return (string)$this->value;
+        return $this->value;
     }
 }


### PR DESCRIPTION
> [!CAUTION]
> ATM depends on #619

| :ticket: Issue | IBX-9727 |
|----------------|-----------|
| :dart: DXP version target | TBD |

#### Related PRs: 
- https://github.com/ibexa/core/pull/619


#### Description:

Added strict type hints to field type layer (contracts and implementation).
For now this is just a preview as it's not finished yet. Targeting #619 to have better clarity overall what has been done regarding IBX-9727 and what's still missing.

#### For QA:

Sanity checks, regression build.

#### Documentation:

##### Breaking changes

* `\Ibexa\Contracts\Core\FieldType\FieldType::validateFieldSettings` contract now expects its first argument to be
  of an `array<string, mixed>` type.
* `\Ibexa\Contracts\Core\FieldType\FieldType::getValidatorConfigurationSchema` contract returns now strict `array` and
  hints a hash map (`array<string, mixed>`) as its shape.
* `\Ibexa\Contracts\Core\FieldType\FieldType::getSettingsSchema` contract returns now strict `array` and hits a hash
  map (`array<string, mixed>`) as its shape.
* `\Ibexa\Contracts\Core\FieldType\FieldType::applyDefaultSettings` contract now expects its first argument to be of an
  `array<string, mixed>` type.
* `\Ibexa\Contracts\Core\FieldType\FieldType::isSearchable` contract returns now strict `bool`.
* `\Ibexa\Contracts\Core\FieldType\FieldType::isSingular` contract returns now strict `bool`.
* `\Ibexa\Contracts\Core\FieldType\FieldType::onlyEmptyInstance` contract returns now strict `bool`.
* `\Ibexa\Contracts\Core\FieldType\FieldType::getEmptyValue` contract returns now strict
  `\Ibexa\Contracts\Core\FieldType\Value`. Implementations can return covariant types of
  `\Ibexa\Contracts\Core\FieldType\Value`.
* `\Ibexa\Contracts\Core\FieldType\FieldType::isEmptyValue` contract returns now strict `bool`.
* `\Ibexa\Contracts\Core\FieldType\FieldType::fromHash` contract returns now strict
  `\Ibexa\Contracts\Core\FieldType\Value`. Implementations can return covariant types of
  `\Ibexa\Contracts\Core\FieldType\Value`.
* `\Ibexa\Contracts\Core\FieldType\FieldType::toHash` contract returns now strict `mixed` type. Implementations not
  defining a strict return type at all need to be updated.
* `\Ibexa\Contracts\Core\FieldType\Value::__toString` contract returns now strict `string` type. Make sure your custom
  field type values implementations return the same. The interface itself declares strict types.
* Core field type Value classes' (`\Ibexa\Core\FieldType\*\Value`) members (properties) are now strictly typed and
  `readonly` (except for Binary File-based field types). Instead of overriding their properties, instantiate a new
  Value.
* `\Ibexa\Core\FieldType\FieldType::getSortInfo` method accepts now a strict `\Ibexa\Contracts\Core\FieldType\Value`
  type and returns a strict `mixed` type. Implementation return type can be covariant.  
