### PR TITLE
IBX-11423: added optional parameter $showAllTranslations to URLAliasS…

### DIFF
--- a/src/contracts/Repository/Decorator/URLAliasServiceDecorator.php
+++ b/src/contracts/Repository/Decorator/URLAliasServiceDecorator.php
@@ -92,9 +92,9 @@ abstract class URLAliasServiceDecorator implements URLAliasService
         );
     }
 
-    public function load(string $id): URLAlias
+    public function load(string $id, ?bool $showAllTranslations = null): URLAlias
     {
-        return $this->innerService->load($id);
+        return $this->innerService->load($id, $showAllTranslations);
     }
 
     public function refreshSystemUrlAliasesForLocation(Location $location): void

--- a/src/contracts/Repository/URLAliasService.php
+++ b/src/contracts/Repository/URLAliasService.php
@@ -156,10 +156,11 @@ interface URLAliasService
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      *
      * @param string $id
+     * @param bool|null $showAllTranslations If enabled will include all alias as if they where always available.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\URLAlias
      */
-    public function load(string $id): URLAlias;
+    public function load(string $id, ?bool $showAllTranslations = null): URLAlias;
 
     /**
      * Refresh all system URL aliases for the given Location (and historize outdated if needed).

--- a/src/lib/Repository/SiteAccessAware/URLAliasService.php
+++ b/src/lib/Repository/SiteAccessAware/URLAliasService.php
@@ -103,9 +103,9 @@ class URLAliasService implements URLAliasServiceInterface
         );
     }
 
-    public function load(string $id): URLAlias
+    public function load(string $id, ?bool $showAllTranslations = null): URLAlias
     {
-        return $this->service->load($id);
+        return $this->service->load($id, $showAllTranslations);
     }
 
     public function refreshSystemUrlAliasesForLocation(Location $location): void

--- a/src/lib/Repository/URLAliasService.php
+++ b/src/lib/Repository/URLAliasService.php
@@ -721,16 +721,17 @@ class URLAliasService implements URLAliasServiceInterface
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      *
      * @param string $id
+     * @param bool|null $showAllTranslations If enabled will include all alias as if they where always available.
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\URLAlias
      */
-    public function load(string $id): URLAlias
+    public function load(string $id, ?bool $showAllTranslations = null): URLAlias
     {
         $spiUrlAlias = $this->urlAliasHandler->loadUrlAlias($id);
         $path = $this->extractPath(
             $spiUrlAlias,
             null,
-            $this->languageResolver->getShowAllTranslations(),
+            $this->languageResolver->getShowAllTranslations($showAllTranslations),
             $this->languageResolver->getPrioritizedLanguages()
         );
 


### PR DESCRIPTION
| :ticket: Issue | IBX-11423|
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/1864


#### Description:
Added optional parameter $showAllTranslations to URLAliasService::load()

In Ibexa\Bundle\AdminUi\Controller\UrlAliasController::removeAction(), the service is used to load aliases to be removed, but it returns only the aliases for the default language. Added the optional parameter to use in the related PR to load aliases for all languages when creating a list of aliases to remove.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
