### PR TITLE
Improve ValidationError translation extraction

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9157,18 +9157,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Translation/TranslatableExceptionsFileVisitor.php
 
 		-
-			message: '#^Access to an undefined property PhpParser\\Node\\Arg\|PhpParser\\Node\\VariadicPlaceholder\:\:\$value\.$#'
-			identifier: property.notFound
-			count: 2
-			path: src/lib/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
-
-		-
-			message: '#^Method Ibexa\\Core\\MVC\\Symfony\\Translation\\ValidationErrorFileVisitor\:\:setLogger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
-
-		-
 			message: '#^Parameter \#1 \$desc of method JMS\\TranslationBundle\\Model\\Message\:\:setDesc\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 2

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -371,3 +371,10 @@ services:
         decoration_priority: 500
         arguments:
             $inner: '@.inner'
+
+
+    jms_translation.doc_parser:
+        class: Doctrine\Common\Annotations\DocParser
+        calls:
+            - [setImports, [{ desc: 'JMS\TranslationBundle\Annotation\Desc', domain: 'Ibexa\Core\MVC\Symfony\Translation\Annotation\Domain', ignore: 'JMS\TranslationBundle\Annotation\Ignore', meaning: 'JMS\TranslationBundle\Annotation\Meaning' }]]
+            - [setIgnoreNotImportedAnnotations, [true]]

--- a/src/bundle/Core/Resources/translations/ibexa_repository_exceptions.en.xlf
+++ b/src/bundle/Core/Resources/translations/ibexa_repository_exceptions.en.xlf
@@ -8,8 +8,13 @@
     <body>
       <trans-unit id="bb8de8e210fd9fae30fd529a1128c07ae8512c22" resname="$limitationValue-&gt;limitationValues for '%identifier%' Limitation can not be empty">
         <source><![CDATA[$limitationValue->limitationValues for '%identifier%' Limitation can not be empty]]></source>
-        <target state="new"><![CDATA[$limitationValue->limitationValues for '%identifier%' Limitation can not be empty]]></target>
+        <target><![CDATA[$limitationValue->limitationValues for '%identifier%' Limitation can not be empty]]></target>
         <note>key: $limitationValue-&gt;limitationValues for '%identifier%' Limitation can not be empty</note>
+      </trans-unit>
+      <trans-unit id="42ef075b32c50b4397ed9c744eb8b918bdf4ccd2" resname="$limitationValue-&gt;limitationValues[%key%] =&gt; Invalid SiteAccess value '%value%'">
+        <source><![CDATA[$limitationValue->limitationValues[%key%] => Invalid SiteAccess value '%value%']]></source>
+        <target state="new"><![CDATA[$limitationValue->limitationValues[%key%] => Invalid SiteAccess value '%value%']]></target>
+        <note>key: $limitationValue-&gt;limitationValues[%key%] =&gt; Invalid SiteAccess value '%value%'</note>
       </trans-unit>
       <trans-unit id="bdaae3444afba4eebebe2e0f684a0e56e81afafd" resname="'%actualValue%' is incorrect value">
         <source>'%actualValue%' is incorrect value</source>
@@ -23,17 +28,17 @@
       </trans-unit>
       <trans-unit id="4441981a48137dfcbf678e8348db9c71725f25f9" resname="A valid file is required. The following file extensions are not allowed: %extensionsBlackList%">
         <source>A valid file is required. The following file extensions are not allowed: %extensionsBlackList%</source>
-        <target state="new">A valid file is required. The following file extensions are not allowed: %extensionsBlackList%</target>
+        <target>A valid file is required. The following file extensions are not allowed: %extensionsBlackList%</target>
         <note>key: A valid file is required. The following file extensions are not allowed: %extensionsBlackList%</note>
       </trans-unit>
       <trans-unit id="0acb3bbe9dfdab72c9b4b5b5360e8cf8eafd055f" resname="A valid image file is required.">
         <source>A valid image file is required.</source>
-        <target state="new">A valid image file is required.</target>
+        <target>A valid image file is required.</target>
         <note>key: A valid image file is required.</note>
       </trans-unit>
       <trans-unit id="c007a4a555b90607676d583c8e48b5c7385b3bfd" resname="Alternative text is required.">
         <source>Alternative text is required.</source>
-        <target state="new">Alternative text is required.</target>
+        <target>Alternative text is required.</target>
         <note>key: Alternative text is required.</note>
       </trans-unit>
       <trans-unit id="80e5a0a47ac1df407b0218c2283872a86aba0fc1" resname="Argument '%argumentName%' has a bad state: %whatIsWrong%">
@@ -73,7 +78,7 @@
       </trans-unit>
       <trans-unit id="50d1d8cb3212e4d0e5acc060e738f1826b33dd30" resname="Content %type% is not a valid asset target">
         <source>Content %type% is not a valid asset target</source>
-        <target state="new">Content %type% is not a valid asset target</target>
+        <target>Content %type% is not a valid asset target</target>
         <note>key: Content %type% is not a valid asset target</note>
       </trans-unit>
       <trans-unit id="8967aa151e1b84f60c505163d42350eb6a96e948" resname="Content fields did not validate">
@@ -83,7 +88,7 @@
       </trans-unit>
       <trans-unit id="67c302ca410832c6ac09962375892b15fbae858e" resname="Content type %contentTypeIdentifier% is not a valid relation target">
         <source>Content type %contentTypeIdentifier% is not a valid relation target</source>
-        <target state="new">Content type %contentTypeIdentifier% is not a valid relation target</target>
+        <target>Content type %contentTypeIdentifier% is not a valid relation target</target>
         <note>key: Content type %contentTypeIdentifier% is not a valid relation target</note>
       </trans-unit>
       <trans-unit id="8f64e46d8c92143a1a8fde9790a6a2423759a0ce" resname="Content type field definitions did not validate">
@@ -93,7 +98,7 @@
       </trans-unit>
       <trans-unit id="9e1ffd3b1b0cb7ca0472aadaf71c3d5466eaf907" resname="Content with identifier %contentId% is not a valid relation target">
         <source>Content with identifier %contentId% is not a valid relation target</source>
-        <target state="new">Content with identifier %contentId% is not a valid relation target</target>
+        <target>Content with identifier %contentId% is not a valid relation target</target>
         <note>key: Content with identifier %contentId% is not a valid relation target</note>
       </trans-unit>
       <trans-unit id="dbf0b883e33a6e7c433ffa9a536fd214cda39b5c" resname="Could not find %classType% class '%className%'">
@@ -113,27 +118,27 @@
       </trans-unit>
       <trans-unit id="bd31261fbee17ca1e69927adfd77e877e2a86002" resname="Country with Alpha2 code '%alpha2%' is not defined in FieldType settings.">
         <source>Country with Alpha2 code '%alpha2%' is not defined in FieldType settings.</source>
-        <target state="new">Country with Alpha2 code '%alpha2%' is not defined in FieldType settings.</target>
+        <target>Country with Alpha2 code '%alpha2%' is not defined in FieldType settings.</target>
         <note>key: Country with Alpha2 code '%alpha2%' is not defined in FieldType settings.</note>
       </trans-unit>
       <trans-unit id="0916f6f9b4fbf5df579dbdf281c4dd486bb2bd8d" resname="Each keyword must be a string.">
         <source>Each keyword must be a string.</source>
-        <target state="new">Each keyword must be a string.</target>
+        <target>Each keyword must be a string.</target>
         <note>key: Each keyword must be a string.</note>
       </trans-unit>
       <trans-unit id="34a44ca5a04b672701b17d1833449abde0baaca2" resname="Email '%email%' is used by another user. You must enter a unique email.">
         <source>Email '%email%' is used by another user. You must enter a unique email.</source>
-        <target state="new">Email '%email%' is used by another user. You must enter a unique email.</target>
+        <target>Email '%email%' is used by another user. You must enter a unique email.</target>
         <note>key: Email '%email%' is used by another user. You must enter a unique email.</note>
       </trans-unit>
       <trans-unit id="887c8dbb94effba65b41b2328e66467e597cdc5d" resname="Email required">
         <source>Email required</source>
-        <target state="new">Email required</target>
+        <target>Email required</target>
         <note>key: Email required</note>
       </trans-unit>
       <trans-unit id="0d40734d4581a1c3c3d21e4cea906a2afbe21264" resname="Enabled must be boolean value">
         <source>Enabled must be boolean value</source>
-        <target state="new">Enabled must be boolean value</target>
+        <target>Enabled must be boolean value</target>
         <note>key: Enabled must be boolean value</note>
       </trans-unit>
       <trans-unit id="c6136a74d1562ea6d15321ee75b9b307fc787e79" resname="Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%">
@@ -153,38 +158,48 @@
       </trans-unit>
       <trans-unit id="51c68e3006b2889d57967698bf42465ccdc686f6" resname="Field definition does not allow multiple countries to be selected.">
         <source>Field definition does not allow multiple countries to be selected.</source>
-        <target state="new">Field definition does not allow multiple countries to be selected.</target>
+        <target>Field definition does not allow multiple countries to be selected.</target>
         <note>key: Field definition does not allow multiple countries to be selected.</note>
       </trans-unit>
       <trans-unit id="59fe5c99eeba126598f07f11a900ac1d317ee778" resname="Field definition does not allow multiple options to be selected.">
         <source>Field definition does not allow multiple options to be selected.</source>
-        <target state="new">Field definition does not allow multiple options to be selected.</target>
+        <target>Field definition does not allow multiple options to be selected.</target>
         <note>key: Field definition does not allow multiple options to be selected.</note>
+      </trans-unit>
+      <trans-unit id="e335dfc8327f78786877a50b4c817c99ff882e16" resname="Field type %field_type_identifier% is not searchable">
+        <source>Field type %field_type_identifier% is not searchable</source>
+        <target state="new">Field type %field_type_identifier% is not searchable</target>
+        <note>key: Field type %field_type_identifier% is not searchable</note>
       </trans-unit>
       <trans-unit id="0a7a9d488d82cb20f7b0fdfb67cf91f5be027dd1" resname="FieldType '%fieldType%' does not accept settings">
         <source>FieldType '%fieldType%' does not accept settings</source>
-        <target state="new">FieldType '%fieldType%' does not accept settings</target>
+        <target>FieldType '%fieldType%' does not accept settings</target>
         <note>key: FieldType '%fieldType%' does not accept settings</note>
       </trans-unit>
       <trans-unit id="063039e538d6185d99729be1c3d7500cdb8764d2" resname="FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'">
         <source>FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'</source>
-        <target state="new">FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'</target>
+        <target>FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'</target>
         <note>key: FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'</note>
       </trans-unit>
       <trans-unit id="9fd939f460767fe70deca9a2253612faaf21541f" resname="ISBN value must be in a valid ISBN-10 format">
         <source>ISBN value must be in a valid ISBN-10 format</source>
-        <target state="new">ISBN value must be in a valid ISBN-10 format</target>
+        <target>ISBN value must be in a valid ISBN-10 format</target>
         <note>key: ISBN value must be in a valid ISBN-10 format</note>
       </trans-unit>
       <trans-unit id="176a3a93bc13f5306ba1b9facec5b8c178a19584" resname="ISBN-10 must be 10 character length">
         <source>ISBN-10 must be 10 character length</source>
-        <target state="new">ISBN-10 must be 10 character length</target>
+        <target>ISBN-10 must be 10 character length</target>
         <note>key: ISBN-10 must be 10 character length</note>
       </trans-unit>
       <trans-unit id="6de49a02bf544fb50e2c6ecfc05848b02631ebf2" resname="Invalid login format">
         <source>Invalid login format</source>
-        <target state="new">Invalid login format</target>
+        <target>Invalid login format</target>
         <note>key: Invalid login format</note>
+      </trans-unit>
+      <trans-unit id="9df15913bb6595f50be0587e011cc3f8434ad031" resname="Keyword value must be less than or equal to 255 characters.">
+        <source>Keyword value must be less than or equal to 255 characters.</source>
+        <target state="new">Keyword value must be less than or equal to 255 characters.</target>
+        <note>key: Keyword value must be less than or equal to 255 characters.</note>
       </trans-unit>
       <trans-unit id="87d1caa3303a7197201d77b1bcb03ae38356097b" resname="Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%">
         <source>Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</source>
@@ -198,27 +213,27 @@
       </trans-unit>
       <trans-unit id="e4ff6279bf086f085375b32cb0e2cb0122b01e8f" resname="Login required">
         <source>Login required</source>
-        <target state="new">Login required</target>
+        <target>Login required</target>
         <note>key: Login required</note>
       </trans-unit>
       <trans-unit id="726e352f30c0a2a13b529ee5419862a5a8bb9653" resname="New password cannot be the same as old password">
         <source>New password cannot be the same as old password</source>
-        <target state="new">New password cannot be the same as old password</target>
+        <target>New password cannot be the same as old password</target>
         <note>key: New password cannot be the same as old password</note>
       </trans-unit>
       <trans-unit id="07d09e0efe61a3f503bff8bb248753d3506f97e8" resname="Option with index %index% does not exist in the field definition.">
         <source>Option with index %index% does not exist in the field definition.</source>
-        <target state="new">Option with index %index% does not exist in the field definition.</target>
+        <target>Option with index %index% does not exist in the field definition.</target>
         <note>key: Option with index %index% does not exist in the field definition.</note>
       </trans-unit>
       <trans-unit id="f974cd6ec5fdcdad5df910fdf052d94c1c54f335" resname="Password expiration warning value should be lower then password expiration value">
         <source>Password expiration warning value should be lower then password expiration value</source>
-        <target state="new">Password expiration warning value should be lower then password expiration value</target>
+        <target>Password expiration warning value should be lower then password expiration value</target>
         <note>key: Password expiration warning value should be lower then password expiration value</note>
       </trans-unit>
       <trans-unit id="b9a6ccd9e7097c94755ba57d1450e8ae9cab4b87" resname="Password required">
         <source>Password required</source>
-        <target state="new">Password required</target>
+        <target>Password required</target>
         <note>key: Password required</note>
       </trans-unit>
       <trans-unit id="ef12e750e94380df0d1de86b1cc274b45dc94e94" resname="Path '%path%' already exists for the given context">
@@ -233,77 +248,77 @@
       </trans-unit>
       <trans-unit id="f9f69b1cbde93fbe301240d7b3263d9bd3442edc" resname="Setting '%setting%' contains unsupported mime types">
         <source>Setting '%setting%' contains unsupported mime types</source>
-        <target state="new">Setting '%setting%' contains unsupported mime types</target>
+        <target>Setting '%setting%' contains unsupported mime types</target>
         <note>key: Setting '%setting%' contains unsupported mime types</note>
       </trans-unit>
       <trans-unit id="b914ca7737f63ae891ab3e637e8e72e74c9d56cf" resname="Setting '%setting%' has unknown default value">
         <source>Setting '%setting%' has unknown default value</source>
-        <target state="new">Setting '%setting%' has unknown default value</target>
+        <target>Setting '%setting%' has unknown default value</target>
         <note>key: Setting '%setting%' has unknown default value</note>
       </trans-unit>
       <trans-unit id="fce1718779ee47de2e388b5af61ab50a8d5a7f8b" resname="Setting '%setting%' is of unknown type">
         <source>Setting '%setting%' is of unknown type</source>
-        <target state="new">Setting '%setting%' is of unknown type</target>
+        <target>Setting '%setting%' is of unknown type</target>
         <note>key: Setting '%setting%' is of unknown type</note>
       </trans-unit>
       <trans-unit id="861d7d199b8b7918672a8e35a394fa5e2c42cf94" resname="Setting '%setting%' is unknown">
         <source>Setting '%setting%' is unknown</source>
-        <target state="new">Setting '%setting%' is unknown</target>
+        <target>Setting '%setting%' is unknown</target>
         <note>key: Setting '%setting%' is unknown</note>
       </trans-unit>
       <trans-unit id="097531c663fd009dbd56325b818e16f3531ad068" resname="Setting '%setting%' must be either %selection_browse% or %selection_dropdown%">
         <source>Setting '%setting%' must be either %selection_browse% or %selection_dropdown%</source>
-        <target state="new">Setting '%setting%' must be either %selection_browse% or %selection_dropdown%</target>
+        <target>Setting '%setting%' must be either %selection_browse% or %selection_dropdown%</target>
         <note>key: Setting '%setting%' must be either %selection_browse% or %selection_dropdown%</note>
       </trans-unit>
       <trans-unit id="03f216a06c84d4b197c23e20b0f4aa34e01d6d43" resname="Setting '%setting%' value cannot be lower than 0">
         <source>Setting '%setting%' value cannot be lower than 0</source>
-        <target state="new">Setting '%setting%' value cannot be lower than 0</target>
+        <target>Setting '%setting%' value cannot be lower than 0</target>
         <note>key: Setting '%setting%' value cannot be lower than 0</note>
       </trans-unit>
       <trans-unit id="caa9738d2c5a25e32b8cd1cf44b7c1c8148b1b54" resname="Setting '%setting%' value must be of array type">
         <source>Setting '%setting%' value must be of array type</source>
-        <target state="new">Setting '%setting%' value must be of array type</target>
+        <target>Setting '%setting%' value must be of array type</target>
         <note>key: Setting '%setting%' value must be of array type</note>
       </trans-unit>
       <trans-unit id="bd4ed9b70b5f83107e2b14559fc977dddfca7a70" resname="Setting '%setting%' value must be of boolean type">
         <source>Setting '%setting%' value must be of boolean type</source>
-        <target state="new">Setting '%setting%' value must be of boolean type</target>
+        <target>Setting '%setting%' value must be of boolean type</target>
         <note>key: Setting '%setting%' value must be of boolean type</note>
       </trans-unit>
       <trans-unit id="26461bb829eaa12bb6ce07c767561c4b8f33ba12" resname="Setting '%setting%' value must be of either null or bool">
         <source>Setting '%setting%' value must be of either null or bool</source>
-        <target state="new">Setting '%setting%' value must be of either null or bool</target>
+        <target>Setting '%setting%' value must be of either null or bool</target>
         <note>key: Setting '%setting%' value must be of either null or bool</note>
       </trans-unit>
       <trans-unit id="3562c94e4532fc117ccc2ee24af9c3330eabacee" resname="Setting '%setting%' value must be of either null, string or integer">
         <source>Setting '%setting%' value must be of either null, string or integer</source>
-        <target state="new">Setting '%setting%' value must be of either null, string or integer</target>
+        <target>Setting '%setting%' value must be of either null, string or integer</target>
         <note>key: Setting '%setting%' value must be of either null, string or integer</note>
       </trans-unit>
       <trans-unit id="bfebc417a482e6ada4ab78ceb573f6e5afa48822" resname="Setting '%setting%' value must be of integer type">
         <source>Setting '%setting%' value must be of integer type</source>
-        <target state="new">Setting '%setting%' value must be of integer type</target>
+        <target>Setting '%setting%' value must be of integer type</target>
         <note>key: Setting '%setting%' value must be of integer type</note>
       </trans-unit>
       <trans-unit id="277ccdbd7cb7e21d7f7b369d6ffce70fd37a35e3" resname="Setting 'Current date and time adjusted by' can be used only when setting 'Default value' is set to 'Adjusted current datetime'">
         <source>Setting 'Current date and time adjusted by' can be used only when setting 'Default value' is set to 'Adjusted current datetime'</source>
-        <target state="new">Setting 'Current date and time adjusted by' can be used only when setting 'Default value' is set to 'Adjusted current datetime'</target>
+        <target>Setting 'Current date and time adjusted by' can be used only when setting 'Default value' is set to 'Adjusted current datetime'</target>
         <note>key: Setting 'Current date and time adjusted by' can be used only when setting 'Default value' is set to 'Adjusted current datetime'</note>
       </trans-unit>
       <trans-unit id="3123ad0ce9fd660a9a47ff624fe86bdf7b92af92" resname="Setting 'Current date and time adjusted by' value must be an instance of 'DateInterval' class">
         <source>Setting 'Current date and time adjusted by' value must be an instance of 'DateInterval' class</source>
-        <target state="new">Setting 'Current date and time adjusted by' value must be an instance of 'DateInterval' class</target>
+        <target>Setting 'Current date and time adjusted by' value must be an instance of 'DateInterval' class</target>
         <note>key: Setting 'Current date and time adjusted by' value must be an instance of 'DateInterval' class</note>
       </trans-unit>
       <trans-unit id="c506a8e66a994618ba7bc87400fc2ef2ef01a9b7" resname="Setting 'Default value' is of unknown type">
         <source>Setting 'Default value' is of unknown type</source>
-        <target state="new">Setting 'Default value' is of unknown type</target>
+        <target>Setting 'Default value' is of unknown type</target>
         <note>key: Setting 'Default value' is of unknown type</note>
       </trans-unit>
       <trans-unit id="cffa2f702aaae8a5b472603a98b5c934c8fd9e19" resname="Setting 'Use seconds' value must be of boolean type">
         <source>Setting 'Use seconds' value must be of boolean type</source>
-        <target state="new">Setting 'Use seconds' value must be of boolean type</target>
+        <target>Setting 'Use seconds' value must be of boolean type</target>
         <note>key: Setting 'Use seconds' value must be of boolean type</note>
       </trans-unit>
       <trans-unit id="1677f5311a0f3fc35be40d540553e892d187618e" resname="The User does not have the '%function%' '%module%' permission">
@@ -318,82 +333,82 @@
       </trans-unit>
       <trans-unit id="b43d86934008faa891bafd26e803154c82e1d2d7" resname="The file size cannot exceed %size% byte.">
         <source>The file size cannot exceed %size% byte.</source>
-        <target state="new">The file size cannot exceed %size% byte.</target>
+        <target>The file size cannot exceed %size% byte.</target>
         <note>key: The file size cannot exceed %size% byte.</note>
       </trans-unit>
       <trans-unit id="cb5f9b0dcc5347641d221acd261381a44b8a2c5e" resname="The file size cannot exceed %size% bytes.">
         <source>The file size cannot exceed %size% bytes.</source>
-        <target state="new">The file size cannot exceed %size% bytes.</target>
+        <target>The file size cannot exceed %size% bytes.</target>
         <note>key: The file size cannot exceed %size% bytes.</note>
       </trans-unit>
       <trans-unit id="e59547cf884453e4f2c54f7ebfc78ceb69c743ca" resname="The file size cannot exceed %size% megabyte.">
         <source>The file size cannot exceed %size% megabyte.</source>
-        <target state="new">The file size cannot exceed %size% megabyte.</target>
+        <target>The file size cannot exceed %size% megabyte.</target>
         <note>key: The file size cannot exceed %size% megabyte.</note>
       </trans-unit>
       <trans-unit id="8d20c15b8b0736e4c747437cb4dd1b27001d9ed1" resname="The file size cannot exceed %size% megabytes.">
         <source>The file size cannot exceed %size% megabytes.</source>
-        <target state="new">The file size cannot exceed %size% megabytes.</target>
+        <target>The file size cannot exceed %size% megabytes.</target>
         <note>key: The file size cannot exceed %size% megabytes.</note>
       </trans-unit>
       <trans-unit id="8592cd2c2482f1bf9d07227a7ad0c4dd3ec466a7" resname="The following options are available for setting '%setting%': %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multiple%, %selection_template_based_single%">
         <source>The following options are available for setting '%setting%': %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multiple%, %selection_template_based_single%</source>
-        <target state="new">The following options are available for setting '%setting%': %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multiple%, %selection_template_based_single%</target>
+        <target>The following options are available for setting '%setting%': %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multiple%, %selection_template_based_single%</target>
         <note>key: The following options are available for setting '%setting%': %selection_browse%, %selection_dropdown%, %selection_list_with_radio_buttons%, %selection_list_with_checkboxes%, %selection_multiple_selection_list%, %selection_template_based_multiple%, %selection_template_based_single%</note>
       </trans-unit>
       <trans-unit id="ef1bb7a9545247d483f9d73e7eba659bf01c214a" resname="The given e-mail '%email%' is invalid">
         <source>The given e-mail '%email%' is invalid</source>
-        <target state="new">The given e-mail '%email%' is invalid</target>
+        <target>The given e-mail '%email%' is invalid</target>
         <note>key: The given e-mail '%email%' is invalid</note>
       </trans-unit>
       <trans-unit id="3985ff268119a8583776a5be47a7d2fe786443dd" resname="The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.">
         <source>The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.</source>
-        <target state="new">The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.</target>
+        <target>The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.</target>
         <note>key: The mime type of the file is invalid (%mimeType%). Allowed mime types are %mimeTypes%.</note>
       </trans-unit>
       <trans-unit id="46a134849e071f19e08a9815ec0384f806615bfc" resname="The selected content items number cannot be higher than %limit%.">
         <source>The selected content items number cannot be higher than %limit%.</source>
-        <target state="new">The selected content items number cannot be higher than %limit%.</target>
+        <target>The selected content items number cannot be higher than %limit%.</target>
         <note>key: The selected content items number cannot be higher than %limit%.</note>
       </trans-unit>
       <trans-unit id="ba85dfc3ec69f4c49d6db6be38aebbb266752f91" resname="The string can not exceed %size% character.">
         <source>The string can not exceed %size% character.</source>
-        <target state="new">The string can not exceed %size% character.</target>
+        <target>The string can not exceed %size% character.</target>
         <note>key: The string can not exceed %size% character.</note>
       </trans-unit>
       <trans-unit id="4e5c3e8885e3073cb30ab2e042990054648734e5" resname="The string can not exceed %size% characters.">
         <source>The string can not exceed %size% characters.</source>
-        <target state="new">The string can not exceed %size% characters.</target>
+        <target>The string can not exceed %size% characters.</target>
         <note>key: The string can not exceed %size% characters.</note>
       </trans-unit>
       <trans-unit id="488e4c6db5553d3c87fa27dd43864bd141f1f82b" resname="The string cannot be shorter than %size% character.">
         <source>The string cannot be shorter than %size% character.</source>
-        <target state="new">The string cannot be shorter than %size% character.</target>
+        <target>The string cannot be shorter than %size% character.</target>
         <note>key: The string cannot be shorter than %size% character.</note>
       </trans-unit>
       <trans-unit id="b736e8be94c612df3c9bbb082fc132fbcafe6ce8" resname="The string cannot be shorter than %size% characters.">
         <source>The string cannot be shorter than %size% characters.</source>
-        <target state="new">The string cannot be shorter than %size% characters.</target>
+        <target>The string cannot be shorter than %size% characters.</target>
         <note>key: The string cannot be shorter than %size% characters.</note>
       </trans-unit>
       <trans-unit id="c10b0c448f6442d0a67d6787f458e09c823d79f7" resname="The user login '%login%' is used by another user. You must enter a unique login.">
         <source>The user login '%login%' is used by another user. You must enter a unique login.</source>
-        <target state="new">The user login '%login%' is used by another user. You must enter a unique login.</target>
+        <target>The user login '%login%' is used by another user. You must enter a unique login.</target>
         <note>key: The user login '%login%' is used by another user. You must enter a unique login.</note>
       </trans-unit>
       <trans-unit id="4d599538a5fe5385937cbee8c10499a135233c7a" resname="The value can not be higher than %size%.">
         <source>The value can not be higher than %size%.</source>
-        <target state="new">The value can not be higher than %size%.</target>
+        <target>The value can not be higher than %size%.</target>
         <note>key: The value can not be higher than %size%.</note>
       </trans-unit>
       <trans-unit id="abef90370bd924c3c08bd2467b305c8f982f8929" resname="The value can not be lower than %size%.">
         <source>The value can not be lower than %size%.</source>
-        <target state="new">The value can not be lower than %size%.</target>
+        <target>The value can not be lower than %size%.</target>
         <note>key: The value can not be lower than %size%.</note>
       </trans-unit>
       <trans-unit id="26a24798112d7590cdf9933e385524955d6d5042" resname="The value must be a valid email address.">
         <source>The value must be a valid email address.</source>
-        <target state="new">The value must be a valid email address.</target>
+        <target>The value must be a valid email address.</target>
         <note>key: The value must be a valid email address.</note>
       </trans-unit>
       <trans-unit id="3b2e044f9c9821aef27834972d90f59f28b1a0b4" resname="Token '%tokenType%:%token%' expired on '%when%'">
@@ -408,62 +423,67 @@
       </trans-unit>
       <trans-unit id="883293f3c259167489768ede2a51ee202bf6f951" resname="Validator %validator% expects parameter %parameter% to be of %type% type.">
         <source>Validator %validator% expects parameter %parameter% to be of %type% type.</source>
-        <target state="new">Validator %validator% expects parameter %parameter% to be of %type% type.</target>
+        <target>Validator %validator% expects parameter %parameter% to be of %type% type.</target>
         <note>key: Validator %validator% expects parameter %parameter% to be of %type% type.</note>
       </trans-unit>
       <trans-unit id="60b08b7060418c6649003ad172cb464d0f08a5ca" resname="Validator %validator% expects parameter %parameter% to be of %type%.">
         <source>Validator %validator% expects parameter %parameter% to be of %type%.</source>
-        <target state="new">Validator %validator% expects parameter %parameter% to be of %type%.</target>
+        <target>Validator %validator% expects parameter %parameter% to be of %type%.</target>
         <note>key: Validator %validator% expects parameter %parameter% to be of %type%.</note>
       </trans-unit>
       <trans-unit id="a9f2ff0ce778111aff38235670551cc9c6b30c9c" resname="Validator %validator% expects parameter %parameter% to be set.">
         <source>Validator %validator% expects parameter %parameter% to be set.</source>
-        <target state="new">Validator %validator% expects parameter %parameter% to be set.</target>
+        <target>Validator %validator% expects parameter %parameter% to be set.</target>
         <note>key: Validator %validator% expects parameter %parameter% to be set.</note>
+      </trans-unit>
+      <trans-unit id="addd4fedccc1d5b5bf14115eefad5b39af6341e1" resname="Validator '%parameter%' is unknown">
+        <source>Validator '%parameter%' is unknown</source>
+        <target>Validator '%parameter%' is unknown</target>
+        <note>key: Validator '%parameter%' is unknown</note>
       </trans-unit>
       <trans-unit id="53769a408989ce357c62f26d2e911672f9b052a6" resname="Validator '%validator%' is unknown">
         <source>Validator '%validator%' is unknown</source>
-        <target state="new">Validator '%validator%' is unknown</target>
+        <target>Validator '%validator%' is unknown</target>
         <note>key: Validator '%validator%' is unknown</note>
       </trans-unit>
       <trans-unit id="4930120b71d17e3e3e44611673bb24b6b27e3843" resname="Validator parameter '%parameter%' is unknown">
         <source>Validator parameter '%parameter%' is unknown</source>
-        <target state="new">Validator parameter '%parameter%' is unknown</target>
+        <target>Validator parameter '%parameter%' is unknown</target>
         <note>key: Validator parameter '%parameter%' is unknown</note>
       </trans-unit>
       <trans-unit id="d559b6e08c07df29c0eafa4f3ce26a01f54735d1" resname="Validator parameter '%parameter%' value can't be negative">
         <source>Validator parameter '%parameter%' value can't be negative</source>
-        <target state="new">Validator parameter '%parameter%' value can't be negative</target>
+        <target>Validator parameter '%parameter%' value can't be negative</target>
         <note>key: Validator parameter '%parameter%' value can't be negative</note>
       </trans-unit>
       <trans-unit id="ab05735d99df463618923994a726dfb03ffdfa03" resname="Validator parameter '%parameter%' value must be an integer">
         <source>Validator parameter '%parameter%' value must be an integer</source>
-        <target state="new">Validator parameter '%parameter%' value must be an integer</target>
+        <target>Validator parameter '%parameter%' value must be an integer</target>
         <note>key: Validator parameter '%parameter%' value must be an integer</note>
       </trans-unit>
       <trans-unit id="89b7b652fa6791c8f4eab4b3f1a870add84c0c32" resname="Validator parameter '%parameter%' value must be equal to/greater than 0">
         <source>Validator parameter '%parameter%' value must be equal to/greater than 0</source>
-        <target state="new">Validator parameter '%parameter%' value must be equal to/greater than 0</target>
+        <target>Validator parameter '%parameter%' value must be equal to/greater than 0</target>
         <note>key: Validator parameter '%parameter%' value must be equal to/greater than 0</note>
       </trans-unit>
       <trans-unit id="e6c3b0ade928148395602d05d89b235ae1f88f0d" resname="Validator parameter '%parameter%' value must be of integer type">
         <source>Validator parameter '%parameter%' value must be of integer type</source>
-        <target state="new">Validator parameter '%parameter%' value must be of integer type</target>
+        <target>Validator parameter '%parameter%' value must be of integer type</target>
         <note>key: Validator parameter '%parameter%' value must be of integer type</note>
       </trans-unit>
       <trans-unit id="f6c1cab69cb480fed52a2b65b83ffb6963696b36" resname="Validator parameter '%parameter%' value must be regex for now">
         <source>Validator parameter '%parameter%' value must be regex for now</source>
-        <target state="new">Validator parameter '%parameter%' value must be regex for now</target>
+        <target>Validator parameter '%parameter%' value must be regex for now</target>
         <note>key: Validator parameter '%parameter%' value must be regex for now</note>
       </trans-unit>
       <trans-unit id="9039ff35728ad4af93dcaba4b21557a727888e30" resname="Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value">
         <source>Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value</source>
-        <target state="new">Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value</target>
+        <target>Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value</target>
         <note>key: Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value</note>
       </trans-unit>
       <trans-unit id="b6c92ee4799eb55f6bd347344b7ab326f6483e1f" resname="Value for required field definition '%identifier%' with language '%languageCode%' is empty">
         <source>Value for required field definition '%identifier%' with language '%languageCode%' is empty</source>
-        <target state="new">Value for required field definition '%identifier%' with language '%languageCode%' is empty</target>
+        <target>Value for required field definition '%identifier%' with language '%languageCode%' is empty</target>
         <note>key: Value for required field definition '%identifier%' with language '%languageCode%' is empty</note>
       </trans-unit>
       <trans-unit id="e37bafa4a8807f7a425f8d967cadc8e704c629b3" resname="You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'">
@@ -473,32 +493,32 @@
       </trans-unit>
       <trans-unit id="9a8096c63a5bb1163bb47cd39ab1721cb10329aa" resname="limitationValues[%key%] =&gt; '%value%' does not equal Location's path string: '%path_string%'">
         <source><![CDATA[limitationValues[%key%] => '%value%' does not equal Location's path string: '%path_string%']]></source>
-        <target state="new"><![CDATA[limitationValues[%key%] => '%value%' does not equal Location's path string: '%path_string%']]></target>
+        <target><![CDATA[limitationValues[%key%] => '%value%' does not equal Location's path string: '%path_string%']]></target>
         <note>key: limitationValues[%key%] =&gt; '%value%' does not equal Location's path string: '%path_string%'</note>
       </trans-unit>
       <trans-unit id="619a3446ec0941d3e7e64a1b63c2938925e9b56a" resname="limitationValues[%key%] =&gt; '%value%' does not exist in the backend">
         <source><![CDATA[limitationValues[%key%] => '%value%' does not exist in the backend]]></source>
-        <target state="new"><![CDATA[limitationValues[%key%] => '%value%' does not exist in the backend]]></target>
+        <target><![CDATA[limitationValues[%key%] => '%value%' does not exist in the backend]]></target>
         <note>key: limitationValues[%key%] =&gt; '%value%' does not exist in the backend</note>
       </trans-unit>
       <trans-unit id="1d60b8441327f4f07094c741cea646a38ec94d67" resname="limitationValues[%key%] =&gt; '%value%' must be 1 (owner)">
         <source><![CDATA[limitationValues[%key%] => '%value%' must be 1 (owner)]]></source>
-        <target state="new"><![CDATA[limitationValues[%key%] => '%value%' must be 1 (owner)]]></target>
+        <target><![CDATA[limitationValues[%key%] => '%value%' must be 1 (owner)]]></target>
         <note>key: limitationValues[%key%] =&gt; '%value%' must be 1 (owner)</note>
       </trans-unit>
       <trans-unit id="6deaad828c2b2506ccef5940fbc0a31ee540ce77" resname="limitationValues[%key%] =&gt; '%value%' must be an integer">
         <source><![CDATA[limitationValues[%key%] => '%value%' must be an integer]]></source>
-        <target state="new"><![CDATA[limitationValues[%key%] => '%value%' must be an integer]]></target>
+        <target><![CDATA[limitationValues[%key%] => '%value%' must be an integer]]></target>
         <note>key: limitationValues[%key%] =&gt; '%value%' must be an integer</note>
       </trans-unit>
       <trans-unit id="c0a48e6a6766b8cd35fb48e23879de59d7cca50a" resname="limitationValues[%key%] =&gt; '%value%' must be either 1 (owner) or 2 (session)">
         <source><![CDATA[limitationValues[%key%] => '%value%' must be either 1 (owner) or 2 (session)]]></source>
-        <target state="new"><![CDATA[limitationValues[%key%] => '%value%' must be either 1 (owner) or 2 (session)]]></target>
+        <target><![CDATA[limitationValues[%key%] => '%value%' must be either 1 (owner) or 2 (session)]]></target>
         <note>key: limitationValues[%key%] =&gt; '%value%' must be either 1 (owner) or 2 (session)</note>
       </trans-unit>
       <trans-unit id="a41b00a888d13bc3843d9320a061a9b613a17796" resname="limitationValues[] =&gt; '%languageCodes%' translation(s) do not exist">
         <source><![CDATA[limitationValues[] => '%languageCodes%' translation(s) do not exist]]></source>
-        <target state="new"><![CDATA[limitationValues[] => '%languageCodes%' translation(s) do not exist]]></target>
+        <target><![CDATA[limitationValues[] => '%languageCodes%' translation(s) do not exist]]></target>
         <note>key: limitationValues[] =&gt; '%languageCodes%' translation(s) do not exist</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/validators.en.xlf
+++ b/src/bundle/Core/Resources/translations/validators.en.xlf
@@ -8,7 +8,7 @@
     <body>
       <trans-unit id="cb73b740405234713ab9927dd526edf48a250f60" resname="ibexa.identifier_already_exists">
         <source>Identifier already exists.</source>
-        <target state="new">Identifier already exists.</target>
+        <target>Identifier already exists.</target>
         <note>key: ibexa.identifier_already_exists</note>
       </trans-unit>
     </body>

--- a/src/lib/FieldType/BaseTextType.php
+++ b/src/lib/FieldType/BaseTextType.php
@@ -63,11 +63,10 @@ abstract class BaseTextType extends FieldType
     protected function buildUnknownValidatorError(string $parameterName, string $validatorIdentifier): ValidationError
     {
         return new ValidationError(
-            "Validator '$parameterName' is unknown",
+            /** @Desc("Validator '%parameter%' is unknown") */
+            "Validator '%parameter%' is unknown",
             null,
-            [
-                $parameterName => $validatorIdentifier,
-            ]
+            ['%parameter%' => $parameterName]
         );
     }
 

--- a/src/lib/FieldType/ISBN/Type.php
+++ b/src/lib/FieldType/ISBN/Type.php
@@ -13,6 +13,7 @@ use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\FieldType;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Value as BaseValue;
+use JMS\TranslationBundle\Annotation\Ignore;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
@@ -157,7 +158,10 @@ class Type extends FieldType implements TranslationContainerInterface
         } else {
             // ISBN-13 check
             if (!$this->validateISBN13Checksum($isbnTestNumber, $error)) {
+                // TODO: Replace the out-parameter error flow with stable translation keys/templates.
+                // JMS extraction cannot read a ValidationError ID passed through a variable.
                 $validationErrors[] = new ValidationError(
+                    /** @Ignore */
                     $error,
                     null,
                     [],

--- a/src/lib/FieldType/Keyword/Type.php
+++ b/src/lib/FieldType/Keyword/Type.php
@@ -25,6 +25,7 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 class Type extends FieldType implements TranslationContainerInterface
 {
     public const MAX_KEYWORD_LENGTH = 255;
+    private const string ERROR_MESSAGE_MAX_KEYWORD_LENGTH = 'Keyword value must be less than or equal to 255 characters.';
 
     /**
      * Returns the field type identifier for this field type.
@@ -120,7 +121,7 @@ class Type extends FieldType implements TranslationContainerInterface
                 );
             } elseif (mb_strlen($keyword) > self::MAX_KEYWORD_LENGTH) {
                 $validationErrors[] = new ValidationError(
-                    'Keyword value must be less than or equal to ' . self::MAX_KEYWORD_LENGTH . ' characters.',
+                    self::ERROR_MESSAGE_MAX_KEYWORD_LENGTH,
                     null,
                     [],
                     'values'

--- a/src/lib/FieldType/Validator/BaseNumericValidator.php
+++ b/src/lib/FieldType/Validator/BaseNumericValidator.php
@@ -10,6 +10,7 @@ namespace Ibexa\Core\FieldType\Validator;
 
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
+use JMS\TranslationBundle\Annotation\Ignore;
 
 abstract class BaseNumericValidator extends Validator
 {
@@ -24,7 +25,10 @@ abstract class BaseNumericValidator extends Validator
         foreach ($constraints as $name => $value) {
             $validationErrorMessage = $this->getConstraintsValidationErrorMessage($name, $value);
             if (null !== $validationErrorMessage) {
+                // TODO: Return stable translation keys/templates instead of a computed message string.
+                // JMS extraction cannot read a ValidationError ID passed through a variable.
                 $validationErrors[] = new ValidationError(
+                    /** @Ignore */
                     $validationErrorMessage,
                     null,
                     [

--- a/src/lib/FieldType/Validator/StringLengthValidator.php
+++ b/src/lib/FieldType/Validator/StringLengthValidator.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\Core\FieldType\Validator;
 use Ibexa\Core\FieldType\Value as BaseValue;
+use JMS\TranslationBundle\Annotation\Desc;
 
 /**
  * Validator for checking min. and max. length of strings.
@@ -47,11 +48,10 @@ class StringLengthValidator extends Validator
                 case 'maxStringLength':
                     if ($value !== false && !is_int($value) && !(null === $value)) {
                         $validationErrors[] = new ValidationError(
-                            sprintf('Validator parameter \'%s\' value must be of integer type', self::PARAMETER_NAME),
+                            /** @Desc("Validator parameter '%parameter%' value must be of integer type") */
+                            "Validator parameter '%parameter%' value must be of integer type",
                             null,
-                            [
-                                self::PARAMETER_NAME => $name,
-                            ]
+                            [self::PARAMETER_NAME => $name]
                         );
                     } elseif ($value < 0) {
                         $validationErrors[] = new ValidationError(

--- a/src/lib/Limitation/SiteAccessLimitationType.php
+++ b/src/lib/Limitation/SiteAccessLimitationType.php
@@ -83,12 +83,9 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
         foreach ($limitationValue->limitationValues as $key => $value) {
             if (!isset($siteAccessList[$value])) {
                 $validationErrors[] = new ValidationError(
-                    "\$limitationValue->limitationValues[%key%] => Invalid SiteAccess value \"$value\"",
+                    "\$limitationValue->limitationValues[%key%] => Invalid SiteAccess value '%value%'",
                     null,
-                    [
-                        'value' => $value,
-                        'key' => $key,
-                    ]
+                    ['%key%' => $key, '%value%' => $value]
                 );
             }
         }

--- a/src/lib/MVC/Symfony/Translation/Annotation/Domain.php
+++ b/src/lib/MVC/Symfony/Translation/Annotation/Domain.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\MVC\Symfony\Translation\Annotation;
+
+use JMS\TranslationBundle\Exception\RuntimeException;
+
+/**
+ * @Annotation
+ */
+final class Domain
+{
+    /** @var string @Required */
+    public $value;
+
+    public function __construct()
+    {
+        if (0 === func_num_args()) {
+            return;
+        }
+
+        $values = func_get_arg(0);
+
+        if (!isset($values['value'])) {
+            throw new RuntimeException('The "value" attribute for annotation "@Domain" must be set.');
+        }
+
+        $this->value = $values['value'];
+    }
+}

--- a/src/lib/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
+++ b/src/lib/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
@@ -4,10 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
 
 namespace Ibexa\Core\MVC\Symfony\Translation;
 
 use Doctrine\Common\Annotations\DocParser;
+use Ibexa\Core\MVC\Symfony\Translation\Annotation\Domain;
 use JMS\TranslationBundle\Annotation\Desc;
 use JMS\TranslationBundle\Annotation\Ignore;
 use JMS\TranslationBundle\Annotation\Meaning;
@@ -17,12 +19,20 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
-use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use Psr\Log\LoggerInterface;
+use SplFileInfo;
 use Twig\Node\Node as TwigNode;
 
 /**
@@ -36,22 +46,25 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
 
     private MessageCatalogue $catalogue;
 
-    private \SplFileInfo $file;
+    private SplFileInfo $file;
 
     private DocParser $docParser;
 
-    private LoggerInterface $logger;
+    private ?LoggerInterface $logger = null;
 
-    private Node $previousNode;
+    private ?Node $previousNode = null;
+
+    /** @var list<array<string, string>> */
+    private array $classStringConstantStack = [];
+
+    /** @var list<?string> */
+    private array $classNameStack = [];
+
+    /** @var list<?string> */
+    private array $namespaceStack = [];
 
     protected string $defaultDomain = 'ibexa_repository_exceptions';
 
-    /**
-     * DefaultPhpFileExtractor constructor.
-     *
-     * @param \Doctrine\Common\Annotations\DocParser $docParser
-     * @param \JMS\TranslationBundle\Translation\FileSourceFactory $fileSourceFactory
-     */
     public function __construct(DocParser $docParser, FileSourceFactory $fileSourceFactory)
     {
         $this->docParser = $docParser;
@@ -60,20 +73,39 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
         $this->traverser->addVisitor($this);
     }
 
-    /**
-     * @param \Psr\Log\LoggerInterface $logger
-     */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
 
     public function enterNode(Node $node): null
     {
-        if (!$node instanceof Node\Expr\New_
-            || !$node->class instanceof Node\Name
-            || strtolower((string)$node->class) !== 'validationerror'
+        if ($node instanceof Namespace_) {
+            $this->namespaceStack[] = $node->name?->toString();
+            $this->previousNode = $node;
+
+            return null;
+        }
+
+        if ($node instanceof ClassLike) {
+            $this->classStringConstantStack[] = $this->extractStringConstants($node);
+            $this->classNameStack[] = $node->name?->toString();
+            $this->previousNode = $node;
+
+            return null;
+        }
+
+        if (!$node instanceof New_
+            || !$node->class instanceof Name
+            || strtolower((string) $node->class) !== 'validationerror'
         ) {
+            $this->previousNode = $node;
+
+            return null;
+        }
+
+        $idArg = $this->getArgument($node, 0);
+        if (null === $idArg) {
             $this->previousNode = $node;
 
             return null;
@@ -81,6 +113,7 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
 
         $ignore = false;
         $desc = $meaning = null;
+        $domain = $this->defaultDomain;
         if (null !== $docComment = $this->getDocCommentForNode($node)) {
             foreach ($this->docParser->parse($docComment, 'file ' . $this->file . ' near line ' . $node->getLine()) as $annot) {
                 if ($annot instanceof Ignore) {
@@ -89,18 +122,26 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
                     $desc = $annot->text;
                 } elseif ($annot instanceof Meaning) {
                     $meaning = $annot->text;
+                } elseif ($annot instanceof Domain) {
+                    $domain = $annot->value;
                 }
             }
         }
 
-        if (!$node->args[0]->value instanceof String_) {
+        $id = $this->resolveTranslationId($idArg->value);
+        if (null === $id) {
             if ($ignore) {
                 return null;
             }
 
-            $message = sprintf('Can only extract the translation ID from a scalar string, but got "%s". Refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).', get_class($node->args[0]->value), $this->file, $node->args[0]->value->getLine());
+            $message = sprintf(
+                'Can only extract the translation ID from a scalar string, but got "%s". Refactor your code to make it extractable, or add the doc comment /** @Ignore */ to this code element (in %s on line %d).',
+                get_class($idArg->value),
+                $this->file,
+                $idArg->value->getLine()
+            );
 
-            if (isset($this->logger)) {
+            if (null !== $this->logger) {
                 $this->logger->error($message);
 
                 return null;
@@ -109,15 +150,15 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
             throw new RuntimeException($message);
         }
 
-        $message = new Message($node->args[0]->value->value, $this->defaultDomain);
+        $message = new Message($id, $domain);
         $message->setDesc($desc);
         $message->setMeaning($meaning);
         $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
         $this->catalogue->add($message);
 
-        // plural
-        if (isset($node->args[1]) && $node->args[1]->value instanceof String_) {
-            $message = new Message($node->args[1]->value->value, $this->defaultDomain);
+        $pluralArg = $this->getArgument($node, 1);
+        if (null !== $pluralArg && null !== ($pluralId = $this->resolveTranslationId($pluralArg->value))) {
+            $message = new Message($pluralId, $domain);
             $message->setDesc($desc);
             $message->setMeaning($meaning);
             $message->addSource($this->fileSourceFactory->create($this->file, $node->getLine()));
@@ -128,24 +169,29 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
     }
 
     /**
-     * @param \SplFileInfo $file
-     * @param \JMS\TranslationBundle\Model\MessageCatalogue $catalogue
-     * @param \PhpParser\Node\Stmt[] $ast
+     * @param array<\PhpParser\Node> $nodes
      */
-    public function visitPhpFile(\SplFileInfo $file, MessageCatalogue $catalogue, array $ast): void
-    {
-        $this->file = $file;
-        $this->catalogue = $catalogue;
-        $this->traverser->traverse($ast);
-    }
-
     public function beforeTraverse(array $nodes): null
     {
+        $this->previousNode = null;
+        $this->classStringConstantStack = [];
+        $this->classNameStack = [];
+        $this->namespaceStack = [];
+
         return null;
     }
 
     public function leaveNode(Node $node): null
     {
+        if ($node instanceof ClassLike) {
+            array_pop($this->classStringConstantStack);
+            array_pop($this->classNameStack);
+        }
+
+        if ($node instanceof Namespace_) {
+            array_pop($this->namespaceStack);
+        }
+
         return null;
     }
 
@@ -155,46 +201,122 @@ class ValidationErrorFileVisitor implements LoggerAwareInterface, FileVisitorInt
     }
 
     /**
-     * @param \SplFileInfo $file
-     * @param \JMS\TranslationBundle\Model\MessageCatalogue $catalogue
+     * @param array<\PhpParser\Node> $ast
      */
-    public function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue): void
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast): void
+    {
+        $this->file = $file;
+        $this->catalogue = $catalogue;
+        $this->traverser->traverse($ast);
+    }
+
+    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue): void
     {
     }
 
-    /**
-     * @param \SplFileInfo $file
-     * @param \JMS\TranslationBundle\Model\MessageCatalogue $catalogue
-     * @param \Twig\Node\Node $ast
-     */
-    public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast): void
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast): void
     {
     }
 
-    /**
-     * @param \PhpParser\Node\Expr\New_ $node
-     *
-     * @return string|null
-     */
-    private function getDocCommentForNode(Node $node): ?string
+    private function getDocCommentForNode(New_ $node): ?string
     {
-        // check if there is a doc comment for the ID argument
-        // ->trans(/** @Desc("FOO") */ 'my.id')
-        if (null !== $comment = $node->args[0]->getDocComment()) {
+        $idArg = $this->getArgument($node, 0);
+        if (null !== $idArg && null !== ($comment = $idArg->getDocComment())) {
             return $comment->getText();
         }
 
-        // this may be placed somewhere up in the hierarchy,
-        // -> /** @Desc("FOO") */ trans('my.id')
-        // /** @Desc("FOO") */ ->trans('my.id')
-        // /** @Desc("FOO") */ $translator->trans('my.id')
         if (null !== $comment = $node->getDocComment()) {
             return $comment->getText();
         }
 
-        return
-            ($comment = $this->previousNode->getDocComment()) !== null
+        return null !== $this->previousNode && null !== ($comment = $this->previousNode->getDocComment())
             ? $comment->getText()
             : null;
+    }
+
+    private function getArgument(New_ $node, int $index): ?Arg
+    {
+        return isset($node->args[$index]) && $node->args[$index] instanceof Arg
+            ? $node->args[$index]
+            : null;
+    }
+
+    private function resolveTranslationId(Node $node): ?string
+    {
+        if ($node instanceof String_) {
+            return $node->value;
+        }
+
+        if (!$node instanceof ClassConstFetch || !$node->name instanceof Identifier) {
+            return null;
+        }
+
+        if (!$this->isCurrentClassConstantFetch($node)) {
+            return null;
+        }
+
+        $constants = end($this->classStringConstantStack);
+        if (false === $constants) {
+            return null;
+        }
+
+        return $constants[$node->name->toString()] ?? null;
+    }
+
+    private function isCurrentClassConstantFetch(ClassConstFetch $node): bool
+    {
+        if (!$node->class instanceof Name || [] === $this->classStringConstantStack) {
+            return false;
+        }
+
+        $className = strtolower($node->class->toString());
+        if (in_array($className, ['self', 'static'], true)) {
+            return true;
+        }
+
+        $currentClass = $this->getCurrentClassName();
+        if (null === $currentClass) {
+            return false;
+        }
+
+        if ($className === strtolower($currentClass)) {
+            return true;
+        }
+
+        $namespace = end($this->namespaceStack);
+        if (false === $namespace || null === $namespace) {
+            return false;
+        }
+
+        return ltrim($className, '\\') === strtolower($namespace . '\\' . $currentClass);
+    }
+
+    private function getCurrentClassName(): ?string
+    {
+        $className = end($this->classNameStack);
+
+        return false === $className ? null : $className;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function extractStringConstants(ClassLike $class): array
+    {
+        $constants = [];
+
+        foreach ($class->stmts ?? [] as $statement) {
+            if (!$statement instanceof ClassConst) {
+                continue;
+            }
+
+            foreach ($statement->consts as $const) {
+                if ($const->value instanceof String_) {
+                    $constants[$const->name->toString()] = $const->value->value;
+                }
+            }
+        }
+
+        return $constants;
     }
 }

--- a/src/lib/Repository/ContentTypeService.php
+++ b/src/lib/Repository/ContentTypeService.php
@@ -708,7 +708,9 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         if ($fieldDefinitionCreateStruct->isSearchable && !$fieldType->isSearchable()) {
             $validationErrors[] = new ValidationError(
-                "FieldType '{$fieldDefinitionCreateStruct->fieldTypeIdentifier}' is not searchable"
+                'Field type %field_type_identifier% is not searchable',
+                null,
+                ['%field_type_identifier%' => $fieldDefinitionCreateStruct->fieldTypeIdentifier]
             );
         }
 

--- a/src/lib/Repository/Mapper/ContentTypeDomainMapper.php
+++ b/src/lib/Repository/Mapper/ContentTypeDomainMapper.php
@@ -277,7 +277,11 @@ class ContentTypeDomainMapper extends ProxyAwareDomainMapper
         $validationErrors = [];
         if ($fieldDefinitionUpdateStruct->isSearchable && !$fieldType->isSearchable()) {
             $validationErrors[] = new ValidationError(
-                "FieldType '{$fieldDefinition->fieldTypeIdentifier}' is not searchable"
+                'Field type %field_type_identifier% is not searchable',
+                null,
+                [
+                    '%field_type_identifier%' => $fieldDefinition->fieldTypeIdentifier,
+                ]
             );
         }
         $validationErrors = array_merge(

--- a/src/lib/Repository/Validator/UserPasswordValidator.php
+++ b/src/lib/Repository/Validator/UserPasswordValidator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Core\Repository\Validator;
 
 use Ibexa\Core\FieldType\ValidationError;
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validation;
 
@@ -198,6 +199,14 @@ class UserPasswordValidator
      */
     private function createValidationError(string $message, array $values = []): ValidationError
     {
-        return new ValidationError($message, null, $values, 'password');
+        // TODO: Refactor this helper to use stable translation keys/templates.
+        // JMS extraction cannot read a ValidationError ID passed through a variable.
+        return new ValidationError(
+            /** @Ignore */
+            $message,
+            null,
+            $values,
+            'password'
+        );
     }
 }

--- a/tests/lib/Limitation/SiteAccessLimitationTypeTest.php
+++ b/tests/lib/Limitation/SiteAccessLimitationTypeTest.php
@@ -9,6 +9,7 @@ namespace Ibexa\Tests\Core\Limitation;
 
 use Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
+use Ibexa\Contracts\Core\Repository\Values\Translation\Message;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\ObjectStateLimitation;
 use Ibexa\Contracts\Core\Repository\Values\User\Limitation\SiteAccessLimitation;
@@ -175,6 +176,27 @@ class SiteAccessLimitationTypeTest extends Base
     {
         $validationErrors = $limitationType->validate($limitation);
         self::assertCount($errorCount, $validationErrors);
+    }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testValidateErrorMessage(SiteAccessLimitationType $limitationType): void
+    {
+        $validationErrors = $limitationType->validate(
+            new SiteAccessLimitation(
+                [
+                    'limitationValues' => ['2339567439'],
+                ]
+            )
+        );
+
+        self::assertCount(1, $validationErrors);
+        self::assertInstanceOf(Message::class, $validationErrors[0]->getTranslatableMessage());
+        self::assertSame(
+            "\$limitationValue->limitationValues[0] => Invalid SiteAccess value '2339567439'",
+            (string) $validationErrors[0]->getTranslatableMessage()
+        );
     }
 
     /**

--- a/tests/lib/MVC/Symfony/Translation/BaseMessageExtractorPhpFileVisitorTestCase.php
+++ b/tests/lib/MVC/Symfony/Translation/BaseMessageExtractorPhpFileVisitorTestCase.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Core\MVC\Symfony\Translation;
 
 use Doctrine\Common\Annotations\DocParser;
+use Ibexa\Core\MVC\Symfony\Translation\Annotation\Domain;
+use JMS\TranslationBundle\Annotation\Desc;
+use JMS\TranslationBundle\Annotation\Ignore;
+use JMS\TranslationBundle\Annotation\Meaning;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
@@ -38,6 +42,13 @@ abstract class BaseMessageExtractorPhpFileVisitorTestCase extends TestCase
     protected function setUp(): void
     {
         $docParser = new DocParser();
+        $docParser->setImports([
+            'desc' => Desc::class,
+            'domain' => Domain::class,
+            'ignore' => Ignore::class,
+            'meaning' => Meaning::class,
+        ]);
+
         $fileSourceFactory = new FileSourceFactory(self::FIXTURES_DIR);
         $factory = new ParserFactory();
         $this->phpParser = $factory->createForHostVersion();

--- a/tests/lib/MVC/Symfony/Translation/ValidationErrorFileVisitorTest.php
+++ b/tests/lib/MVC/Symfony/Translation/ValidationErrorFileVisitorTest.php
@@ -11,8 +11,10 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Translation;
 use Doctrine\Common\Annotations\DocParser;
 use Ibexa\Core\MVC\Symfony\Translation\ValidationErrorFileVisitor;
 use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use JMS\TranslationBundle\Translation\FileSourceFactory;
+use SplFileInfo;
 
 /**
  * @covers \Ibexa\Core\MVC\Symfony\Translation\ValidationErrorFileVisitor
@@ -30,8 +32,48 @@ final class ValidationErrorFileVisitorTest extends BaseMessageExtractorPhpFileVi
                 new Message('error_1.singular_only', 'ibexa_repository_exceptions'),
                 new Message('error_2.singular', 'ibexa_repository_exceptions'),
                 new Message('error_2.plural', 'ibexa_repository_exceptions'),
+                new Message('error_3.with_desc', 'ibexa_repository_exceptions'),
+                new Message('error_4.validators_domain', 'validators'),
             ],
         ];
+    }
+
+    public function testExtractTranslationKeepsDescriptionForClassConstant(): void
+    {
+        $messageCatalogue = new MessageCatalogue();
+        $file = self::FIXTURES_DIR . 'ValidationErrorUsageStub.php';
+        $fileInfo = new SplFileInfo($file);
+
+        $ast = $this->getASTFromFile($file);
+        $this->visitor->visitPhpFile(
+            $fileInfo,
+            $messageCatalogue,
+            $ast
+        );
+
+        $message = $messageCatalogue->get('error_3.with_desc', 'ibexa_repository_exceptions');
+
+        self::assertNotNull($message);
+        self::assertSame('Validation error extracted from class const', $message->getDesc());
+    }
+
+    public function testExtractTranslationAllowsDomainOverride(): void
+    {
+        $messageCatalogue = new MessageCatalogue();
+        $file = self::FIXTURES_DIR . 'ValidationErrorUsageStub.php';
+        $fileInfo = new SplFileInfo($file);
+
+        $ast = $this->getASTFromFile($file);
+        $this->visitor->visitPhpFile(
+            $fileInfo,
+            $messageCatalogue,
+            $ast
+        );
+
+        $message = $messageCatalogue->get('error_4.validators_domain', 'validators');
+
+        self::assertNotNull($message);
+        self::assertSame('Validation error extracted into validators domain', $message->getDesc());
     }
 
     protected function buildVisitor(DocParser $docParser, FileSourceFactory $fileSourceFactory): FileVisitorInterface

--- a/tests/lib/MVC/Symfony/Translation/fixtures/ValidationErrorUsageStub.php
+++ b/tests/lib/MVC/Symfony/Translation/fixtures/ValidationErrorUsageStub.php
@@ -9,12 +9,19 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Core\MVC\Symfony\Translation\fixtures;
 
 use Ibexa\Core\FieldType\ValidationError;
+use Ibexa\Core\MVC\Symfony\Translation\Annotation\Domain;
+use JMS\TranslationBundle\Annotation\Desc;
 
 /**
  * @see \Ibexa\Tests\Core\MVC\Symfony\Translation\ValidationErrorFileVisitorTest
  */
 final class ValidationErrorUsageStub
 {
+    private const SINGULAR = 'error_2.singular';
+    private const PLURAL = 'error_2.plural';
+    private const WITH_DESC = 'error_3.with_desc';
+    private const WITH_VALIDATORS_DOMAIN = 'error_4.validators_domain';
+
     /**
      * @return \Ibexa\Contracts\Core\FieldType\ValidationError[]
      */
@@ -23,5 +30,17 @@ final class ValidationErrorUsageStub
         yield new ValidationError('error_1.singular_only');
 
         yield new ValidationError('error_2.singular', 'error_2.plural');
+
+        yield new ValidationError(static::SINGULAR, self::PLURAL);
+
+        yield new ValidationError(
+            /** @Desc("Validation error extracted from class const") */
+            self::WITH_DESC
+        );
+
+        yield new ValidationError(
+            /** @Desc("Validation error extracted into validators domain") @Domain("validators") */
+            self::WITH_VALIDATORS_DOMAIN
+        );
     }
 }

--- a/tests/lib/Repository/ContentTypeServiceValidationErrorTest.php
+++ b/tests/lib/Repository/ContentTypeServiceValidationErrorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository;
+
+use Ibexa\Contracts\Core\FieldType\FieldType as SPIFieldType;
+use Ibexa\Contracts\Core\Persistence\Content\Type\Handler;
+use Ibexa\Contracts\Core\Persistence\User\Handler as UserHandler;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\Repository\Repository as RepositoryInterface;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Translation\Message;
+use Ibexa\Core\FieldType\FieldTypeRegistry;
+use Ibexa\Core\Repository\ContentTypeService;
+use Ibexa\Core\Repository\Mapper\ContentDomainMapper;
+use Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper;
+use PHPUnit\Framework\TestCase;
+
+final class ContentTypeServiceValidationErrorTest extends TestCase
+{
+    public function testValidateFieldDefinitionCreateStructBuildsTranslatableSearchableError(): void
+    {
+        $service = new class(
+            $this->createMock(RepositoryInterface::class),
+            $this->createMock(Handler::class),
+            $this->createMock(UserHandler::class),
+            $this->createMock(ContentDomainMapper::class),
+            $this->createMock(ContentTypeDomainMapper::class),
+            $this->createMock(FieldTypeRegistry::class),
+            $this->createMock(PermissionResolver::class)
+        ) extends ContentTypeService {
+            /**
+             * @return array<\Ibexa\Contracts\Core\FieldType\ValidationError>
+             */
+            public function exposeValidateFieldDefinitionCreateStruct(
+                FieldDefinitionCreateStruct $fieldDefinitionCreateStruct,
+                SPIFieldType $fieldType
+            ): array {
+                return $this->validateFieldDefinitionCreateStruct($fieldDefinitionCreateStruct, $fieldType);
+            }
+        };
+
+        $fieldDefinitionCreateStruct = new FieldDefinitionCreateStruct();
+        $fieldDefinitionCreateStruct->fieldTypeIdentifier = 'ibexa_non_searchable';
+        $fieldDefinitionCreateStruct->isSearchable = true;
+        $fieldDefinitionCreateStruct->validatorConfiguration = [];
+        $fieldDefinitionCreateStruct->fieldSettings = [];
+
+        $fieldType = $this->createMock(SPIFieldType::class);
+        $fieldType->method('isSearchable')->willReturn(false);
+        $fieldType->method('validateValidatorConfiguration')->willReturn([]);
+        $fieldType->method('validateFieldSettings')->willReturn([]);
+
+        $validationErrors = $service->exposeValidateFieldDefinitionCreateStruct($fieldDefinitionCreateStruct, $fieldType);
+
+        self::assertCount(1, $validationErrors);
+        self::assertInstanceOf(Message::class, $validationErrors[0]->getTranslatableMessage());
+        self::assertSame(
+            'Field type ibexa_non_searchable is not searchable',
+            (string) $validationErrors[0]->getTranslatableMessage()
+        );
+    }
+}

--- a/tests/lib/Repository/Mapper/ContentTypeDomainMapperValidationErrorTest.php
+++ b/tests/lib/Repository/Mapper/ContentTypeDomainMapperValidationErrorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository\Mapper;
+
+use Ibexa\Contracts\Core\FieldType\FieldType as SPIFieldType;
+use Ibexa\Contracts\Core\Persistence\Content\Language\Handler as SPILanguageHandler;
+use Ibexa\Contracts\Core\Persistence\Content\Type\Handler as SPITypeHandler;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
+use Ibexa\Contracts\Core\Repository\Values\Translation\Message;
+use Ibexa\Core\Base\Exceptions\ContentTypeFieldDefinitionValidationException;
+use Ibexa\Core\FieldType\FieldTypeRegistry;
+use Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper;
+use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class ContentTypeDomainMapperValidationErrorTest extends TestCase
+{
+    public function testBuildSPIFieldDefinitionFromUpdateStructBuildsTranslatableSearchableError(): void
+    {
+        $fieldType = $this->createMock(SPIFieldType::class);
+        $fieldType->method('isSearchable')->willReturn(false);
+        $fieldType->method('validateValidatorConfiguration')->willReturn([]);
+        $fieldType->method('validateFieldSettings')->willReturn([]);
+
+        $fieldTypeRegistry = $this->createMock(FieldTypeRegistry::class);
+        $fieldTypeRegistry->method('getFieldType')->with('ibexa_non_searchable')->willReturn($fieldType);
+
+        $mapper = new ContentTypeDomainMapper(
+            $this->createMock(SPITypeHandler::class),
+            $this->createMock(SPILanguageHandler::class),
+            $fieldTypeRegistry
+        );
+
+        $fieldDefinitionUpdateStruct = new FieldDefinitionUpdateStruct();
+        $fieldDefinitionUpdateStruct->isSearchable = true;
+        $fieldDefinitionUpdateStruct->validatorConfiguration = [];
+        $fieldDefinitionUpdateStruct->fieldSettings = [];
+
+        $fieldDefinition = new FieldDefinition([
+            'id' => 1,
+            'identifier' => 'test_field',
+            'fieldTypeIdentifier' => 'ibexa_non_searchable',
+            'fieldGroup' => 'content',
+            'position' => 0,
+            'isTranslatable' => false,
+            'isRequired' => false,
+            'isThumbnail' => false,
+            'isInfoCollector' => false,
+            'isSearchable' => false,
+            'mainLanguageCode' => 'eng-GB',
+            'names' => ['eng-GB' => 'Test field'],
+            'descriptions' => ['eng-GB' => ''],
+            'validatorConfiguration' => [],
+            'fieldSettings' => [],
+            'defaultValue' => null,
+            'prioritizedLanguages' => [],
+        ]);
+
+        try {
+            $mapper->buildSPIFieldDefinitionFromUpdateStruct($fieldDefinitionUpdateStruct, $fieldDefinition, 'eng-GB');
+            self::fail('Expected ContentTypeFieldDefinitionValidationException was not thrown.');
+        } catch (ContentTypeFieldDefinitionValidationException $exception) {
+            $errors = $exception->getFieldErrors();
+
+            self::assertArrayHasKey('test_field', $errors);
+            self::assertCount(1, $errors['test_field']);
+            self::assertInstanceOf(Message::class, $errors['test_field'][0]->getTranslatableMessage());
+            self::assertSame(
+                'Field type ibexa_non_searchable is not searchable',
+                (string) $errors['test_field'][0]->getTranslatableMessage()
+            );
+        }
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR improves the way translation messages are extracted from `ValidationError` usages.
Until now, the custom ValidationErrorFileVisitor only accepted scalar string literals as translation IDs. In practice, this meant that a very common and perfectly valid PHP pattern, such as `new ValidationError(self::SOME_MESSAGE)`, could not be extracted, even though the value was statically known. As a result, developers had to either inline translation keys as raw strings, duplicate messages elsewhere for extraction purposes, or silence the extractor with `@Ignore`.

This change makes the extractor more practical and consistent with real-world usage. `ValidationErrorFileVisitor` now supports simple class constant references, including self::CONST, static::CONST, and equivalent references to the current class, as long as they can be resolved statically to a string value. The implementation intentionally stays conservative: it does not try to evaluate arbitrary PHP expressions, and it only resolves cases that are safe and predictable during AST-based analysis.

In addition, this PR introduces support for a new `@Domain(...)` annotation for ValidationError extraction. Previously, messages handled by `ValidationErrorFileVisitor` always fell back to the visitor’s default domain, which made it impossible to cleanly route validation messages into domains such as validators without relying on separate translation container declarations. With `@Domain(...)`, the extraction domain can now be controlled directly at the ValidationError call site, alongside existing metadata such as `@Desc` and `@Meaning`.

The runtime JMS doc parser configuration has also been updated so that the new annotation is recognized during actual translation extraction, not only in isolated unit tests. This was necessary to make the feature work end-to-end in real extraction runs.

The test suite for ValidationErrorFileVisitor has been expanded accordingly. It now covers extraction from string literals, extraction from class constants, imported `@Desc` usage, and explicit domain override with `@Domain(...)`. The visitor implementation was also slightly tightened to satisfy static analysis more cleanly.

While working on extraction issues, a few remaining ValidationError usages were identified where the translation ID is still passed through a variable. Those cases are not meaningfully extractable with the current static model and were already effectively unsupported. For now, they have been marked with `@Ignore` and documented with TODO comments explaining that they should
eventually be refactored to stable translation keys or templates. This keeps extraction noise down without pretending those messages are currently extractable.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
