### PR TITLE
IBX-10734: simplexml_load_string() throws an exception on ezselection fields when using libxml2 2.13.8 and higher

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -185,6 +185,13 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/lib/MVC/Symfony/Matcher/ContentBased/UrlAlias.php
+
+		-
+			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\DateAndTimeConverter\:\:getDateIntervalFromXML\(\) should return DateInterval but returns DateInterval\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+
 		-
 			message: '#^Cannot access property \$ownerDocument on DOMElement\|false\.$#'
 			identifier: property.nonObject

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18084,11 +18084,6 @@ parameters:
 			count: 1
 			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
 
-		-
-			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\DateAndTimeConverter\:\:getDateIntervalFromXML\(\) should return DateInterval but returns DateInterval\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
 
 		-
 			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\DateAndTimeConverter\:\:toFieldDefinition\(\) has no return type specified\.$#'
@@ -32310,11 +32305,6 @@ parameters:
 			count: 1
 			path: tests/integration/Core/Repository/Common/SlugConverter.php
 
-		-
-			message: '#^Variable \$definition might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: tests/integration/Core/Repository/Container/Compiler/SetAllServicesPublicPass.php
 
 		-
 			message: '#^Cannot call method getValue\(\) on Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Field\|null\.$#'
@@ -41940,11 +41930,6 @@ parameters:
 			count: 1
 			path: tests/integration/Core/Repository/ObjectStateServiceTest.php
 
-		-
-			message: '#^Cannot access property \$id on bool\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: tests/integration/Core/Repository/ObjectStateServiceTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Repository\\ObjectStateServiceTest\:\:assertObjectsLoadedByIdentifiers\(\) has no return type specified\.$#'
@@ -41976,11 +41961,6 @@ parameters:
 			count: 1
 			path: tests/integration/Core/Repository/ObjectStateServiceTest.php
 
-		-
-			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Repository\\ObjectStateServiceTest\:\:createObjectStateGroups\(\) should return array\<bool\> but returns list\<Ibexa\\Contracts\\Core\\Repository\\Values\\ObjectState\\ObjectStateGroup\>\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/integration/Core/Repository/ObjectStateServiceTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Integration\\Core\\Repository\\ObjectStateServiceTest\:\:deleteExistingObjectStateGroups\(\) has no return type specified\.$#'

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -119,7 +119,7 @@ class SelectionConverter implements Converter
         }
 
         foreach ($storageDef->multilingualData as $languageCode => $mlData) {
-            $xml = isset($mlData->dataText) ? simplexml_load_string($mlData->dataText) : false;
+            $xml = $mlData->dataText ? simplexml_load_string($mlData->dataText) : false;
             if ($xml !== false) {
                 foreach ($xml->options->option as $option) {
                     $multiLingualOptions[$languageCode][(int)$option['id']] = (string)$option['name'];

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -119,7 +119,7 @@ class SelectionConverter implements Converter
         }
 
         foreach ($storageDef->multilingualData as $languageCode => $mlData) {
-            $xml = simplexml_load_string($mlData->dataText);
+            $xml = isset($mlData->dataText) ? simplexml_load_string($mlData->dataText) : false;
             if ($xml !== false) {
                 foreach ($xml->options->option as $option) {
                     $multiLingualOptions[$languageCode][(int)$option['id']] = (string)$option['name'];

--- a/tests/integration/Core/Repository/ObjectStateServiceTest.php
+++ b/tests/integration/Core/Repository/ObjectStateServiceTest.php
@@ -467,7 +467,7 @@ class ObjectStateServiceTest extends BaseTest
      * Creates a set of object state groups and returns an array of all
      * existing group identifiers after creation.
      *
-     * @return bool[]
+     * @return \Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateGroup[]
      */
     protected function createObjectStateGroups()
     {

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
@@ -327,10 +327,6 @@ EOT;
         $this->assertEquals($expectedFieldDefinition, $actualFieldDefinition);
     }
 
-    /**
-     * @group fieldType
-     * @group selection
-     */
     public function testToFieldDefinitionWithMultilingualDataSkipsEmptyDataText(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
@@ -364,8 +364,8 @@ EOT;
 
         $fieldSettings = $actualFieldDefinition->fieldTypeConstraints->fieldSettings;
 
-        $this->assertSame([0 => 'First'], $fieldSettings['multilingualOptions']['eng-GB']);
-        $this->assertSame([0 => 'Premier'], $fieldSettings['multilingualOptions']['fre-FR']);
+        self::assertSame([0 => 'First'], $fieldSettings['multilingualOptions']['eng-GB']);
+        self::assertSame([0 => 'Premier'], $fieldSettings['multilingualOptions']['fre-FR']);
     }
 }
 

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/SelectionTest.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use Ibexa\Core\FieldType\FieldSettings;
 use Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter;
+use Ibexa\Core\Persistence\Legacy\Content\MultilingualStorageFieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
 use PHPUnit\Framework\TestCase;
@@ -324,6 +325,47 @@ EOT;
         $this->converter->toFieldDefinition($storageFieldDefinition, $actualFieldDefinition);
 
         $this->assertEquals($expectedFieldDefinition, $actualFieldDefinition);
+    }
+
+    /**
+     * @group fieldType
+     * @group selection
+     */
+    public function testToFieldDefinitionWithMultilingualDataSkipsEmptyDataText(): void
+    {
+        $storageFieldDefinition = new StorageFieldDefinition();
+        $storageFieldDefinition->dataInt1 = 1;
+        $storageFieldDefinition->dataText5 = <<<EOT
+<?xml version="1.0" encoding="utf-8"?>
+<ezselection><options><option id="0" name="First"/></options></ezselection>
+EOT;
+
+        $mlDataEmpty = new MultilingualStorageFieldDefinition();
+        $mlDataEmpty->dataText = '';
+
+        $mlDataValid = new MultilingualStorageFieldDefinition();
+        $mlDataValid->dataText = <<<EOT
+<?xml version="1.0" encoding="utf-8"?>
+<ezselection><options><option id="0" name="Premier"/></options></ezselection>
+EOT;
+
+        $storageFieldDefinition->multilingualData = [
+            'eng-GB' => $mlDataEmpty,
+            'fre-FR' => $mlDataValid,
+        ];
+
+        $actualFieldDefinition = new PersistenceFieldDefinition(
+            [
+                'mainLanguageCode' => 'eng-GB',
+            ]
+        );
+
+        $this->converter->toFieldDefinition($storageFieldDefinition, $actualFieldDefinition);
+
+        $fieldSettings = $actualFieldDefinition->fieldTypeConstraints->fieldSettings;
+
+        $this->assertSame([0 => 'First'], $fieldSettings['multilingualOptions']['eng-GB']);
+        $this->assertSame([0 => 'Premier'], $fieldSettings['multilingualOptions']['fre-FR']);
     }
 }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-10734 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
When creating new content type and adding selection field, it immediately tries to parse this field through converter, obviously on initial setup this field will be empty.
On certain versions of `libxml2` like `2.13.8`, function `simplexml_load_string` will throw an exception when the parameter is null.
I've added a check on `$mlData->dataText`  to avoid this exception.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
