### PR TITLE
Fixed accessing non-interface methods in StructWrapperValidator

### DIFF
--- a/src/contracts/Validation/StructWrapperValidator.php
+++ b/src/contracts/Validation/StructWrapperValidator.php
@@ -62,8 +62,8 @@ final class StructWrapperValidator implements ValidatorInterface
                 $error->getInvalidValue(),
                 $error->getPlural(),
                 $error->getCode(),
-                $error->getConstraint(),
-                $error->getCause()
+                $error instanceof ConstraintViolation ? $error->getConstraint() : null,
+                $error instanceof ConstraintViolation ? $error->getCause() : null
             );
 
             $unwrappedErrors->add($unwrappedError);


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:

Seems like PHPStan after the latest release started detecting 2 new issues:

```
 ------ -------------------------------------------------------------------------------------------------------- 
  Line   src/contracts/Validation/StructWrapperValidator.php                                                     
 ------ -------------------------------------------------------------------------------------------------------- 
  65     Call to an undefined method Symfony\Component\Validator\ConstraintViolationInterface::getConstraint().  
         🪪  method.notFound                                                                                     
  66     Call to an undefined method Symfony\Component\Validator\ConstraintViolationInterface::getCause().       
         🪪  method.notFound                                                                                     
 ------ --------------------------------------------------------------------------------------------------------
```

The report is valid, as neither `getConstraint` nor `getCause` method exist on `ConstraintViolationInterface`. The methods appeared on the contract in further Symfony version (the issue doesn't exist on 5.0 branch).


#### For QA:

No QA required.
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->


#### Documentation:

No documentation required.


