### PR TITLE
Made CriteriaConverter handlers priority-aware

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49141,18 +49141,6 @@ parameters:
 			path: tests/lib/Base/Container/Compiler/Search/FieldTypeRegistryPassTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriteriaConverterPassTest\:\:testAddContentHandlers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriteriaConverterPassTest\:\:testAddLocationHandlers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriterionFieldValueHandlerRegistryPassTest\:\:testRegisterValueHandler\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9307,18 +9307,6 @@ parameters:
 			path: src/lib/Base/Container/Compiler/Search/FieldRegistryPass.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriteriaConverterPass\:\:addHandlers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriteriaConverterPass\:\:addHandlers\(\) has parameter \$handlers with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Base\\Container\\Compiler\\Search\\Legacy\\CriteriaConverterPass\:\:process\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
@@ -8,65 +8,56 @@ namespace Ibexa\Core\Base\Container\Compiler\Search\Legacy;
 
 use Ibexa\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * This compiler pass will register Legacy Search Engine criterion handlers.
  */
 class CriteriaConverterPass implements CompilerPassInterface
 {
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     */
+    use PriorityTaggedServiceTrait;
+
     public function process(ContainerBuilder $container)
     {
-        if (
-            !$container->hasDefinition('ibexa.search.legacy.gateway.criteria_converter.content') &&
-            !$container->hasDefinition('ibexa.search.legacy.gateway.criteria_converter.location') &&
-            !$container->hasDefinition('ibexa.core.trash.search.legacy.gateway.criteria_converter') &&
-            !$container->hasDefinition(CriteriaConverter::class)
-        ) {
+        $this->setHandlersForConverter(
+            $container,
+            'ibexa.search.legacy.gateway.criteria_converter.content',
+            'ibexa.search.legacy.gateway.criterion_handler.content'
+        );
+
+        $this->setHandlersForConverter(
+            $container,
+            'ibexa.search.legacy.gateway.criteria_converter.location',
+            'ibexa.search.legacy.gateway.criterion_handler.location'
+        );
+
+        $this->setHandlersForConverter(
+            $container,
+            'ibexa.core.trash.search.legacy.gateway.criteria_converter',
+            'ibexa.search.legacy.trash.gateway.criterion.handler'
+        );
+
+        $this->setHandlersForConverter(
+            $container,
+            CriteriaConverter::class,
+            'ibexa.storage.legacy.url.criterion.handler'
+        );
+    }
+
+    private function setHandlersForConverter(
+        ContainerBuilder $container,
+        string $serviceId,
+        string $handlersTag
+    ): void {
+        if (!$container->hasDefinition($serviceId)) {
             return;
         }
 
-        if ($container->hasDefinition('ibexa.search.legacy.gateway.criteria_converter.content')) {
-            $criteriaConverterContent = $container->getDefinition('ibexa.search.legacy.gateway.criteria_converter.content');
-
-            $contentHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.gateway.criterion_handler.content');
-
-            $this->addHandlers($criteriaConverterContent, $contentHandlers);
-        }
-
-        if ($container->hasDefinition('ibexa.search.legacy.gateway.criteria_converter.location')) {
-            $criteriaConverterLocation = $container->getDefinition('ibexa.search.legacy.gateway.criteria_converter.location');
-
-            $locationHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.gateway.criterion_handler.location');
-
-            $this->addHandlers($criteriaConverterLocation, $locationHandlers);
-        }
-
-        if ($container->hasDefinition('ibexa.core.trash.search.legacy.gateway.criteria_converter')) {
-            $trashCriteriaConverter = $container->getDefinition('ibexa.core.trash.search.legacy.gateway.criteria_converter');
-            $trashCriteriaHandlers = $container->findTaggedServiceIds('ibexa.search.legacy.trash.gateway.criterion.handler');
-
-            $this->addHandlers($trashCriteriaConverter, $trashCriteriaHandlers);
-        }
-
-        if ($container->hasDefinition(CriteriaConverter::class)) {
-            $urlCriteriaConverter = $container->getDefinition(CriteriaConverter::class);
-            $urlCriteriaHandlers = $container->findTaggedServiceIds('ibexa.storage.legacy.url.criterion.handler');
-
-            $this->addHandlers($urlCriteriaConverter, $urlCriteriaHandlers);
-        }
-    }
-
-    protected function addHandlers(Definition $definition, $handlers)
-    {
-        foreach ($handlers as $id => $attributes) {
-            $definition->addMethodCall('addHandler', [new Reference($id)]);
-        }
+        $handlers = $this->findAndSortTaggedServices($handlersTag, $container);
+        $container
+            ->getDefinition($serviceId)
+            ->setArgument('$handlers', $handlers);
     }
 }
 

--- a/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
+++ b/src/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
@@ -54,10 +54,11 @@ class CriteriaConverterPass implements CompilerPassInterface
             return;
         }
 
+        $service = $container->getDefinition($serviceId);
         $handlers = $this->findAndSortTaggedServices($handlersTag, $container);
-        $container
-            ->getDefinition($serviceId)
-            ->setArgument('$handlers', $handlers);
+        foreach ($handlers as $handler) {
+            $service->addMethodCall('addHandler', [$handler]);
+        }
     }
 }
 

--- a/tests/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
+++ b/tests/lib/Base/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
@@ -84,29 +84,17 @@ class CriteriaConverterPassTest extends AbstractCompilerPassTestCase
     }
 
     /**
-     * @return iterable<array{string, string}>
+     * @return iterable<string, string>
      */
     public static function provideServiceToTagName(): iterable
     {
-        yield [
-            'ibexa.search.legacy.gateway.criteria_converter.content',
-            'ibexa.search.legacy.gateway.criterion_handler.content',
-        ];
+        yield 'ibexa.search.legacy.gateway.criteria_converter.content' => 'ibexa.search.legacy.gateway.criterion_handler.content';
 
-        yield [
-            'ibexa.search.legacy.gateway.criteria_converter.location',
-            'ibexa.search.legacy.gateway.criterion_handler.location',
-        ];
+        yield 'ibexa.search.legacy.gateway.criteria_converter.location' => 'ibexa.search.legacy.gateway.criterion_handler.location';
 
-        yield [
-            'ibexa.core.trash.search.legacy.gateway.criteria_converter',
-            'ibexa.search.legacy.trash.gateway.criterion.handler',
-        ];
+        yield 'ibexa.core.trash.search.legacy.gateway.criteria_converter' => 'ibexa.search.legacy.trash.gateway.criterion.handler';
 
-        yield [
-            CriteriaConverter::class,
-            'ibexa.storage.legacy.url.criterion.handler',
-        ];
+        yield CriteriaConverter::class => 'ibexa.storage.legacy.url.criterion.handler';
     }
 
     /**
@@ -114,8 +102,8 @@ class CriteriaConverterPassTest extends AbstractCompilerPassTestCase
      */
     public static function provideDescribedServiceToTagName(): iterable
     {
-        foreach (self::provideServiceToTagName() as $serviceToTagName) {
-            yield sprintf('Service "%s" with tag "%s"', $serviceToTagName[0], $serviceToTagName[1]) => $serviceToTagName;
+        foreach (self::provideServiceToTagName() as $serviceId => $tag) {
+            yield sprintf('Service "%s" with tag "%s"', $serviceId, $tag) => [$serviceId, $tag];
         }
     }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/641

#### Description:
Discovered while working on CriteriaConverter issues that their handlers are not sorted by `priority`, which is usually available for tags.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
