### PR TITLE
IBX-10597: Fixed accessing uninitialized image variation properties when switching to the original variation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17029,18 +17029,6 @@ parameters:
 			path: src/lib/Repository/LocationService.php
 
 		-
-			message: '#^Property Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType\:\:\$defaultSortField \(int\) on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.property
-			count: 1
-			path: src/lib/Repository/LocationService.php
-
-		-
-			message: '#^Property Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType\:\:\$defaultSortOrder \(int\) on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.property
-			count: 1
-			path: src/lib/Repository/LocationService.php
-
-		-
 			message: '#^Property Ibexa\\Core\\Repository\\LocationService\:\:\$repository \(Ibexa\\Core\\Repository\\Repository\) does not accept Ibexa\\Contracts\\Core\\Repository\\Repository\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -22647,54 +22635,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:supportsValueProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testGetVariationAlreadyStored\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testGetVariationInvalidVariation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testGetVariationNotStored\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testGetVariationNotStoredHavingReferences\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testGetVariationOriginal\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testGetVariationOriginalNotFound\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testGetVariationWrongValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Imagine\\AliasGeneratorTest\:\:testSupportsValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/bundle/Core/Imagine/AliasGeneratorTest.php
 
@@ -33991,12 +33931,6 @@ parameters:
 			path: tests/integration/Core/Repository/Regression/EZP21771IbexaStringTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Repository\\Regression\\EZP21798Test\:\:testRoleChanges\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/integration/Core/Repository/Regression/EZP21798Test.php
-
-		-
 			message: '#^Parameter \#1 \$value of function count expects array\|Countable, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\User\\Policy\> given\.$#'
 			identifier: argument.type
 			count: 1
@@ -38493,18 +38427,6 @@ parameters:
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLWildcardTranslationResult'' and Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLWildcardTranslationResult will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
-			count: 1
-			path: tests/integration/Core/Repository/URLWildcardServiceTest.php
-
-		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with int will always evaluate to true\.$#'
-			identifier: staticMethod.alreadyNarrowedType
-			count: 1
-			path: tests/integration/Core/Repository/URLWildcardServiceTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Repository\\URLWildcardServiceTest\:\:testCreateSetsIdPropertyOnURLWildcard\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/integration/Core/Repository/URLWildcardServiceTest.php
 
@@ -60373,50 +60295,8 @@ parameters:
 			path: tests/lib/Repository/Values/User/RoleTest.php
 
 		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: staticMethod.alreadyNarrowedType
-			count: 1
-			path: tests/lib/Repository/Values/User/RoleTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Values\\User\\RoleTest\:\:assertPropertiesCorrect\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Values/User/RoleTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Values\\User\\RoleTest\:\:testIsPropertySet\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Values/User/RoleTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Values\\User\\RoleTest\:\:testMissingProperty\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Values/User/RoleTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Values\\User\\RoleTest\:\:testNewClass\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Values/User/RoleTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Values\\User\\RoleTest\:\:testReadOnlyProperty\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Values/User/RoleTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Values\\User\\RoleTest\:\:testUnsetProperty\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Values/User/RoleTest.php
-
-		-
-			message: '#^Property Ibexa\\Contracts\\Core\\Repository\\Values\\User\\Role\:\:\$id \(int\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
 			count: 1
 			path: tests/lib/Repository/Values/User/RoleTest.php
 
@@ -60481,20 +60361,8 @@ parameters:
 			path: tests/lib/Repository/Values/User/UserTest.php
 
 		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: staticMethod.alreadyNarrowedType
-			count: 1
-			path: tests/lib/Repository/Values/User/UserTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Values\\User\\UserTest\:\:assertPropertiesCorrect\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: tests/lib/Repository/Values/User/UserTest.php
-
-		-
-			message: '#^Property Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\:\:\$login \(string\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
 			count: 1
 			path: tests/lib/Repository/Values/User/UserTest.php
 

--- a/src/bundle/Core/Imagine/AliasGenerator.php
+++ b/src/bundle/Core/Imagine/AliasGenerator.php
@@ -134,6 +134,8 @@ class AliasGenerator implements VariationHandler
                 'imageId' => $imageValue->imageId,
                 'width' => $variationWidth,
                 'height' => $variationHeight,
+                'fileSize' => $imageValue->getFileSize() ?? 0,
+                'mimeType' => $imageValue->mime ?? '',
             ]
         );
     }

--- a/src/lib/Repository/LocationService.php
+++ b/src/lib/Repository/LocationService.php
@@ -412,10 +412,8 @@ class LocationService implements LocationServiceInterface
 
         $contentType = $content->getContentType();
 
-        $locationCreateStruct->sortField = $locationCreateStruct->sortField
-            ?? ($contentType->defaultSortField ?? Location::SORT_FIELD_NAME);
-        $locationCreateStruct->sortOrder = $locationCreateStruct->sortOrder
-            ?? ($contentType->defaultSortOrder ?? Location::SORT_ORDER_ASC);
+        $locationCreateStruct->sortField = $locationCreateStruct->sortField ?? $contentType->defaultSortField;
+        $locationCreateStruct->sortOrder = $locationCreateStruct->sortOrder ?? $contentType->defaultSortOrder;
 
         $contentInfo = $content->contentInfo;
 

--- a/tests/bundle/Core/Imagine/AliasGeneratorTest.php
+++ b/tests/bundle/Core/Imagine/AliasGeneratorTest.php
@@ -40,29 +40,29 @@ use Psr\Log\LoggerInterface;
 
 final class AliasGeneratorTest extends TestCase
 {
-    private MockObject|LoaderInterface $dataLoader;
+    private MockObject&LoaderInterface $dataLoader;
 
-    private MockObject|FilterManager $filterManager;
+    private MockObject&FilterManager $filterManager;
 
-    private MockObject|ResolverInterface $ioResolver;
+    private MockObject&ResolverInterface $ioResolver;
 
-    private MockObject|FilterConfiguration $filterConfiguration;
+    private FilterConfiguration $filterConfiguration;
 
-    private MockObject|LoggerInterface $logger;
+    private MockObject&LoggerInterface $logger;
 
-    private MockObject|ImagineInterface $imagine;
+    private MockObject&ImagineInterface $imagine;
 
-    private MockObject|AliasGenerator $aliasGenerator;
+    private AliasGenerator $aliasGenerator;
 
-    private MockObject|VariationHandler $decoratedAliasGenerator;
+    private VariationHandler $decoratedAliasGenerator;
 
-    private MockObject|BoxInterface $box;
+    private MockObject&BoxInterface $box;
 
-    private MockObject|ImageInterface $image;
+    private MockObject&ImageInterface $image;
 
-    private MockObject|IOServiceInterface $ioService;
+    private MockObject&IOServiceInterface $ioService;
 
-    private MockObject|VariationPathGenerator $variationPathGenerator;
+    private MockObject&VariationPathGenerator $variationPathGenerator;
 
     protected function setUp(): void
     {

--- a/tests/bundle/Core/Imagine/AliasGeneratorTest.php
+++ b/tests/bundle/Core/Imagine/AliasGeneratorTest.php
@@ -4,16 +4,19 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Tests\Bundle\Core\Imagine;
 
 use DateTime;
 use Ibexa\Bundle\Core\Imagine\AliasGenerator;
 use Ibexa\Bundle\Core\Imagine\Variation\ImagineAwareAliasGenerator;
+use Ibexa\Contracts\Core\FieldType\Value;
 use Ibexa\Contracts\Core\FieldType\Value as FieldTypeValue;
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidVariationException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Variation\Values\ImageVariation;
+use Ibexa\Contracts\Core\Variation\VariationHandler;
 use Ibexa\Contracts\Core\Variation\VariationPathGenerator;
 use Ibexa\Core\FieldType\Image\Value as ImageValue;
 use Ibexa\Core\FieldType\TextLine\Value as TextLineValue;
@@ -31,46 +34,35 @@ use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class AliasGeneratorTest extends TestCase
+final class AliasGeneratorTest extends TestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Liip\ImagineBundle\Binary\Loader\LoaderInterface */
-    private $dataLoader;
+    private MockObject|LoaderInterface $dataLoader;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Liip\ImagineBundle\Imagine\Filter\FilterManager */
-    private $filterManager;
+    private MockObject|FilterManager $filterManager;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface */
-    private $ioResolver;
+    private MockObject|ResolverInterface $ioResolver;
 
-    /** @var \Liip\ImagineBundle\Imagine\Filter\FilterConfiguration */
-    private $filterConfiguration;
+    private MockObject|FilterConfiguration $filterConfiguration;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Psr\Log\LoggerInterface */
-    private $logger;
+    private MockObject|LoggerInterface $logger;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Imagine\Image\ImagineInterface */
-    private $imagine;
+    private MockObject|ImagineInterface $imagine;
 
-    /** @var \Ibexa\Bundle\Core\Imagine\AliasGenerator */
-    private $aliasGenerator;
+    private MockObject|AliasGenerator $aliasGenerator;
 
-    /** @var \Ibexa\Contracts\Core\Variation\VariationHandler */
-    private $decoratedAliasGenerator;
+    private MockObject|VariationHandler $decoratedAliasGenerator;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Imagine\Image\BoxInterface */
-    private $box;
+    private MockObject|BoxInterface $box;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Imagine\Image\ImageInterface */
-    private $image;
+    private MockObject|ImageInterface $image;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Core\IO\IOServiceInterface */
-    private $ioService;
+    private MockObject|IOServiceInterface $ioService;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Ibexa\Contracts\Core\Variation\VariationPathGenerator */
-    private $variationPathGenerator;
+    private MockObject|VariationPathGenerator $variationPathGenerator;
 
     protected function setUp(): void
     {
@@ -105,11 +97,8 @@ class AliasGeneratorTest extends TestCase
 
     /**
      * @dataProvider supportsValueProvider
-     *
-     * @param \Ibexa\Contracts\Core\FieldType\Value $value
-     * @param bool $isSupported
      */
-    public function testSupportsValue($value, $isSupported)
+    public function testSupportsValue(Value $value, bool $isSupported): void
     {
         self::assertSame($isSupported, $this->aliasGenerator->supportsValue($value));
     }
@@ -123,7 +112,7 @@ class AliasGeneratorTest extends TestCase
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function supportsValueProvider()
+    public function supportsValueProvider(): array
     {
         return [
             [$this->createMock(FieldTypeValue::class), false],
@@ -133,7 +122,7 @@ class AliasGeneratorTest extends TestCase
         ];
     }
 
-    public function testGetVariationWrongValue()
+    public function testGetVariationWrongValue(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -149,7 +138,7 @@ class AliasGeneratorTest extends TestCase
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function testGetVariationNotStored()
+    public function testGetVariationNotStored(): void
     {
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'my_variation';
@@ -195,7 +184,7 @@ class AliasGeneratorTest extends TestCase
         );
     }
 
-    public function testGetVariationOriginal()
+    public function testGetVariationOriginal(): void
     {
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'original';
@@ -209,6 +198,8 @@ class AliasGeneratorTest extends TestCase
                 'imageId' => $imageId,
                 'width' => $imageWidth,
                 'height' => $imageHeight,
+                'fileSize' => 1024,
+                'mime' => 'image/jpeg',
             ]
         );
         $field = new Field([
@@ -242,9 +233,18 @@ class AliasGeneratorTest extends TestCase
                 'imageId' => $imageId,
                 'height' => $imageHeight,
                 'width' => $imageWidth,
+                'fileSize' => 1024,
+                'mimeType' => 'image/jpeg',
             ]
         );
-        self::assertEquals($expected, $this->decoratedAliasGenerator->getVariation($field, new VersionInfo(), $variationName));
+        self::assertEquals(
+            $expected,
+            $this->decoratedAliasGenerator->getVariation(
+                $field,
+                new VersionInfo(),
+                $variationName
+            )
+        );
     }
 
     /**
@@ -252,7 +252,7 @@ class AliasGeneratorTest extends TestCase
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function testGetVariationNotStoredHavingReferences()
+    public function testGetVariationNotStoredHavingReferences(): void
     {
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'my_variation';
@@ -323,7 +323,7 @@ class AliasGeneratorTest extends TestCase
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function testGetVariationAlreadyStored()
+    public function testGetVariationAlreadyStored(): void
     {
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'my_variation';
@@ -362,7 +362,7 @@ class AliasGeneratorTest extends TestCase
         );
     }
 
-    public function testGetVariationOriginalNotFound()
+    public function testGetVariationOriginalNotFound(): void
     {
         $this->expectException(SourceImageNotFoundException::class);
 
@@ -378,7 +378,7 @@ class AliasGeneratorTest extends TestCase
         $this->aliasGenerator->getVariation($field, new VersionInfo(), 'foo');
     }
 
-    public function testGetVariationInvalidVariation()
+    public function testGetVariationInvalidVariation(): void
     {
         $this->expectException(InvalidVariationException::class);
 

--- a/tests/integration/Core/Repository/Regression/EZP21798Test.php
+++ b/tests/integration/Core/Repository/Regression/EZP21798Test.php
@@ -23,7 +23,7 @@ class EZP21798Test extends BaseTestCase
      * This test will verify that anonymous users can access to a new section
      * that it's allowed to
      */
-    public function testRoleChanges()
+    public function testRoleChanges(): void
     {
         $repository = $this->getRepository();
         $permissionResolver = $repository->getPermissionResolver();

--- a/tests/integration/Core/Repository/URLWildcardServiceTest.php
+++ b/tests/integration/Core/Repository/URLWildcardServiceTest.php
@@ -58,20 +58,6 @@ class URLWildcardServiceTest extends BaseTestCase
      *
      * @depends testCreate
      */
-    public function testCreateSetsIdPropertyOnURLWildcard(URLWildcard $urlWildcard)
-    {
-        self::assertNotNull($urlWildcard->id);
-    }
-
-    /**
-     * Test for the create() method.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\URLWildcard $urlWildcard
-     *
-     * @covers \Ibexa\Contracts\Core\Repository\URLWildcardService::create()
-     *
-     * @depends testCreate
-     */
     public function testCreateSetsPropertiesOnURLWildcard(URLWildcard $urlWildcard)
     {
         $this->assertPropertiesCorrect(

--- a/tests/lib/Repository/Values/User/RoleTest.php
+++ b/tests/lib/Repository/Values/User/RoleTest.php
@@ -23,7 +23,7 @@ class RoleTest extends TestCase
     /**
      * Test a new class and default values on properties.
      */
-    public function testNewClass()
+    public function testNewClass(): void
     {
         $this->assertPropertiesCorrect(
             [
@@ -40,7 +40,7 @@ class RoleTest extends TestCase
      *
      * @covers \Ibexa\Core\Repository\Values\User\Role::__get
      */
-    public function testMissingProperty()
+    public function testMissingProperty(): void
     {
         $this->expectException(PropertyNotFoundException::class);
 
@@ -54,7 +54,7 @@ class RoleTest extends TestCase
      *
      * @covers \Ibexa\Core\Repository\Values\User\Role::__set
      */
-    public function testReadOnlyProperty()
+    public function testReadOnlyProperty(): void
     {
         $this->expectException(PropertyReadOnlyException::class);
 
@@ -66,14 +66,11 @@ class RoleTest extends TestCase
     /**
      * Test if property exists.
      */
-    public function testIsPropertySet()
+    public function testIsPropertySet(): void
     {
         $role = new Role();
         $value = isset($role->notDefined);
         self::assertFalse($value);
-
-        $value = isset($role->id);
-        self::assertTrue($value);
     }
 
     /**
@@ -81,7 +78,7 @@ class RoleTest extends TestCase
      *
      * @covers \Ibexa\Core\Repository\Values\User\Role::__unset
      */
-    public function testUnsetProperty()
+    public function testUnsetProperty(): void
     {
         $this->expectException(PropertyReadOnlyException::class);
 

--- a/tests/lib/Repository/Values/User/UserTest.php
+++ b/tests/lib/Repository/Values/User/UserTest.php
@@ -77,9 +77,6 @@ final class UserTest extends TestCase
         $user = new User();
         $value = isset($user->notDefined);
         self::assertFalse($value);
-
-        $value = isset($user->login);
-        self::assertTrue($value);
     }
 
     public function testUnsetProperty(): void


### PR DESCRIPTION
| :ticket: Issue | IBX-10597 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
>[!NOTE]
> I fixed issues reported by freshly updated PHPStan whenever I could, the rest landed in the baseline. Can be extracted to a separate PR if needed.

The issue stems from the fact, that `fileSize` and `mimeType` are uninitialized when switching to the original variation. Since we have strict typing for this area, this results in 500 error. Getting mentioned properties from `Ibexa\Core\FieldType\Image\Value` seems to be the most logical approach but I am open for other ideas.

I updated failing tests showing the concept in practice, also added missing strict types wherever missing (and spotted).

#### For QA:
Sanities on images and variations.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
