### PR TITLE
IBX-3035: [Twig] Allowed passing parameters to `ibexa render` function

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30445,12 +30445,6 @@ parameters:
 			path: tests/bundle/Core/Fragment/DirectFragmentRendererTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Symfony\\\\Component\\\\HttpFoundation\\\\Response'' and Symfony\\Component\\HttpFoundation\\Response will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 4
-			path: tests/bundle/Core/Fragment/DirectFragmentRendererTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\Fragment\\FragmentListenerFactoryTest\:\:buildFragmentListenerProvider\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -58549,20 +58543,8 @@ parameters:
 			path: tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
 
 		-
-			message: '#^Method Symfony\\Component\\HttpKernel\\Fragment\\FragmentRendererInterface@anonymous/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest\.php\:51\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			message: '#^Method Symfony\\Component\\HttpKernel\\Fragment\\FragmentRendererInterface@anonymous/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest\.php\:53\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
-
-		-
-			message: '#^Property Symfony\\Component\\HttpKernel\\Fragment\\FragmentRendererInterface@anonymous/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest\.php\:51\:\:\$rendered \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
-
-		-
-			message: '#^Property Symfony\\Component\\HttpKernel\\Fragment\\FragmentRendererInterface@anonymous/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest\.php\:51\:\:\$rendered \(string\) on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.property
 			count: 1
 			path: tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
 
@@ -58625,24 +58607,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: tests/lib/MVC/Symfony/Templating/GlobalHelperTest.php
-
-		-
-			message: '#^Anonymous function has an unused use \$content\.$#'
-			identifier: closure.unusedUse
-			count: 1
-			path: tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
-
-		-
-			message: '#^Anonymous function has an unused use \$siteAccess\.$#'
-			identifier: closure.unusedUse
-			count: 1
-			path: tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Symfony\\\\Component\\\\HttpKernel\\\\Controller\\\\ControllerReference'' and Symfony\\Component\\HttpKernel\\Controller\\ControllerReference will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
 
 		-
 			message: '#^Anonymous function has an unused use \$content\.$#'

--- a/src/lib/MVC/Symfony/Templating/RenderContentStrategy.php
+++ b/src/lib/MVC/Symfony/Templating/RenderContentStrategy.php
@@ -41,6 +41,7 @@ final class RenderContentStrategy extends BaseRenderStrategy implements RenderSt
         $controllerReference = new ControllerReference('ibexa_content::viewAction', [
             'contentId' => $content->id,
             'viewType' => $options->get('viewType', self::DEFAULT_VIEW_TYPE),
+            'params' => $options->get('params', []),
         ]);
 
         $renderer = $this->getFragmentRenderer($options->get('method', $this->defaultRenderer));

--- a/src/lib/MVC/Symfony/Templating/RenderLocationStrategy.php
+++ b/src/lib/MVC/Symfony/Templating/RenderLocationStrategy.php
@@ -42,6 +42,7 @@ final class RenderLocationStrategy extends BaseRenderStrategy implements RenderS
             'contentId' => $content->id,
             'locationId' => $location->id,
             'viewType' => $options->get('viewType', self::DEFAULT_VIEW_TYPE),
+            'params' => $options->get('params', []),
         ]);
 
         $renderer = $this->getFragmentRenderer($options->get('method', $this->defaultRenderer));

--- a/tests/bundle/Core/Fragment/DirectFragmentRendererTest.php
+++ b/tests/bundle/Core/Fragment/DirectFragmentRendererTest.php
@@ -65,7 +65,6 @@ final class DirectFragmentRendererTest extends TestCase
         $directFragmentRenderer = $this->getDirectFragmentRenderer($controllerResolver);
         $response = $directFragmentRenderer->render($controllerReference, $request);
 
-        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('rendered_response', $response->getContent());
     }
 
@@ -82,7 +81,6 @@ final class DirectFragmentRendererTest extends TestCase
         $directFragmentRenderer = $this->getDirectFragmentRenderer($controllerResolver);
         $response = $directFragmentRenderer->render('', new Request(), []);
 
-        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('response_body', $response->getContent());
     }
 
@@ -113,7 +111,6 @@ final class DirectFragmentRendererTest extends TestCase
         );
         $response = $directFragmentRenderer->render('', new Request(), []);
 
-        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('rendered_template_identifier', $response->getContent());
     }
 
@@ -130,7 +127,6 @@ final class DirectFragmentRendererTest extends TestCase
         $directFragmentRenderer = $this->getDirectFragmentRenderer($controllerResolver);
         $response = $directFragmentRenderer->render('', new Request(), []);
 
-        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('some_prerendered_response', $response->getContent());
     }
 

--- a/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
+++ b/tests/lib/MVC/Symfony/Templating/BaseRenderStrategyTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\Templating\RenderOptions;
 use Ibexa\Core\Repository\Values\Content\Content;
 use Ibexa\Core\Repository\Values\Content\Location;
 use Ibexa\Core\Repository\Values\Content\VersionInfo;
@@ -20,6 +21,7 @@ use Ibexa\Tests\Core\Search\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
 abstract class BaseRenderStrategyTest extends TestCase
@@ -52,8 +54,7 @@ abstract class BaseRenderStrategyTest extends TestCase
             /** @var string */
             private $name;
 
-            /** @var string */
-            private $rendered;
+            private ?string $rendered;
 
             public function __construct(
                 string $name,
@@ -96,6 +97,57 @@ abstract class BaseRenderStrategyTest extends TestCase
                 ]),
             ]),
         ]);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface&\PHPUnit\Framework\MockObject\MockObject $fragmentRendererMock
+     * @param \Ibexa\Contracts\Core\Repository\Values\ValueObject&\PHPUnit\Framework\MockObject\MockObject $valueObjectMock
+     * @param class-string<RenderStrategy> $renderStrategyClass
+     */
+    public function forwardParamOptionsToFragmentRenderer(
+        object $fragmentRendererMock,
+        object $valueObjectMock,
+        string $renderStrategyClass
+    ): void {
+        $params = [
+            'param1' => 'value1',
+            'param2' => 'value2',
+        ];
+
+        $fragmentRendererMock
+            ->method('getName')
+            ->willReturn('fragment_render_mock');
+        $fragmentRendererMock->expects(self::once())
+            ->method('render')
+            ->with(
+                self::callback(static function ($controllerReference) use ($params): bool {
+                    if (!$controllerReference instanceof ControllerReference) {
+                        return false;
+                    }
+
+                    return $controllerReference->attributes['params'] === $params;
+                }),
+            )
+            ->willReturn(new Response('fragment_render_mock_rendered'));
+
+        $renderContentStrategy = $this->createRenderStrategy(
+            $renderStrategyClass,
+            [
+                $fragmentRendererMock,
+            ],
+        );
+
+        /** @var \Ibexa\Contracts\Core\Repository\Values\ValueObject&\PHPUnit\Framework\MockObject\MockObject $valueObjectMock */
+        self::assertTrue($renderContentStrategy->supports($valueObjectMock));
+
+        self::assertSame(
+            'fragment_render_mock_rendered',
+            $renderContentStrategy->render($valueObjectMock, new RenderOptions([
+                'method' => 'fragment_render_mock',
+                'viewType' => 'awesome',
+                'params' => $params,
+            ]))
+        );
     }
 }
 

--- a/tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
+++ b/tests/lib/MVC/Symfony/Templating/RenderContentStrategyTest.php
@@ -32,7 +32,7 @@ class RenderContentStrategyTest extends BaseRenderStrategyTest
 
         $valueObject = new class() extends ValueObject {
         };
-        $this->assertFalse($renderContentStrategy->supports($valueObject));
+        self::assertFalse($renderContentStrategy->supports($valueObject));
 
         $this->expectException(InvalidArgumentException::class);
         $renderContentStrategy->render($valueObject, new RenderOptions());
@@ -49,9 +49,9 @@ class RenderContentStrategyTest extends BaseRenderStrategyTest
         );
 
         $contentMock = $this->createMock(Content::class);
-        $this->assertTrue($renderContentStrategy->supports($contentMock));
+        self::assertTrue($renderContentStrategy->supports($contentMock));
 
-        $this->assertSame(
+        self::assertSame(
             'inline_rendered',
             $renderContentStrategy->render($contentMock, new RenderOptions())
         );
@@ -65,7 +65,7 @@ class RenderContentStrategyTest extends BaseRenderStrategyTest
         );
 
         $contentMock = $this->createMock(Content::class);
-        $this->assertTrue($renderContentStrategy->supports($contentMock));
+        self::assertTrue($renderContentStrategy->supports($contentMock));
 
         $this->expectException(InvalidArgumentException::class);
         $renderContentStrategy->render($contentMock, new RenderOptions());
@@ -83,13 +83,22 @@ class RenderContentStrategyTest extends BaseRenderStrategyTest
         );
 
         $contentMock = $this->createMock(Content::class);
-        $this->assertTrue($renderContentStrategy->supports($contentMock));
+        self::assertTrue($renderContentStrategy->supports($contentMock));
 
-        $this->assertSame(
+        self::assertSame(
             'method_b_rendered',
             $renderContentStrategy->render($contentMock, new RenderOptions([
                 'method' => 'method_b',
             ]))
+        );
+    }
+
+    public function testForwardParamOptionsToFragmentRenderer(): void
+    {
+        $this->forwardParamOptionsToFragmentRenderer(
+            $this->createMock(FragmentRendererInterface::class),
+            $this->createMock(Content::class),
+            RenderContentStrategy::class,
         );
     }
 
@@ -127,19 +136,19 @@ class RenderContentStrategyTest extends BaseRenderStrategyTest
             ->method('getName')
             ->willReturn('method_b');
 
-        $controllerReferenceCallback = $this->callback(function (ControllerReference $controllerReference) {
-            $this->assertInstanceOf(ControllerReference::class, $controllerReference);
-            $this->assertEquals('ibexa_content::viewAction', $controllerReference->controller);
-            $this->assertSame([
+        $controllerReferenceCallback = $this->callback(static function (ControllerReference $controllerReference): bool {
+            self::assertEquals('ibexa_content::viewAction', $controllerReference->controller);
+            self::assertSame([
                 'contentId' => 123,
                 'viewType' => 'awesome',
+                'params' => [],
             ], $controllerReference->attributes);
 
             return true;
         });
 
-        $requestCallback = $this->callback(function (Request $request) use ($siteAccess, $content): bool {
-            $this->assertSame('TEST/1.0', $request->headers->get('Surrogate-Capability'));
+        $requestCallback = $this->callback(static function (Request $request): bool {
+            self::assertSame('TEST/1.0', $request->headers->get('Surrogate-Capability'));
 
             return true;
         });
@@ -162,7 +171,7 @@ class RenderContentStrategyTest extends BaseRenderStrategyTest
             $request
         );
 
-        $this->assertSame('some_rendered_content', $renderContentStrategy->render(
+        self::assertSame('some_rendered_content', $renderContentStrategy->render(
             $content,
             new RenderOptions([
                 'method' => 'method_b',

--- a/tests/lib/MVC/Symfony/Templating/RenderLocationStrategyTest.php
+++ b/tests/lib/MVC/Symfony/Templating/RenderLocationStrategyTest.php
@@ -93,6 +93,15 @@ class RenderLocationStrategyTest extends BaseRenderStrategyTest
         );
     }
 
+    public function testForwardParamOptionsToFragmentRenderer(): void
+    {
+        $this->forwardParamOptionsToFragmentRenderer(
+            $this->createMock(FragmentRendererInterface::class),
+            $this->createMock(Location::class),
+            RenderLocationStrategy::class,
+        );
+    }
+
     public function testExpectedMethodRenderRequestFormat(): void
     {
         $request = new Request();
@@ -114,6 +123,7 @@ class RenderLocationStrategyTest extends BaseRenderStrategyTest
                 'contentId' => 234,
                 'locationId' => 345,
                 'viewType' => 'awesome',
+                'params' => [],
             ], $controllerReference->attributes);
 
             return true;


### PR DESCRIPTION
| :ticket: Issue | IBX-3035 |
|----------------|-----------|


#### Description:
When using `render(controller('ibexa_content::viewAction'))`, you can send parameters to the controller which will be available in the template. 

Example:
```
    <h2>render controller</h2>
    {{ render(controller('ibexa_content::viewAction', {
        'contentId': content.id,
        'viewType': 'line',
        'params':
            { 'my_param': 'custom_data', }
    })) }}

    <h2>render_esi controller</h2>
    {{ render_esi(controller('ibexa_content::viewAction', {
        'contentId': content.id,
        'viewType': 'line',
        'params':
            { 'my_param': 'custom_data', }
    })) }}
```

This PR adds the same possibility when using `ibexa_render()` :
```
    <h2>direct</h2>
    {{ ibexa_render(content,
        {
            'viewType': 'line',
            'method': 'direct',
            'params': {
                'my_param': 'custom_data'
            }
        })
    }} <br/>

    {{ ibexa_render(location,
        {
            'viewType': 'line',
            'method': 'direct',
            'params': {
            'my_param': 'custom_data'
        }
        })
    }} <br/>

    <h2>inline</h2>
    {{ ibexa_render(content,
        {
            'viewType': 'line',
            'method': 'inline',
            'params': {
                'my_param': 'custom_data'
            }
        })
    }} <br/>

    {{ ibexa_render(location,
        {
            'viewType': 'line',
            'method': 'inline',
            'params': {
                'my_param': 'custom_data'
            }
        })
    }} <br/>


    <h2>esi</h2>
    {{ ibexa_render(content,
        {
            'viewType': 'line',
            'method': 'esi',
            'params': {
                'my_param': 'custom_data'
            }
        })
    }} <br/>

    {{ ibexa_render(location,
        {
            'viewType': 'line',
            'method': 'esi',
            'params': {
                'my_param': 'custom_data'
            }
        })
    }} <br/>
```

<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
