### PR TITLE
Added sorting options to `ibexa:debug:config`

### DIFF
--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -107,13 +107,13 @@ EOM
         $scope = $input->getOption('scope');
         $parameterData = $this->configResolver->getParameter($parameter, $namespace, $scope);
 
-        if (null !== ($sort = $input->getOption('sort')) && is_array($parameterData) && is_array($parameterData[0]) && key_exists($sort, $parameterData[0]) && is_scalar($parameterData[0][$sort])) {
+        if (null !== ($sort = $input->getOption('sort')) && is_array($parameterData) && is_array($parameterData[0]) && array_key_exists($sort, $parameterData[0]) && is_scalar($parameterData[0][$sort])) {
             if ($input->getOption('reverse-sort')) {
-                usort($parameterData, function ($a, $b) use ($sort) {
+                usort($parameterData, static function ($a, $b) use ($sort) {
                     return $b[$sort] <=> $a[$sort];
                 });
             } else {
-                usort($parameterData, function ($a, $b) use ($sort) {
+                usort($parameterData, static function ($a, $b) use ($sort) {
                     return $a[$sort] <=> $b[$sort];
                 });
             }

--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -107,7 +107,7 @@ EOM
         $scope = $input->getOption('scope');
         $parameterData = $this->configResolver->getParameter($parameter, $namespace, $scope);
 
-        if (null !== ($sort = $input->getOption('sort')) && is_array($parameterData) && is_array($parameterData[0])) {
+        if (null !== ($sort = $input->getOption('sort')) && is_array($parameterData) && is_array($parameterData[0]) && key_exists($sort, $parameterData[0]) && is_scalar($parameterData[0][$sort])) {
             if ($input->getOption('reverse-sort')) {
                 usort($parameterData, function ($a, $b) use ($sort) {
                     return $b[$sort] <=> $a[$sort];

--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -69,6 +69,18 @@ class DebugConfigResolverCommand extends Command
             InputOption::VALUE_REQUIRED,
             'Set a different namespace than the default "ibexa.site_access.config" used by SiteAccess settings.'
         );
+        $this->addOption(
+            'sort',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Sort list of hashes by this key, ascending. For example: --sort template'
+        );
+        $this->addOption(
+            'reverse-sort',
+            null,
+            InputOption::VALUE_NONE,
+            'Reverse the sorting to descending. For example: --sort priority --reverse-sort'
+        );
         $this->setHelp(
             <<<EOM
 Outputs a given config resolver parameter, more commonly known as a SiteAccess setting.
@@ -94,6 +106,18 @@ EOM
         $namespace = $input->getOption('namespace');
         $scope = $input->getOption('scope');
         $parameterData = $this->configResolver->getParameter($parameter, $namespace, $scope);
+
+        if (null !== ($sort = $input->getOption('sort')) && is_array($parameterData) && is_array($parameterData[0])) {
+            if ($input->getOption('reverse-sort')) {
+                usort($parameterData, function ($a, $b) use ($sort) {
+                    return $b[$sort] <=> $a[$sort];
+                });
+            } else {
+                usort($parameterData, function ($a, $b) use ($sort) {
+                    return $a[$sort] <=> $b[$sort];
+                });
+            }
+        }
 
         // In case of json output return early with no newlines and only the parameter data
         if ($input->getOption('json')) {

--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -116,11 +116,14 @@ EOM
             if (!array_is_list($parameterData)) {
                 throw new InvalidArgumentException('--sort', "'$parameter' is a hash but sort can be used only on a list (an array with numeral keys incremented from zero).");
             }
-            for ($i = 0, $count = count($parameterData); $i < $count; ++$i) {
-                if (!array_key_exists($sort, $parameterData[$i])) {
+            foreach ($parameterData as $item) {
+                if (!is_array($item) || array_is_list($item)) {
+                    throw new InvalidArgumentException('--sort', "'$parameter' list items aren't all hashes. Sort can be used only on a list of hashes.");
+                }
+                if (!array_key_exists($sort, $item)) {
                     throw new InvalidArgumentException('--sort', "'$sort' property doesn't exist on each '$parameter' list item.");
                 }
-                if (!is_scalar($parameterData[$i][$sort])) {
+                if (!is_scalar($item[$sort])) {
                     throw new InvalidArgumentException('--sort', "'$sort' properties aren't always scalar and can't be sorted.");
                 }
             }

--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -116,7 +116,7 @@ EOM
             if (!array_is_list($parameterData)) {
                 throw new InvalidArgumentException('--sort', "'$parameter' is a hash but sort can be used only on a list (an array with numeral keys incremented from zero).");
             }
-            for ($i=0, $count = count($parameterData); $i < $count; $i++) {
+            for ($i = 0, $count = count($parameterData); $i < $count; ++$i) {
                 if (!array_key_exists($sort, $parameterData[$i])) {
                     throw new InvalidArgumentException('--sort', "'$sort' property doesn't exist on each '$parameter' list item.");
                 }

--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -111,16 +111,18 @@ EOM
 
         if (null !== $sort && !empty($parameterData)) {
             if (!is_array($parameterData)) {
-                throw new InvalidArgumentException('--sort', "'$parameter' isn't a list. Sort can be used only on list.");
+                throw new InvalidArgumentException('--sort', "'$parameter' isn't a list. Sort can be used only on a list.");
             }
             if (!array_is_list($parameterData)) {
-                throw new InvalidArgumentException('--sort', "'$parameter' is a hash or an object. Sort can be used only on list.");
+                throw new InvalidArgumentException('--sort', "'$parameter' is a hash but sort can be used only on a list (an array with numeral keys incremented from zero).");
             }
-            if (!array_key_exists($sort, $parameterData[0])) {
-                throw new InvalidArgumentException('--sort', "'$sort' property doesn't exist on '$parameter' list items.");
-            }
-            if (!is_scalar($parameterData[0][$sort])) {
-                throw new InvalidArgumentException('--sort', "'{$parameter}[n][{$sort}]' properties aren't scalar and can't be sorted.");
+            for ($i=0, $count = count($parameterData); $i < $count; $i++) {
+                if (!array_key_exists($sort, $parameterData[$i])) {
+                    throw new InvalidArgumentException('--sort', "'$sort' property doesn't exist on each '$parameter' list item.");
+                }
+                if (!is_scalar($parameterData[$i][$sort])) {
+                    throw new InvalidArgumentException('--sort', "'$sort' properties aren't always scalar and can't be sorted.");
+                }
             }
             if ($input->getOption('reverse-sort')) {
                 usort($parameterData, static fn (array $a, array $b): int => $b[$sort] <=> $a[$sort]);


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Sort parameter list when sortable, when it's an array of arrays by a scalar value's key.

For example, see `admin` siteaccess field templates by decreasing priority:
`php bin/console ibexa:debug:config field_templates --siteaccess admin --sort priority --reverse-sort`

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
