### PR TITLE
IBX-10849: [IO] Fixed passing string as a value of Content-Length header

### DIFF
--- a/src/bundle/IO/BinaryStreamResponse.php
+++ b/src/bundle/IO/BinaryStreamResponse.php
@@ -245,7 +245,7 @@ class BinaryStreamResponse extends Response
 
                 $this->setStatusCode(Response::HTTP_PARTIAL_CONTENT);
                 $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
-                $this->headers->set('Content-Length', $end - $start + 1);
+                $this->headers->set('Content-Length', (string) ($end - $start + 1));
             }
         }
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-10849 |
|----------------|-----------|


#### Description:
BinaryStreamResponse headers->set() function argument 2 ($values) must be of type array|string|null. Int was provided, and caused Exception.

#### For QA:
PR is providing test that covers the case.

#### Documentation:

