### PR TITLE
IBX-9060: Updated StatusCriterionHandler to use `in` expression for multi-status support

### DIFF
--- a/src/lib/Persistence/Legacy/Notification/Gateway/CriterionHandler/StatusCriterionHandler.php
+++ b/src/lib/Persistence/Legacy/Notification/Gateway/CriterionHandler/StatusCriterionHandler.php
@@ -27,7 +27,7 @@ final class StatusCriterionHandler implements CriterionHandlerInterface
 
     public function apply(QueryBuilder $qb, CriterionInterface $criterion): void
     {
-        $qb->andWhere($qb->expr()->eq(DoctrineDatabase::COLUMN_IS_PENDING, ':status'));
-        $qb->setParameter(':status', $criterion->getStatuses(), Connection::PARAM_STR_ARRAY);
+        $qb->andWhere($qb->expr()->in(DoctrineDatabase::COLUMN_IS_PENDING, ':status'));
+        $qb->setParameter(':status', $criterion->getStatuses(), Connection::PARAM_INT_ARRAY);
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-9060 |
|----------------|----------|


#### Description:
This PR fixes an issue where passing both 'read' and 'unread' statuses to the notification search form
resulted in a SQL cardinality error due to use of '=' instead of 'IN'. The criterion handler now uses
`expr()->in()` and `PARAM_INT_ARRAY` to support filtering by multiple status values correctly.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
