### PR TITLE
IBX-8811: Rebranded SiteAccess session prefix

### DIFF
--- a/tests/lib/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizerTest.php
+++ b/tests/lib/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizerTest.php
@@ -66,7 +66,7 @@ final class SimplifiedRequestNormalizerTest extends TestCase
                 'Accept-Encoding' => 'gzip, deflate, br',
                 'Accept-Language' => 'pl-PL,pl;q=0.9,en-US;q=0.8,en;q=0.7',
                 'User-Agent' => 'Mozilla/5.0',
-                'Cookie' => 'eZSESSID21232f297a57a5a743894a0e4a801fc3=mgbs2p6lv936hb5hmdd2cvq6bq',
+                'Cookie' => 'IBX_SESSION_ID21232f297a57a5a743894a0e4a801fc3=mgbs2p6lv936hb5hmdd2cvq6bq',
                 'Connection' => 'keep-alive',
             ],
         );


### PR DESCRIPTION
| :ticket: Issue | IBX-8811 |
|----------------|-----------|

#### Related PRs: 

#420

#### Description:

Fix one forgotten prefix from eZSESSID to IBX_SESSION_ID rebranding.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
