### PR TITLE
IBX-11181: Trusted Proxies is not set on Ibexa Cloud

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41122,7 +41122,7 @@ parameters:
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location'' and Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
-			count: 10
+			count: 9
 			path: tests/integration/Core/Repository/LocationServiceTest.php
 
 		-
@@ -41152,7 +41152,7 @@ parameters:
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location'' and Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
-			count: 2
+			count: 1
 			path: tests/integration/Core/Repository/LocationServiceTest.php
 
 		-

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -312,8 +312,6 @@ services:
             $cache: '@ibexa.cache_pool'
 
     Ibexa\Bundle\Core\EventSubscriber\TrustedHeaderClientIpEventSubscriber:
-        arguments:
-            $trustedHeaderName: '%ibexa.trusted_header_client_ip_name%'
         tags:
             - {name: kernel.event_subscriber}
 


### PR DESCRIPTION
| :ticket: Issue | IBX-11181 |
|----------------|-----------|

#### Related PRs: 
- PR for filtering X-Forward-For in varnish and fastly VCLs are comming

#### Description:
[Trusted proxies](https://symfony.com/doc/7.4/deployment/proxies.html#solution-settrustedproxies) are not set on Ibexa Cloud when using Fastly. We document (via [Upsun](https://fixed.docs.upsun.com/guides/ibexa/fastly.html#remove-varnish-configuration),) that user must disable `TRUSTED_PROXIES: "REMOTE_ADDR"` in `.platform.app.yaml` (which is correct), but we don’t say or specify how to configure `TRUSTED_PROXIES` correctly.

And frankly, it is not easy/possible to do via static config given how the Upsun router behaves:

Upsun router behavior:

- Will not filter `X-FORWARD-FOR` sent by malicious client
- It will add client's IP to `X-FORWARD-FOR`, appending header if already set ( "1.1.1.1" => "1.1.1.1, 2.2.2.2")
- It will always set a `X-Client-IP` header ( value is IP of client). Value is also end-user's IP if request is received via Fastly ( [doc](https://docs.upsun.com/development/headers.html#request-headers) )
- Will filter Client-Cdn if request is not originating from any supported CDN ( [doc](https://docs.upsun.com/development/headers.html#classification-data-headers) )
    - When received from Fastly, value of header will be `fastly`
- $_SERVER['REMOTE_ADDR'] will be spoofed, will have same value as X-Client-IP

So there is no static IP or IP range you can set as trusted proxies when using Fastly on Upsun. For instance, setting trusted hosts to [Fasty's public IP list](https://www.fastly.com/documentation/reference/api/utils/public-ip-list/) will not do any good. Thus, Ibexa DXP should automatically detect on Ibexa Cloud if request is received via Fastly

Next, I really doesn't understand the original purpose of `TrustedHeaderClientIpEventSubscriber`. It basically does this:
- If running on Upsun (formerly known as Platform.sh), the request header `X_FORWARDED_FOR` will be set (value will be copied from the `X-Client-IP` request header) and `X_FORWARDED_FOR` will be set as [`trusted_headers`](https://symfony.com/doc/7.4/deployment/proxies.html)
- However, this header will still be ignored unless devs somehow also sets `trusted_proxies` correctly.
- Also, the subscriber can be configured to use some other header than `X-Client-IP` as source

My next doubt is why there was some need for this in relation to [IBX-4046](https://issues.ibexa.co/browse/IBX-4046)
FYI : Original PR : https://github.com/ibexa/core/pull/165/files

As the Upsun router anyway sets the X-Forward-For header, and devs still needed to set `trusted_proxies` in config ( which IMO is impossible), the old implementation in `TrustedHeaderClientIpEventSubscriber` is void.
But it certainly may be that I am missing something important....?

What the new implementation of `TrustedHeaderClientIpEventSubscriber` does:
- If we are on Ibexa Cloud and request is coming from Fastly, then we declare that the request is received via trusted proxy


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->
Maybe do sanity checks with "create Applications for Customer portal" feature, as original implementation of `TrustedHeaderClientIpEventSubscriber` was implemented in relation to that.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 


[IBX-4046]: https://ibexa.atlassian.net/browse/IBX-4046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ