### PR TITLE
IBX-10854: Added ability to hide content item drafts

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -33792,11 +33792,6 @@ parameters:
 			count: 4
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
-		-
-			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, int\|null given\.$#'
-			identifier: argument.type
-			count: 12
-			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
 			message: '#^Parameter \#1 \$locations of method Ibexa\\Tests\\Integration\\Core\\Repository\\ContentServiceTest\:\:filterHiddenLocations\(\) expects array\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\>, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\> given\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -33768,11 +33768,6 @@ parameters:
 			count: 4
 			path: tests/integration/Core/Repository/ContentServiceTest.php
 
-		-
-			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, int\|null given\.$#'
-			identifier: argument.type
-			count: 12
-			path: tests/integration/Core/Repository/ContentServiceTest.php
 
 		-
 			message: '#^Parameter \#1 \$locations of method Ibexa\\Tests\\Integration\\Core\\Repository\\ContentServiceTest\:\:filterHiddenLocations\(\) expects array\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\>, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\> given\.$#'

--- a/src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/src/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -933,30 +933,37 @@ final class DoctrineDatabase extends Gateway
         // select all node assignments with OP_CODE_CREATE (3) for this content
         $query = $this->connection->createQueryBuilder();
         $query
-            ->select('*')
-            ->from('eznode_assignment')
+            ->select('na.*', 'co.is_hidden AS content_is_hidden')
+            ->from('eznode_assignment', 'na')
+            ->innerJoin(
+                'na',
+                'ezcontentobject',
+                'co',
+                'co.id = na.contentobject_id'
+            )
             ->where(
                 $query->expr()->eq(
-                    'contentobject_id',
+                    'na.contentobject_id',
                     $query->createPositionalParameter($contentId, ParameterType::INTEGER)
                 )
             )
             ->andWhere(
                 $query->expr()->eq(
-                    'contentobject_version',
+                    'na.contentobject_version',
                     $query->createPositionalParameter($versionNo, ParameterType::INTEGER)
                 )
             )
             ->andWhere(
                 $query->expr()->eq(
-                    'op_code',
+                    'na.op_code',
                     $query->createPositionalParameter(
                         self::NODE_ASSIGNMENT_OP_CODE_CREATE,
                         ParameterType::INTEGER
                     )
                 )
             )
-            ->orderBy('id');
+            ->orderBy('na.id');
+
         $statement = $query->execute();
 
         // convert all these assignments to nodes
@@ -967,7 +974,11 @@ final class DoctrineDatabase extends Gateway
             $mainLocationId = $isMain ? null : $this->getMainNodeId($contentId);
 
             $parentLocationData = $this->getBasicNodeData((int)$row['parent_node']);
-            $isInvisible = $row['is_hidden'] || $parentLocationData['is_hidden'] || $parentLocationData['is_invisible'];
+            $isInvisible =
+                (bool) $row['is_hidden']
+                || (bool) $row['content_is_hidden']
+                || $parentLocationData['is_hidden']
+                || $parentLocationData['is_invisible'];
             $this->create(
                 new CreateStruct(
                     [

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2531,14 +2531,17 @@ class ContentService implements ContentServiceInterface
      */
     public function hideContent(ContentInfo $contentInfo): void
     {
-        $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
-        if (!$this->permissionResolver->canUser(
-            'content',
-            'hide',
-            $contentInfo,
-            [$locationTarget]
-        )) {
-            throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
+        // If content is in draft state, mainLocationId is yet not set
+        if ($contentInfo->mainLocationId !== null) {
+            $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
+            if (!$this->permissionResolver->canUser(
+                'content',
+                'hide',
+                $contentInfo,
+                [$locationTarget]
+            )) {
+                throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
+            }
         }
 
         $this->repository->beginTransaction();
@@ -2571,14 +2574,17 @@ class ContentService implements ContentServiceInterface
      */
     public function revealContent(ContentInfo $contentInfo): void
     {
-        $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
-        if (!$this->permissionResolver->canUser(
-            'content',
-            'hide',
-            $contentInfo,
-            [$locationTarget]
-        )) {
-            throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
+        // If content is in draft state, mainLocationId is yet not set
+        if ($contentInfo->mainLocationId !== null) {
+            $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
+            if (!$this->permissionResolver->canUser(
+                'content',
+                'hide',
+                $contentInfo,
+                [$locationTarget]
+            )) {
+                throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
+            }
         }
 
         $this->repository->beginTransaction();

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2532,9 +2532,9 @@ class ContentService implements ContentServiceInterface
     public function hideContent(ContentInfo $contentInfo): void
     {
         // If ContentInfo is in draft state, mainLocationId is yet not set
-        $locationTarget = !$contentInfo->isDraft()
-            ? [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)]
-            : [];
+        $locationTarget = $contentInfo->isDraft()
+            ? []
+            : [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)];
         if (!$this->permissionResolver->canUser(
             'content',
             'hide',

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2533,7 +2533,7 @@ class ContentService implements ContentServiceInterface
     {
         // If ContentInfo is in draft state, mainLocationId is yet not set
         $locationTarget = !$contentInfo->isDraft()
-            ? [new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo)]
+            ? [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)]
             : [];
         if (!$this->permissionResolver->canUser(
             'content',
@@ -2576,7 +2576,7 @@ class ContentService implements ContentServiceInterface
     {
         // If ContentInfo is in draft state, mainLocationId is yet not set
         $locationTarget = !$contentInfo->isDraft()
-            ? [new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo)]
+            ? [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)]
             : [];
 
         if (!$this->permissionResolver->canUser(

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2531,17 +2531,17 @@ class ContentService implements ContentServiceInterface
      */
     public function hideContent(ContentInfo $contentInfo): void
     {
-        // If ContentInfo is in draft state, mainLocationId is yet not set
-        if (!$contentInfo->isDraft()) {
-            $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
-            if (!$this->permissionResolver->canUser(
-                'content',
-                'hide',
-                $contentInfo,
-                [$locationTarget]
-            )) {
-                throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
-            }
+        // If ContentInfo is in draft state, mainocationId is yet not set
+        $locationTarget = !$contentInfo->isDraft()
+            ? [new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo)]
+            : [];
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $contentInfo,
+            $locationTarget
+        )) {
+            throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
         }
 
         $this->repository->beginTransaction();
@@ -2575,16 +2575,17 @@ class ContentService implements ContentServiceInterface
     public function revealContent(ContentInfo $contentInfo): void
     {
         // If ContentInfo is in draft state, mainLocationId is yet not set
-        if (!$contentInfo->isDraft()) {
-            $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
-            if (!$this->permissionResolver->canUser(
-                'content',
-                'hide',
-                $contentInfo,
-                [$locationTarget]
-            )) {
-                throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
-            }
+        $locationTarget = !$contentInfo->isDraft()
+            ? [new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo)]
+            : [];
+
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $contentInfo,
+            [$locationTarget]
+        )) {
+            throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
         }
 
         $this->repository->beginTransaction();

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2583,7 +2583,7 @@ class ContentService implements ContentServiceInterface
             'content',
             'hide',
             $contentInfo,
-            [$locationTarget]
+            $locationTarget
         )) {
             throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
         }

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2531,8 +2531,8 @@ class ContentService implements ContentServiceInterface
      */
     public function hideContent(ContentInfo $contentInfo): void
     {
-        // If content is in draft state, mainLocationId is yet not set
-        if ($contentInfo->mainLocationId !== null) {
+        // If ContentInfo is in draft state, mainLocationId is yet not set
+        if (!$contentInfo->isDraft()) {
             $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
             if (!$this->permissionResolver->canUser(
                 'content',
@@ -2574,8 +2574,8 @@ class ContentService implements ContentServiceInterface
      */
     public function revealContent(ContentInfo $contentInfo): void
     {
-        // If content is in draft state, mainLocationId is yet not set
-        if ($contentInfo->mainLocationId !== null) {
+        // If ContentInfo is in draft state, mainLocationId is yet not set
+        if (!$contentInfo->isDraft()) {
             $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
             if (!$this->permissionResolver->canUser(
                 'content',

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2575,9 +2575,9 @@ class ContentService implements ContentServiceInterface
     public function revealContent(ContentInfo $contentInfo): void
     {
         // If ContentInfo is in draft state, mainLocationId is yet not set
-        $locationTarget = !$contentInfo->isDraft()
-            ? [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)]
-            : [];
+        $locationTarget = $contentInfo->isDraft()
+            ? []
+            : [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)];
 
         if (!$this->permissionResolver->canUser(
             'content',

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2531,7 +2531,7 @@ class ContentService implements ContentServiceInterface
      */
     public function hideContent(ContentInfo $contentInfo): void
     {
-        // If ContentInfo is in draft state, mainocationId is yet not set
+        // If ContentInfo is in draft state, mainLocationId is yet not set
         $locationTarget = !$contentInfo->isDraft()
             ? [new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo)]
             : [];

--- a/src/lib/Repository/ContentService.php
+++ b/src/lib/Repository/ContentService.php
@@ -2531,17 +2531,17 @@ class ContentService implements ContentServiceInterface
      */
     public function hideContent(ContentInfo $contentInfo): void
     {
-        // If content is in draft state, mainLocationId is yet not set
-        if ($contentInfo->mainLocationId !== null) {
-            $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
-            if (!$this->permissionResolver->canUser(
-                'content',
-                'hide',
-                $contentInfo,
-                [$locationTarget]
-            )) {
-                throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
-            }
+        // If ContentInfo is in draft state, mainLocationId is yet not set
+        $targets = $contentInfo->isDraft()
+            ? []
+            : [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)];
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $contentInfo,
+            $targets
+        )) {
+            throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
         }
 
         $this->repository->beginTransaction();
@@ -2574,17 +2574,18 @@ class ContentService implements ContentServiceInterface
      */
     public function revealContent(ContentInfo $contentInfo): void
     {
-        // If content is in draft state, mainLocationId is yet not set
-        if ($contentInfo->mainLocationId !== null) {
-            $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
-            if (!$this->permissionResolver->canUser(
-                'content',
-                'hide',
-                $contentInfo,
-                [$locationTarget]
-            )) {
-                throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
-            }
+        // If ContentInfo is in draft state, mainLocationId is yet not set
+        $targets = $contentInfo->isDraft()
+            ? []
+            : [new DestinationLocationTarget($contentInfo->getMainLocationId(), $contentInfo)];
+
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $contentInfo,
+            $targets
+        )) {
+            throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
         }
 
         $this->repository->beginTransaction();

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -6230,20 +6230,17 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
-     * @covers \Ibexa\Contracts\Core\Repository\ContentService::hideContent
-
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\APIInvalidArgumentException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws BadStateException
+     * @throws ContentFieldValidationException
+     * @throws NotFoundException
+     * @throws UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
     public function testHideContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(false);
-        $location = $this->locationService->loadLocation($publishedContent->contentInfo->mainLocationId);
+        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
         $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
         self::assertTrue($content->contentInfo->isHidden, 'Content is not hidden');
@@ -6260,7 +6257,8 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideAndRevealContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(true);
-        $location = $this->locationService->loadLocation($publishedContent->contentInfo->mainLocationId);
+        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
         $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
         self::assertFalse($content->contentInfo->isHidden, 'Content is hidden');
@@ -6268,11 +6266,11 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\APIInvalidArgumentException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws APIInvalidArgumentException
+     * @throws BadStateException
+     * @throws ContentFieldValidationException
+     * @throws NotFoundException
+     * @throws UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
     private function createContentForHideRevealDraftTests(bool $hideAndRevel): Content

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -6239,10 +6239,10 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
-     * @throws BadStateException
-     * @throws ContentFieldValidationException
-     * @throws NotFoundException
-     * @throws UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
     public function testHideContentDraft(): void
@@ -6275,11 +6275,11 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
-     * @throws APIInvalidArgumentException
-     * @throws BadStateException
-     * @throws ContentFieldValidationException
-     * @throws NotFoundException
-     * @throws UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
     private function createContentForHideRevealDraftTests(bool $hideAndRevel): Content

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -3610,7 +3610,8 @@ class ContentServiceTest extends BaseContentServiceTest
             $demoDesign
         );
 
-        $demoDesignLocation = $this->locationService->loadLocation($demoDesign->mainLocationId);
+        self::assertNotNull($demoDesign->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $demoDesignLocation = $this->locationService->loadLocation($demoDesign->getMainLocationId());
 
         // Trashing Content's last Location will change its status to archived,
         // in this case relation towards it will not be loaded.
@@ -3936,7 +3937,8 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->publishVersion($mediaDraft->getVersionInfo());
         $this->contentService->publishVersion($demoDesignDraft->getVersionInfo());
 
-        $demoDesignLocation = $this->locationService->loadLocation($demoDesignDraft->contentInfo->mainLocationId);
+        self::assertNotNull($demoDesignDraft->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $demoDesignLocation = $this->locationService->loadLocation($demoDesignDraft->contentInfo->getMainLocationId());
 
         // Trashing Content's last Location will change its status to archived,
         // in this case relation from it will not be loaded.
@@ -4138,7 +4140,8 @@ class ContentServiceTest extends BaseContentServiceTest
             $draft3,
         ]);
 
-        $locationToTrash = $this->locationService->loadLocation($draft3->contentInfo->mainLocationId);
+        self::assertNotNull($draft3->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $locationToTrash = $this->locationService->loadLocation($draft3->contentInfo->getMainLocationId());
 
         // Trashing Content's last Location will change its status to archived, in this case relation from it will not be loaded.
         $trashService->trash($locationToTrash);
@@ -5100,8 +5103,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // Automatically creates a new URLAlias for the content
         $liveContent = $this->contentService->publishVersion($draft->getVersionInfo());
 
+        self::assertNotNull($liveContent->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
+            $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId()
         );
 
         $aliases = $urlAliasService->listLocationAliases($location, false);
@@ -5128,8 +5132,9 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $draft = $this->createUpdatedDraftVersion2();
 
+        self::assertNotNull($draft->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation(
-            $draft->getVersionInfo()->getContentInfo()->mainLocationId
+            $draft->getVersionInfo()->getContentInfo()->getMainLocationId()
         );
 
         // Load and assert URL aliases before publishing updated Content, so that
@@ -5156,8 +5161,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // and creates new aliases, based on the changes
         $liveContent = $this->contentService->publishVersion($draft->getVersionInfo());
 
+        self::assertNotNull($liveContent->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
+            $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId()
         );
 
         $aliases = $urlAliasService->listLocationAliases($location, false);
@@ -5195,10 +5201,11 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $content = $this->createContentVersion1();
 
+        self::assertNotNull($content->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         // Create a custom URL alias
         $urlAliasService->createUrlAlias(
             $this->locationService->loadLocation(
-                $content->getVersionInfo()->getContentInfo()->mainLocationId
+                $content->getVersionInfo()->getContentInfo()->getMainLocationId()
             ),
             '/my/fancy/story-about-ibexa-dxp',
             self::ENG_US
@@ -5219,8 +5226,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // the custom one is left untouched
         $liveContent = $this->contentService->publishVersion($draftVersion2->getVersionInfo());
 
+        self::assertNotNull($liveContent->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
+            $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId()
         );
 
         $aliases = $urlAliasService->listLocationAliases($location);
@@ -5391,7 +5399,8 @@ class ContentServiceTest extends BaseContentServiceTest
         $urlAliasService = $this->getRepository()->getURLAliasService();
 
         $content = $this->createContentVersion2();
-        $mainLocation = $this->locationService->loadLocation($content->contentInfo->mainLocationId);
+        self::assertNotNull($content->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $mainLocation = $this->locationService->loadLocation($content->contentInfo->getMainLocationId());
 
         // create custom URL alias for Content main Location
         $urlAliasService->createUrlAlias($mainLocation, '/my-custom-url', self::ENG_GB);
@@ -6338,7 +6347,9 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[2]->contentInfo);
 
         $parentContent = $this->contentService->loadContent($contents[0]->id);
-        $parentLocation = $this->locationService->loadLocation($parentContent->contentInfo->mainLocationId);
+
+        self::assertNotNull($parentContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $parentLocation = $this->locationService->loadLocation($parentContent->contentInfo->getMainLocationId());
         $parentSublocations = $this->locationService->loadLocationList([
             $contents[1]->contentInfo->mainLocationId,
             $contents[2]->contentInfo->mainLocationId,
@@ -6396,9 +6407,11 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[0]->contentInfo);
 
         $directChildContent = $this->contentService->loadContent($contents[1]->id);
-        $directChildLocation = $this->locationService->loadLocation($directChildContent->contentInfo->mainLocationId);
+        self::assertNotNull($directChildContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $directChildLocation = $this->locationService->loadLocation($directChildContent->contentInfo->getMainLocationId());
 
         $childContent = $this->contentService->loadContent($contents[2]->id);
+        self::assertNotNull($childContent->contentInfo->mainLocationId, 'Expected mainLocationId to be set for this test case.');
         $childLocation = $this->locationService->loadLocation($childContent->contentInfo->mainLocationId);
         $childSublocations = $this->locationService->loadLocationList([
             $contents[3]->contentInfo->mainLocationId,

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -6248,9 +6248,11 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(false);
+        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
-        self::assertTrue($publishedContent->contentInfo->isHidden, 'Content is not hidden');
+        $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
+        self::assertTrue($content->contentInfo->isHidden, 'Content is not hidden');
         self::assertTrue($location->isHidden(), 'Location is visible');
     }
 
@@ -6264,9 +6266,11 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideAndRevealContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(true);
+        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
-        self::assertFalse($publishedContent->contentInfo->isHidden, 'Content is hidden');
+        $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
+        self::assertFalse($content->contentInfo->isHidden, 'Content is hidden');
         self::assertFalse($location->isHidden(), 'Location is hidden');
     }
 
@@ -6278,7 +6282,7 @@ class ContentServiceTest extends BaseContentServiceTest
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
-    private function createContentForHideRevealDraftTests(bool $hideAndReveal): Content
+    private function createContentForHideRevealDraftTests(bool $hideAndRevel): Content
     {
         $contentTypeService = $this->getRepository()->getContentTypeService();
 
@@ -6295,14 +6299,11 @@ class ContentServiceTest extends BaseContentServiceTest
         );
 
         $this->contentService->hideContent($draft->contentInfo);
-        if ($hideAndReveal) {
+        if ($hideAndRevel) {
             $this->contentService->revealContent($draft->contentInfo);
         }
 
-        $publishedContent = $this->contentService->publishVersion($draft->versionInfo);
-        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-
-        return $publishedContent;
+        return $this->contentService->publishVersion($draft->versionInfo);
     }
 
     /**

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -3938,7 +3938,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->publishVersion($mediaDraft->getVersionInfo());
         $this->contentService->publishVersion($demoDesignDraft->getVersionInfo());
 
-        $demoDesignLocationId = $demoDesignDraft->contentInfo->getMainLocationId();
+        $demoDesignLocationId = $demoDesignDraft->getContentInfo()->getMainLocationId();
         self::assertNotNull($demoDesignLocationId, 'Expected mainLocationId to be set for this test case.');
         $demoDesignLocation = $this->locationService->loadLocation($demoDesignLocationId);
 
@@ -4142,7 +4142,7 @@ class ContentServiceTest extends BaseContentServiceTest
             $draft3,
         ]);
 
-        $draft3MainLocationId = $draft3->contentInfo->getMainLocationId();
+        $draft3MainLocationId = $draft3->getContentInfo()->getMainLocationId();
         self::assertNotNull($draft3MainLocationId, 'Expected mainLocationId to be set for this test case.');
         $locationToTrash = $this->locationService->loadLocation($draft3MainLocationId);
 
@@ -6250,7 +6250,7 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(false);
-        $publishedContentMainLocationId = $publishedContent->contentInfo->getMainLocationId();
+        $publishedContentMainLocationId = $publishedContent->getContentInfo()->getMainLocationId();
         self::assertNotNull(
             $publishedContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
@@ -6272,7 +6272,7 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideAndRevealContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(true);
-        $publishedContentMainLocationId = $publishedContent->contentInfo->getMainLocationId();
+        $publishedContentMainLocationId = $publishedContent->getContentInfo()->getMainLocationId();
         self::assertNotNull(
             $publishedContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
@@ -6355,7 +6355,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[2]->contentInfo);
 
         $parentContent = $this->contentService->loadContent($contents[0]->id);
-        $parentContentMainLocationId = $parentContent->contentInfo->getMainLocationId();
+        $parentContentMainLocationId = $parentContent->getContentInfo()->getMainLocationId();
 
         self::assertNotNull(
             $parentContentMainLocationId,
@@ -6419,7 +6419,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[0]->contentInfo);
 
         $directChildContent = $this->contentService->loadContent($contents[1]->id);
-        $directChildContentMainLocationId = $directChildContent->contentInfo->getMainLocationId();
+        $directChildContentMainLocationId = $directChildContent->getContentInfo()->getMainLocationId();
         self::assertNotNull(
             $directChildContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
@@ -6427,7 +6427,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $directChildLocation = $this->locationService->loadLocation($directChildContentMainLocationId);
 
         $childContent = $this->contentService->loadContent($contents[2]->id);
-        $childContentMainLocationId = $childContent->contentInfo->getMainLocationId();
+        $childContentMainLocationId = $childContent->getContentInfo()->getMainLocationId();
         self::assertNotNull(
             $childContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -6257,8 +6257,8 @@ class ContentServiceTest extends BaseContentServiceTest
         );
         $location = $this->locationService->loadLocation($publishedContentMainLocationId);
 
-        $content = $this->contentService->loadContent($publishedContent->contentInfo->getId());
-        self::assertTrue($content->contentInfo->isHidden(), 'Content is not hidden');
+        $content = $this->contentService->loadContent($publishedContent->getContentInfo()->getId());
+        self::assertTrue($content->getContentInfo()->isHidden(), 'Content is not hidden');
         self::assertTrue($location->isHidden(), 'Location is visible');
     }
 
@@ -6279,8 +6279,8 @@ class ContentServiceTest extends BaseContentServiceTest
         );
         $location = $this->locationService->loadLocation($publishedContentMainLocationId);
 
-        $content = $this->contentService->loadContent($publishedContent->contentInfo->getId());
-        self::assertFalse($content->contentInfo->isHidden(), 'Content is hidden');
+        $content = $this->contentService->loadContent($publishedContent->getContentInfo()->getId());
+        self::assertFalse($content->getContentInfo()->isHidden(), 'Content is hidden');
         self::assertFalse($location->isHidden(), 'Location is hidden');
     }
 
@@ -6306,12 +6306,13 @@ class ContentServiceTest extends BaseContentServiceTest
             [$locationCreateStructs]
         );
 
-        $this->contentService->hideContent($draft->contentInfo);
+        $draftContentInfo = $draft->getContentInfo();
+        $this->contentService->hideContent($draftContentInfo);
         if ($revel) {
-            $this->contentService->revealContent($draft->contentInfo);
+            $this->contentService->revealContent($draftContentInfo);
         }
 
-        return $this->contentService->publishVersion($draft->versionInfo);
+        return $this->contentService->publishVersion($draft->getVersionInfo());
     }
 
     /**

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -6292,7 +6292,7 @@ class ContentServiceTest extends BaseContentServiceTest
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
-    private function createContentForHideRevealDraftTests(bool $revel): Content
+    private function createContentForHideRevealDraftTests(bool $reveal): Content
     {
         $contentTypeService = $this->getRepository()->getContentTypeService();
         $locationCreateStructs = $this->locationService->newLocationCreateStruct(2);
@@ -6308,7 +6308,7 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $draftContentInfo = $draft->getContentInfo();
         $this->contentService->hideContent($draftContentInfo);
-        if ($revel) {
+        if ($reveal) {
             $this->contentService->revealContent($draftContentInfo);
         }
 

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -6248,11 +6248,9 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(false);
-        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
-        $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
-        self::assertTrue($content->contentInfo->isHidden, 'Content is not hidden');
+        self::assertTrue($publishedContent->contentInfo->isHidden, 'Content is not hidden');
         self::assertTrue($location->isHidden(), 'Location is visible');
     }
 
@@ -6266,11 +6264,9 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideAndRevealContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(true);
-        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
         $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
-        $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
-        self::assertFalse($content->contentInfo->isHidden, 'Content is hidden');
+        self::assertFalse($publishedContent->contentInfo->isHidden, 'Content is hidden');
         self::assertFalse($location->isHidden(), 'Location is hidden');
     }
 
@@ -6282,7 +6278,7 @@ class ContentServiceTest extends BaseContentServiceTest
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
-    private function createContentForHideRevealDraftTests(bool $hideAndRevel): Content
+    private function createContentForHideRevealDraftTests(bool $hideAndReveal): Content
     {
         $contentTypeService = $this->getRepository()->getContentTypeService();
 
@@ -6299,11 +6295,14 @@ class ContentServiceTest extends BaseContentServiceTest
         );
 
         $this->contentService->hideContent($draft->contentInfo);
-        if ($hideAndRevel) {
+        if ($hideAndReveal) {
             $this->contentService->revealContent($draft->contentInfo);
         }
 
-        return $this->contentService->publishVersion($draft->versionInfo);
+        $publishedContent = $this->contentService->publishVersion($draft->versionInfo);
+        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+
+        return $publishedContent;
     }
 
     /**

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -3610,8 +3610,9 @@ class ContentServiceTest extends BaseContentServiceTest
             $demoDesign
         );
 
-        self::assertNotNull($demoDesign->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $demoDesignLocation = $this->locationService->loadLocation($demoDesign->getMainLocationId());
+        $demoDesignMainLocationId = $demoDesign->getMainLocationId();
+        self::assertNotNull($demoDesignMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $demoDesignLocation = $this->locationService->loadLocation($demoDesignMainLocationId);
 
         // Trashing Content's last Location will change its status to archived,
         // in this case relation towards it will not be loaded.
@@ -3937,8 +3938,9 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->publishVersion($mediaDraft->getVersionInfo());
         $this->contentService->publishVersion($demoDesignDraft->getVersionInfo());
 
-        self::assertNotNull($demoDesignDraft->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $demoDesignLocation = $this->locationService->loadLocation($demoDesignDraft->contentInfo->getMainLocationId());
+        $demoDesignLocationId = $demoDesignDraft->contentInfo->getMainLocationId();
+        self::assertNotNull($demoDesignLocationId, 'Expected mainLocationId to be set for this test case.');
+        $demoDesignLocation = $this->locationService->loadLocation($demoDesignLocationId);
 
         // Trashing Content's last Location will change its status to archived,
         // in this case relation from it will not be loaded.
@@ -4140,8 +4142,9 @@ class ContentServiceTest extends BaseContentServiceTest
             $draft3,
         ]);
 
-        self::assertNotNull($draft3->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $locationToTrash = $this->locationService->loadLocation($draft3->contentInfo->getMainLocationId());
+        $draft3MainLocationId = $draft3->contentInfo->getMainLocationId();
+        self::assertNotNull($draft3MainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $locationToTrash = $this->locationService->loadLocation($draft3MainLocationId);
 
         // Trashing Content's last Location will change its status to archived, in this case relation from it will not be loaded.
         $trashService->trash($locationToTrash);
@@ -5103,10 +5106,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // Automatically creates a new URLAlias for the content
         $liveContent = $this->contentService->publishVersion($draft->getVersionInfo());
 
-        self::assertNotNull($liveContent->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId()
-        );
+        $liveContentInfoMainLocationId = $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($liveContentInfoMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($liveContentInfoMainLocationId);
 
         $aliases = $urlAliasService->listLocationAliases($location, false);
 
@@ -5132,10 +5134,9 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $draft = $this->createUpdatedDraftVersion2();
 
-        self::assertNotNull($draft->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $location = $this->locationService->loadLocation(
-            $draft->getVersionInfo()->getContentInfo()->getMainLocationId()
-        );
+        $draftMainLocationId = $draft->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($draftMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($draftMainLocationId);
 
         // Load and assert URL aliases before publishing updated Content, so that
         // SPI cache is warmed up and cache invalidation is also tested.
@@ -5161,10 +5162,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // and creates new aliases, based on the changes
         $liveContent = $this->contentService->publishVersion($draft->getVersionInfo());
 
-        self::assertNotNull($liveContent->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId()
-        );
+        $liveContentInfoMainLocationId = $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($liveContentInfoMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($liveContentInfoMainLocationId);
 
         $aliases = $urlAliasService->listLocationAliases($location, false);
 
@@ -5201,12 +5201,11 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $content = $this->createContentVersion1();
 
-        self::assertNotNull($content->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        $contentMainLocationId = $content->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($contentMainLocationId, 'Expected mainLocationId to be set for this test case.');
         // Create a custom URL alias
         $urlAliasService->createUrlAlias(
-            $this->locationService->loadLocation(
-                $content->getVersionInfo()->getContentInfo()->getMainLocationId()
-            ),
+            $this->locationService->loadLocation($contentMainLocationId),
             '/my/fancy/story-about-ibexa-dxp',
             self::ENG_US
         );
@@ -5226,10 +5225,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // the custom one is left untouched
         $liveContent = $this->contentService->publishVersion($draftVersion2->getVersionInfo());
 
-        self::assertNotNull($liveContent->getVersionInfo()->getContentInfo()->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId()
-        );
+        $liveContentMainLocationId = $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($liveContentMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($liveContentMainLocationId);
 
         $aliases = $urlAliasService->listLocationAliases($location);
 
@@ -5399,11 +5397,12 @@ class ContentServiceTest extends BaseContentServiceTest
         $urlAliasService = $this->getRepository()->getURLAliasService();
 
         $content = $this->createContentVersion2();
+        $contentMainLocationId = $content->getContentInfo()->getMainLocationId();
         self::assertNotNull(
-            $content->contentInfo->getMainLocationId(),
+            $contentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
         );
-        $mainLocation = $this->locationService->loadLocation($content->contentInfo->getMainLocationId());
+        $mainLocation = $this->locationService->loadLocation($contentMainLocationId);
 
         // create custom URL alias for Content main Location
         $urlAliasService->createUrlAlias($mainLocation, '/my-custom-url', self::ENG_GB);
@@ -6251,11 +6250,12 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(false);
+        $publishedContentMainLocationId = $publishedContent->contentInfo->getMainLocationId();
         self::assertNotNull(
-            $publishedContent->contentInfo->getMainLocationId(),
+            $publishedContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
         );
-        $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
+        $location = $this->locationService->loadLocation($publishedContentMainLocationId);
 
         $content = $this->contentService->loadContent($publishedContent->contentInfo->getId());
         self::assertTrue($content->contentInfo->isHidden(), 'Content is not hidden');
@@ -6272,11 +6272,12 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideAndRevealContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(true);
+        $publishedContentMainLocationId = $publishedContent->contentInfo->getMainLocationId();
         self::assertNotNull(
-            $publishedContent->contentInfo->getMainLocationId(),
+            $publishedContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
         );
-        $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
+        $location = $this->locationService->loadLocation($publishedContentMainLocationId);
 
         $content = $this->contentService->loadContent($publishedContent->contentInfo->getId());
         self::assertFalse($content->contentInfo->isHidden(), 'Content is hidden');
@@ -6291,12 +6292,10 @@ class ContentServiceTest extends BaseContentServiceTest
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
      */
-    private function createContentForHideRevealDraftTests(bool $hideAndRevel): Content
+    private function createContentForHideRevealDraftTests(bool $revel): Content
     {
         $contentTypeService = $this->getRepository()->getContentTypeService();
-
         $locationCreateStructs = $this->locationService->newLocationCreateStruct(2);
-
         $contentType = $contentTypeService->loadContentTypeByIdentifier('folder');
 
         $contentCreate = $this->contentService->newContentCreateStruct($contentType, self::ENG_US);
@@ -6308,7 +6307,7 @@ class ContentServiceTest extends BaseContentServiceTest
         );
 
         $this->contentService->hideContent($draft->contentInfo);
-        if ($hideAndRevel) {
+        if ($revel) {
             $this->contentService->revealContent($draft->contentInfo);
         }
 
@@ -6356,12 +6355,13 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[2]->contentInfo);
 
         $parentContent = $this->contentService->loadContent($contents[0]->id);
+        $parentContentMainLocationId = $parentContent->contentInfo->getMainLocationId();
 
         self::assertNotNull(
-            $parentContent->contentInfo->getMainLocationId(),
+            $parentContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
         );
-        $parentLocation = $this->locationService->loadLocation($parentContent->contentInfo->getMainLocationId());
+        $parentLocation = $this->locationService->loadLocation($parentContentMainLocationId);
         $parentSublocations = $this->locationService->loadLocationList([
             $contents[1]->contentInfo->mainLocationId,
             $contents[2]->contentInfo->mainLocationId,
@@ -6419,20 +6419,20 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[0]->contentInfo);
 
         $directChildContent = $this->contentService->loadContent($contents[1]->id);
+        $directChildContentMainLocationId = $directChildContent->contentInfo->getMainLocationId();
         self::assertNotNull(
-            $directChildContent->contentInfo->getMainLocationId(),
+            $directChildContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
         );
-        $directChildLocation = $this->locationService->loadLocation(
-            $directChildContent->contentInfo->getMainLocationId()
-        );
+        $directChildLocation = $this->locationService->loadLocation($directChildContentMainLocationId);
 
         $childContent = $this->contentService->loadContent($contents[2]->id);
+        $childContentMainLocationId = $childContent->contentInfo->getMainLocationId();
         self::assertNotNull(
-            $childContent->contentInfo->getMainLocationId(),
+            $childContentMainLocationId,
             'Expected mainLocationId to be set for this test case.'
         );
-        $childLocation = $this->locationService->loadLocation($childContent->contentInfo->getMainLocationId());
+        $childLocation = $this->locationService->loadLocation($childContentMainLocationId);
         $childSublocations = $this->locationService->loadLocationList([
             $contents[3]->contentInfo->mainLocationId,
             $contents[4]->contentInfo->mainLocationId,

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -5399,7 +5399,10 @@ class ContentServiceTest extends BaseContentServiceTest
         $urlAliasService = $this->getRepository()->getURLAliasService();
 
         $content = $this->createContentVersion2();
-        self::assertNotNull($content->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        self::assertNotNull(
+            $content->contentInfo->getMainLocationId(),
+            'Expected mainLocationId to be set for this test case.'
+        );
         $mainLocation = $this->locationService->loadLocation($content->contentInfo->getMainLocationId());
 
         // create custom URL alias for Content main Location
@@ -6248,11 +6251,14 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(false);
-        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        self::assertNotNull(
+            $publishedContent->contentInfo->getMainLocationId(),
+            'Expected mainLocationId to be set for this test case.'
+        );
         $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
-        $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
-        self::assertTrue($content->contentInfo->isHidden, 'Content is not hidden');
+        $content = $this->contentService->loadContent($publishedContent->contentInfo->getId());
+        self::assertTrue($content->contentInfo->isHidden(), 'Content is not hidden');
         self::assertTrue($location->isHidden(), 'Location is visible');
     }
 
@@ -6266,11 +6272,14 @@ class ContentServiceTest extends BaseContentServiceTest
     public function testHideAndRevealContentDraft(): void
     {
         $publishedContent = $this->createContentForHideRevealDraftTests(true);
-        self::assertNotNull($publishedContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        self::assertNotNull(
+            $publishedContent->contentInfo->getMainLocationId(),
+            'Expected mainLocationId to be set for this test case.'
+        );
         $location = $this->locationService->loadLocation($publishedContent->contentInfo->getMainLocationId());
 
-        $content = $this->contentService->loadContent($publishedContent->contentInfo->id);
-        self::assertFalse($content->contentInfo->isHidden, 'Content is hidden');
+        $content = $this->contentService->loadContent($publishedContent->contentInfo->getId());
+        self::assertFalse($content->contentInfo->isHidden(), 'Content is hidden');
         self::assertFalse($location->isHidden(), 'Location is hidden');
     }
 
@@ -6348,7 +6357,10 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $parentContent = $this->contentService->loadContent($contents[0]->id);
 
-        self::assertNotNull($parentContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
+        self::assertNotNull(
+            $parentContent->contentInfo->getMainLocationId(),
+            'Expected mainLocationId to be set for this test case.'
+        );
         $parentLocation = $this->locationService->loadLocation($parentContent->contentInfo->getMainLocationId());
         $parentSublocations = $this->locationService->loadLocationList([
             $contents[1]->contentInfo->mainLocationId,
@@ -6407,11 +6419,19 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[0]->contentInfo);
 
         $directChildContent = $this->contentService->loadContent($contents[1]->id);
-        self::assertNotNull($directChildContent->contentInfo->getMainLocationId(), 'Expected mainLocationId to be set for this test case.');
-        $directChildLocation = $this->locationService->loadLocation($directChildContent->contentInfo->getMainLocationId());
+        self::assertNotNull(
+            $directChildContent->contentInfo->getMainLocationId(),
+            'Expected mainLocationId to be set for this test case.'
+        );
+        $directChildLocation = $this->locationService->loadLocation(
+            $directChildContent->contentInfo->getMainLocationId()
+        );
 
         $childContent = $this->contentService->loadContent($contents[2]->id);
-        self::assertNotNull($childContent->contentInfo->mainLocationId, 'Expected mainLocationId to be set for this test case.');
+        self::assertNotNull(
+            $childContent->contentInfo->getMainLocationId(),
+            'Expected mainLocationId to be set for this test case.'
+        );
         $childLocation = $this->locationService->loadLocation($childContent->contentInfo->mainLocationId);
         $childSublocations = $this->locationService->loadLocationList([
             $contents[3]->contentInfo->mainLocationId,

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -6432,7 +6432,7 @@ class ContentServiceTest extends BaseContentServiceTest
             $childContent->contentInfo->getMainLocationId(),
             'Expected mainLocationId to be set for this test case.'
         );
-        $childLocation = $this->locationService->loadLocation($childContent->contentInfo->mainLocationId);
+        $childLocation = $this->locationService->loadLocation($childContent->contentInfo->getMainLocationId());
         $childSublocations = $this->locationService->loadLocationList([
             $contents[3]->contentInfo->mainLocationId,
             $contents[4]->contentInfo->mainLocationId,

--- a/tests/integration/Core/Repository/ContentServiceTest.php
+++ b/tests/integration/Core/Repository/ContentServiceTest.php
@@ -3610,7 +3610,9 @@ class ContentServiceTest extends BaseContentServiceTest
             $demoDesign
         );
 
-        $demoDesignLocation = $this->locationService->loadLocation($demoDesign->mainLocationId);
+        $demoDesignMainLocationId = $demoDesign->getMainLocationId();
+        self::assertNotNull($demoDesignMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $demoDesignLocation = $this->locationService->loadLocation($demoDesignMainLocationId);
 
         // Trashing Content's last Location will change its status to archived,
         // in this case relation towards it will not be loaded.
@@ -3936,7 +3938,9 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->publishVersion($mediaDraft->getVersionInfo());
         $this->contentService->publishVersion($demoDesignDraft->getVersionInfo());
 
-        $demoDesignLocation = $this->locationService->loadLocation($demoDesignDraft->contentInfo->mainLocationId);
+        $demoDesignLocationId = $demoDesignDraft->getContentInfo()->getMainLocationId();
+        self::assertNotNull($demoDesignLocationId, 'Expected mainLocationId to be set for this test case.');
+        $demoDesignLocation = $this->locationService->loadLocation($demoDesignLocationId);
 
         // Trashing Content's last Location will change its status to archived,
         // in this case relation from it will not be loaded.
@@ -4138,7 +4142,9 @@ class ContentServiceTest extends BaseContentServiceTest
             $draft3,
         ]);
 
-        $locationToTrash = $this->locationService->loadLocation($draft3->contentInfo->mainLocationId);
+        $draft3MainLocationId = $draft3->getContentInfo()->getMainLocationId();
+        self::assertNotNull($draft3MainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $locationToTrash = $this->locationService->loadLocation($draft3MainLocationId);
 
         // Trashing Content's last Location will change its status to archived, in this case relation from it will not be loaded.
         $trashService->trash($locationToTrash);
@@ -5100,9 +5106,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // Automatically creates a new URLAlias for the content
         $liveContent = $this->contentService->publishVersion($draft->getVersionInfo());
 
-        $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
-        );
+        $liveContentInfoMainLocationId = $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($liveContentInfoMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($liveContentInfoMainLocationId);
 
         $aliases = $urlAliasService->listLocationAliases($location, false);
 
@@ -5128,9 +5134,9 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $draft = $this->createUpdatedDraftVersion2();
 
-        $location = $this->locationService->loadLocation(
-            $draft->getVersionInfo()->getContentInfo()->mainLocationId
-        );
+        $draftMainLocationId = $draft->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($draftMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($draftMainLocationId);
 
         // Load and assert URL aliases before publishing updated Content, so that
         // SPI cache is warmed up and cache invalidation is also tested.
@@ -5156,9 +5162,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // and creates new aliases, based on the changes
         $liveContent = $this->contentService->publishVersion($draft->getVersionInfo());
 
-        $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
-        );
+        $liveContentInfoMainLocationId = $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($liveContentInfoMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($liveContentInfoMainLocationId);
 
         $aliases = $urlAliasService->listLocationAliases($location, false);
 
@@ -5195,11 +5201,11 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $content = $this->createContentVersion1();
 
+        $contentMainLocationId = $content->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($contentMainLocationId, 'Expected mainLocationId to be set for this test case.');
         // Create a custom URL alias
         $urlAliasService->createUrlAlias(
-            $this->locationService->loadLocation(
-                $content->getVersionInfo()->getContentInfo()->mainLocationId
-            ),
+            $this->locationService->loadLocation($contentMainLocationId),
             '/my/fancy/story-about-ibexa-dxp',
             self::ENG_US
         );
@@ -5219,9 +5225,9 @@ class ContentServiceTest extends BaseContentServiceTest
         // the custom one is left untouched
         $liveContent = $this->contentService->publishVersion($draftVersion2->getVersionInfo());
 
-        $location = $this->locationService->loadLocation(
-            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
-        );
+        $liveContentMainLocationId = $liveContent->getVersionInfo()->getContentInfo()->getMainLocationId();
+        self::assertNotNull($liveContentMainLocationId, 'Expected mainLocationId to be set for this test case.');
+        $location = $this->locationService->loadLocation($liveContentMainLocationId);
 
         $aliases = $urlAliasService->listLocationAliases($location);
 
@@ -5391,7 +5397,12 @@ class ContentServiceTest extends BaseContentServiceTest
         $urlAliasService = $this->getRepository()->getURLAliasService();
 
         $content = $this->createContentVersion2();
-        $mainLocation = $this->locationService->loadLocation($content->contentInfo->mainLocationId);
+        $contentMainLocationId = $content->getContentInfo()->getMainLocationId();
+        self::assertNotNull(
+            $contentMainLocationId,
+            'Expected mainLocationId to be set for this test case.'
+        );
+        $mainLocation = $this->locationService->loadLocation($contentMainLocationId);
 
         // create custom URL alias for Content main Location
         $urlAliasService->createUrlAlias($mainLocation, '/my-custom-url', self::ENG_GB);
@@ -6230,6 +6241,171 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
+     */
+    public function testPublishHiddenDraft(): void
+    {
+        $draft = $this->createFolderDraft();
+        $draftContentInfo = $draft->getContentInfo();
+        $this->contentService->hideContent($draftContentInfo);
+
+        $publishedContent = $this->contentService->publishVersion($draft->getVersionInfo());
+        $contentInfo = $publishedContent->getContentInfo();
+
+        self::assertTrue($contentInfo->isHidden(), 'Content is not hidden');
+
+        $mainLocationId = $contentInfo->getMainLocationId();
+
+        self::assertNotNull(
+            $mainLocationId,
+            'Expected mainLocationId to be set for this test case.'
+        );
+
+        $location = $this->locationService->loadLocation($mainLocationId);
+        self::assertTrue($location->isHidden(), 'Location is visible');
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
+     */
+    public function testPublishRevealedDraft(): void
+    {
+        $draft = $this->createFolderDraft();
+        $draftContentInfo = $draft->getContentInfo();
+
+        $this->contentService->hideContent($draftContentInfo);
+        self::assertTrue(
+            $this->contentService
+                ->loadContent($draftContentInfo->getId())
+                ->getContentInfo()
+                ->isHidden()
+        );
+
+        $this->contentService->revealContent($draftContentInfo);
+        self::assertFalse(
+            $this->contentService
+                ->loadContent($draftContentInfo->getId())
+                ->getContentInfo()
+                ->isHidden()
+        );
+
+        $publishedContent = $this->contentService->publishVersion(
+            $draft->getVersionInfo()
+        );
+
+        $contentInfo = $publishedContent->getContentInfo();
+        $mainLocationId = $contentInfo->getMainLocationId();
+
+        self::assertFalse($contentInfo->isHidden(), 'Content is hidden');
+        self::assertNotNull(
+            $mainLocationId,
+            'Expected mainLocationId to be set for this test case.'
+        );
+
+        $location = $this->locationService->loadLocation($mainLocationId);
+
+        self::assertFalse($location->isHidden(), 'Location is hidden');
+    }
+
+    /**
+     * @dataProvider draftVisibilityTransitionsProvider
+     *
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
+     */
+    public function testDraftVisibilityTransitions(
+        bool $initiallyHidden,
+        bool $secondDraftHidden
+    ): void {
+        $draft = $this->createFolderDraft();
+
+        if ($initiallyHidden) {
+            $this->contentService->hideContent($draft->getContentInfo());
+        }
+
+        $publishedContent = $this->contentService->publishVersion($draft->getVersionInfo());
+        $draft2 = $this->contentService->createContentDraft($publishedContent->getContentInfo());
+
+        if ($secondDraftHidden) {
+            $this->contentService->hideContent($draft2->getContentInfo());
+        } else {
+            $this->contentService->revealContent($draft2->getContentInfo());
+        }
+
+        $publishedContent2 = $this->contentService->publishVersion($draft2->getVersionInfo());
+        $contentInfo = $publishedContent2->getContentInfo();
+
+        self::assertSame(
+            $secondDraftHidden,
+            $contentInfo->isHidden(),
+            'Unexpected final hidden state for content.'
+        );
+
+        $mainLocationId = $contentInfo->getMainLocationId();
+
+        self::assertNotNull(
+            $mainLocationId,
+            'Expected mainLocationId to be set.'
+        );
+
+        $location = $this->locationService->loadLocation($mainLocationId);
+
+        self::assertSame(
+            $secondDraftHidden,
+            $location->isHidden(),
+            'Unexpected final hidden state for location.'
+        );
+    }
+
+    /**
+     * @return iterable<string, array{bool, bool}>
+     */
+    public static function draftVisibilityTransitionsProvider(): iterable
+    {
+        yield 'hidden -> hidden' => [true, true];
+        yield 'hidden -> visible' => [true, false];
+        yield 'visible -> hidden' => [false, true];
+        yield 'visible -> visible' => [false, false];
+    }
+
+    /**
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ContentValidationException
+     */
+    private function createFolderDraft(): Content
+    {
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+        $locationCreateStructs = $this->locationService->newLocationCreateStruct(2);
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('folder');
+
+        $contentCreate = $this->contentService->newContentCreateStruct($contentType, self::ENG_US);
+        $contentCreate->setField('name', 'Folder to hide');
+
+        return $this->contentService->createContent(
+            $contentCreate,
+            [$locationCreateStructs]
+        );
+    }
+
+    /**
      * @depends testRevealContent
      */
     public function testRevealContentWithHiddenParent()
@@ -6270,7 +6446,13 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[2]->contentInfo);
 
         $parentContent = $this->contentService->loadContent($contents[0]->id);
-        $parentLocation = $this->locationService->loadLocation($parentContent->contentInfo->mainLocationId);
+        $parentContentMainLocationId = $parentContent->getContentInfo()->getMainLocationId();
+
+        self::assertNotNull(
+            $parentContentMainLocationId,
+            'Expected mainLocationId to be set for this test case.'
+        );
+        $parentLocation = $this->locationService->loadLocation($parentContentMainLocationId);
         $parentSublocations = $this->locationService->loadLocationList([
             $contents[1]->contentInfo->mainLocationId,
             $contents[2]->contentInfo->mainLocationId,
@@ -6328,10 +6510,20 @@ class ContentServiceTest extends BaseContentServiceTest
         $this->contentService->revealContent($contents[0]->contentInfo);
 
         $directChildContent = $this->contentService->loadContent($contents[1]->id);
-        $directChildLocation = $this->locationService->loadLocation($directChildContent->contentInfo->mainLocationId);
+        $directChildContentMainLocationId = $directChildContent->getContentInfo()->getMainLocationId();
+        self::assertNotNull(
+            $directChildContentMainLocationId,
+            'Expected mainLocationId to be set for this test case.'
+        );
+        $directChildLocation = $this->locationService->loadLocation($directChildContentMainLocationId);
 
         $childContent = $this->contentService->loadContent($contents[2]->id);
-        $childLocation = $this->locationService->loadLocation($childContent->contentInfo->mainLocationId);
+        $childContentMainLocationId = $childContent->getContentInfo()->getMainLocationId();
+        self::assertNotNull(
+            $childContentMainLocationId,
+            'Expected mainLocationId to be set for this test case.'
+        );
+        $childLocation = $this->locationService->loadLocation($childContentMainLocationId);
         $childSublocations = $this->locationService->loadLocationList([
             $contents[3]->contentInfo->mainLocationId,
             $contents[4]->contentInfo->mainLocationId,

--- a/tests/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/tests/lib/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -1478,6 +1478,129 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
             )
         );
     }
+
+    public function testCreateLocationsFromNodeAssignmentsCreatesMainLocation(): void
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+
+        $gateway = $this->getLocationGateway();
+
+        $gateway->createNodeAssignment(
+            new CreateStruct([
+                'contentId' => 68,
+                'contentVersion' => 1,
+                'mainLocationId' => true,
+                'remoteId' => 'some_id',
+            ]),
+            77,
+            DoctrineDatabase::NODE_ASSIGNMENT_OP_CODE_CREATE
+        );
+
+        $gateway->createLocationsFromNodeAssignments(68, 1);
+
+        $this->assertQueryResult(
+            [[68, 77, 0, 0]],
+            $this->buildContentTreeSelectContentWithParentQuery(
+                68,
+                77,
+                ['contentobject_id', 'parent_node_id', 'is_hidden', 'is_invisible']
+            )
+        );
+    }
+
+    public function testCreateLocationsFromNodeAssignmentsUpdatesNodeAssignmentOpcode(): void
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+
+        $gateway = $this->getLocationGateway();
+
+        $gateway->createNodeAssignment(
+            new CreateStruct([
+                'contentId' => 68,
+                'contentVersion' => 1,
+                'mainLocationId' => true,
+                'remoteId' => 'some_id',
+            ]),
+            77,
+            DoctrineDatabase::NODE_ASSIGNMENT_OP_CODE_CREATE
+        );
+
+        $gateway->createLocationsFromNodeAssignments(68, 1);
+
+        $this->assertQueryResult(
+            [[DoctrineDatabase::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP]],
+            $this->buildNodeAssignmentSelectContentWithParentQuery(
+                68,
+                77,
+                ['op_code']
+            )
+        );
+    }
+
+    public function testCreateLocationsFromNodeAssignmentsCreatesSecondaryLocation(): void
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+
+        $gateway = $this->getLocationGateway();
+
+        $gateway->createNodeAssignment(
+            new CreateStruct([
+                'contentId' => 75,
+                'contentVersion' => 1,
+                'mainLocationId' => 77,
+                'remoteId' => 'secondary',
+            ]),
+            69,
+            DoctrineDatabase::NODE_ASSIGNMENT_OP_CODE_CREATE
+        );
+
+        $gateway->createLocationsFromNodeAssignments(75, 1);
+
+        $this->assertQueryResult(
+            [[75, 69]],
+            $this->buildContentTreeSelectContentWithParentQuery(
+                75,
+                69,
+                ['contentobject_id', 'parent_node_id']
+            )
+        );
+    }
+
+    public function testCreateLocationsFromNodeAssignmentsCreatesInvisibleLocationForHiddenContent(): void
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+
+        $query = $this->getDatabaseConnection()->createQueryBuilder();
+        $query
+            ->update('ezcontentobject')
+            ->set('is_hidden', $query->createPositionalParameter(1, ParameterType::INTEGER))
+            ->where('id = 68')
+            ->execute();
+
+        $gateway = $this->getLocationGateway();
+
+        $gateway->createNodeAssignment(
+            new CreateStruct([
+                'contentId' => 68,
+                'contentVersion' => 1,
+                'mainLocationId' => true,
+                'remoteId' => 'some_id',
+            ]),
+            77,
+            DoctrineDatabase::NODE_ASSIGNMENT_OP_CODE_CREATE
+        );
+
+        $gateway->createLocationsFromNodeAssignments(68, 1);
+
+        $this->assertQueryResult(
+            [[0, 1]],
+            $this->buildContentTreeSelectContentWithParentQuery(
+                68,
+                77,
+                ['is_hidden', 'is_invisible']
+            )
+        );
+    }
 }
 
 class_alias(DoctrineDatabaseTest::class, 'eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location\Gateway\DoctrineDatabaseTest');

--- a/tests/lib/Persistence/Legacy/Content/Location/Gateway/_fixtures/full_example_tree.php
+++ b/tests/lib/Persistence/Legacy/Content/Location/Gateway/_fixtures/full_example_tree.php
@@ -392,5 +392,6 @@ return [
         ['id' => 72, 'status' => 0],
         ['id' => 73, 'status' => 0],
         ['id' => 74, 'status' => 0],
+        ['id' => 75, 'status' => 0],
     ],
 ];


### PR DESCRIPTION
| :ticket: Issue | IBX-10854 |
|----------------|-----------|

It is not possible to publish content in hidden state

#### For QA:

> [!NOTE]
> Edited by @alongosz 

Requires security testing, e.g., if user who doesn't have hide/reveal permissions is now able to do it.


#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
