### PR TITLE
IBX-10428: Fixed invokable commands failing to compile Container

### DIFF
--- a/src/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPass.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,6 +19,11 @@ final class ConsoleCommandPass implements CompilerPassInterface
     {
         foreach ($container->findTaggedServiceIds('console.command') as $id => $attributes) {
             $definition = $container->getDefinition($id);
+
+            $class = $definition->getClass();
+            if (!is_a($class, Command::class, true)) {
+                continue;
+            }
 
             $definition->addMethodCall('addOption', [
                 'siteaccess',

--- a/src/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPass.php
@@ -21,7 +21,7 @@ final class ConsoleCommandPass implements CompilerPassInterface
             $definition = $container->getDefinition($id);
 
             $class = $definition->getClass();
-            if (!is_a($class, Command::class, true)) {
+            if ($class === null || !is_a($class, Command::class, true)) {
                 continue;
             }
 

--- a/tests/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ConsoleCommandPassTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Compiler;
 
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\ConsoleCommandPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -23,7 +24,7 @@ final class ConsoleCommandPassTest extends AbstractCompilerPassTestCase
 
     public function testAddSiteaccessOption(): void
     {
-        $commandDefinition = new Definition();
+        $commandDefinition = new Definition(Command::class);
         $serviceId = 'some_service_id';
         $commandDefinition->addTag('console.command');
 
@@ -40,5 +41,17 @@ final class ConsoleCommandPassTest extends AbstractCompilerPassTestCase
                 'SiteAccess to use for operations. If not provided, default siteaccess will be used',
             ]
         );
+    }
+
+    public function testSkipsSiteaccessOptionOnInvokables(): void
+    {
+        $commandDefinition = new Definition();
+        $serviceId = 'some_service_id';
+        $commandDefinition->addTag('console.command');
+
+        $this->setDefinition($serviceId, $commandDefinition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasService($serviceId);
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-10428 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This fix allows [invokable commands from Symfony](https://symfony.com/blog/new-in-symfony-7-3-invokable-commands-and-input-attributes) to work properly and not crash the application.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
