### PR TITLE
Added method to get first prioritized language

### DIFF
--- a/src/contracts/Repository/LanguageResolver.php
+++ b/src/contracts/Repository/LanguageResolver.php
@@ -35,6 +35,15 @@ interface LanguageResolver
     public function getPrioritizedLanguages(?array $forcedLanguages = null): array;
 
     /**
+     * Get first prioritized language taking into account forced, context, and configured languages.
+     *
+     * @param array|null $forcedLanguages Optional, typically arguments provided to API, will be used first if set.
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\OutOfBoundsException If no prioritized language is found.
+     */
+    public function getFirstPrioritizedLanguage(?array $forcedLanguages = null): string;
+
+    /**
      * Get currently set UseAlwaysAvailable.
      *
      * @param bool|null $forcedUseAlwaysAvailable Optional, if set will be used instead of configured value,

--- a/src/lib/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
+++ b/src/lib/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Core\Repository\SiteAccessAware\Language;
 
+use Ibexa\Contracts\Core\Repository\Exceptions\OutOfBoundsException;
 use Ibexa\Contracts\Core\Repository\LanguageResolver as APILanguageResolver;
 use Ibexa\Contracts\Core\Repository\Values\Content\Language;
 
@@ -106,6 +107,18 @@ abstract class AbstractLanguageResolver implements APILanguageResolver
         }
 
         return array_values(array_unique(array_merge($languages, $this->getConfiguredLanguages())));
+    }
+
+    public function getFirstPrioritizedLanguage(?array $forcedLanguages = null): string
+    {
+        $languages = $this->getPrioritizedLanguages();
+
+        $firstLanguage = reset($languages);
+        if ($firstLanguage === false) {
+            throw new OutOfBoundsException('No prioritized language found.');
+        }
+
+        return $firstLanguage;
     }
 
     /**

--- a/tests/lib/Repository/SiteAccessAware/Language/LanguageResolverTest.php
+++ b/tests/lib/Repository/SiteAccessAware/Language/LanguageResolverTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Core\Repository\SiteAccessAware\Language;
 
+use Ibexa\Contracts\Core\Repository\Exceptions\OutOfBoundsException;
 use Ibexa\Core\Repository\SiteAccessAware\Language\LanguageResolver;
 use PHPUnit\Framework\TestCase;
 
@@ -48,6 +49,29 @@ class LanguageResolverTest extends TestCase
             $expectedPrioritizedLanguagesList,
             $languageResolver->getPrioritizedLanguages($forcedLanguages)
         );
+    }
+
+    public function testGetFirstPrioritizedLanguage(): void
+    {
+        $languageResolver = new LanguageResolver(
+            configLanguages: ['pol-PL', 'eng-GB'],
+            defaultUseAlwaysAvailable: true,
+            defaultShowAllTranslations: false
+        );
+
+        self::assertEquals('eng-GB', $languageResolver->getFirstPrioritizedLanguage());
+    }
+
+    public function testGetFirstPrioritizedLanguageThrowsExceptionWhenNoLanguageFound(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        $languageResolver = new LanguageResolver(
+            configLanguages: [],
+            defaultUseAlwaysAvailable: true,
+            defaultShowAllTranslations: false
+        );
+        $languageResolver->getFirstPrioritizedLanguage();
     }
 
     /**


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Added `\Ibexa\Contracts\Core\Repository\LanguageResolver::getFirstPrioritizedLanguage` method to retrieve first prioritized language. 


#### For QA:
N/A

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
