### PR TITLE
IBX-11491: Improved ibexa.content.download route

### DIFF
--- a/src/bundle/Core/Resources/config/routing/internal.yml
+++ b/src/bundle/Core/Resources/config/routing/internal.yml
@@ -36,6 +36,8 @@ ibexa.user_hash:
 ibexa.content.download:
     path: /content/download/{contentId}/{fieldIdentifier}/{filename}
     defaults: { _controller: Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController:downloadBinaryFileAction }
+    requirements:
+        contentId: '\d+'
 
 ibexa.content.download.field_id:
     path: /content/download/{contentId}/{fieldId}


### PR DESCRIPTION
| :ticket: Issue | IBX-11491 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
In PHP, we only accept contentId as an int in downloadBinaryFileAction


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
