### PR TITLE
Removed ibexa/polyfill-php82 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,7 @@
         "symfony/var-dumper": "^7.4",
         "symfony/yaml": "^7.4",
         "twig/extra-bundle": "^3.0",
-        "twig/twig": ">=3.0 <3.16 || ^3.19.0",
-        "ibexa/polyfill-php82": "^1.0"
+        "twig/twig": ">=3.0 <3.16 || ^3.19.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This polyfill stopped being necessary since we require PHP 8.3+.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
