### PR TITLE
IBX-11766: Replaced phpunit assertions with webmozart equivalents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^9.6",
         "symfony/phpunit-bridge": "^7.4",
-        "symfony/runtime": "^7.4"
+        "symfony/runtime": "^7.4",
+        "webmozart/assert": "^2.3"
     },
     "conflict": {
         "doctrine/dbal": "2.7.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2197,12 +2197,6 @@ parameters:
 			path: src/bundle/Core/Features/Context/ContentPreviewContext.php
 
 		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with false and non\-falsy\-string will always evaluate to false\.$#'
-			identifier: staticMethod.impossibleType
-			count: 1
-			path: src/bundle/Core/Features/Context/ContentPreviewContext.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\Core\\Features\\Context\\ContentPreviewContext\:\:checkForExceptions\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7441,7 +7435,7 @@ parameters:
 			path: src/lib/FieldType/ValueSerializer/SymfonySerializerAdapter.php
 
 		-
-			message: '#^Method Ibexa\\Core\\FieldType\\ValueSerializer\\SymfonySerializerAdapter\:\:normalize\(\) should return array\|null but returns array\|ArrayObject\|bool\|float\|int\|string\|null\.$#'
+			message: '#^Method Ibexa\\Core\\FieldType\\ValueSerializer\\SymfonySerializerAdapter\:\:normalize\(\) should return array\|null but returns array\<mixed\>\|ArrayObject\<\(int\|string\), mixed\>\|bool\|float\|int\|string\|null\.$#'
 			identifier: return.type
 			count: 1
 			path: src/lib/FieldType/ValueSerializer/SymfonySerializerAdapter.php

--- a/src/bundle/Core/Features/Context/ConsoleContext.php
+++ b/src/bundle/Core/Features/Context/ConsoleContext.php
@@ -112,7 +112,7 @@ class ConsoleContext implements Context
     {
         $this->thereIsASiteaccess($expectedSiteaccessName, true);
         Assertion::eq(
-            $siteaccessList = $this->getConfigResolver()->getParameter('siteaccess.default_siteaccess'),
+            $this->getConfigResolver()->getParameter('siteaccess.default_siteaccess'),
             $expectedSiteaccessName
         );
     }

--- a/src/bundle/Core/Features/Context/ConsoleContext.php
+++ b/src/bundle/Core/Features/Context/ConsoleContext.php
@@ -9,9 +9,9 @@ namespace Ibexa\Bundle\Core\Features\Context;
 
 use Behat\Behat\Context\Context;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
-use PHPUnit\Framework\Assert as Assertion;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
+use Webmozart\Assert\Assert as Assertion;
 
 class ConsoleContext implements Context
 {
@@ -70,9 +70,9 @@ class ConsoleContext implements Context
     public function iExpectItToBeExecutedWithTheSiteaccess($siteaccess)
     {
         $actualSiteaccess = trim($this->scriptOutput);
-        Assertion::assertEquals(
-            $siteaccess,
+        Assertion::eq(
             $actualSiteaccess,
+            $siteaccess,
             "The command was expected to be executed with the siteaccess \"$siteaccess\", but was executed with \"$actualSiteaccess\""
         );
     }
@@ -101,7 +101,7 @@ class ConsoleContext implements Context
             }
         }
 
-        Assertion::assertTrue($found, "No siteaccess named $expectedSiteaccessName was found");
+        Assertion::true($found, "No siteaccess named $expectedSiteaccessName was found");
         $this->it['siteaccess'] = $expectedSiteaccessName;
     }
 
@@ -111,9 +111,9 @@ class ConsoleContext implements Context
     public function thereIsADefaultSiteaccess($expectedSiteaccessName)
     {
         $this->thereIsASiteaccess($expectedSiteaccessName, true);
-        Assertion::assertEquals(
-            $expectedSiteaccessName,
-            $siteaccessList = $this->getConfigResolver()->getParameter('siteaccess.default_siteaccess')
+        Assertion::eq(
+            $siteaccessList = $this->getConfigResolver()->getParameter('siteaccess.default_siteaccess'),
+            $expectedSiteaccessName
         );
     }
 
@@ -167,7 +167,7 @@ class ConsoleContext implements Context
     public function thereIsASiteaccessThatIsNotTheDefaultOne()
     {
         $siteaccessName = $this->getNonDefaultSiteaccessName();
-        Assertion::assertNotNull($siteaccessName, 'There is no siteaccess other than the default one');
+        Assertion::notNull($siteaccessName, 'There is no siteaccess other than the default one');
         $this->it['siteaccess'] = $siteaccessName;
     }
 
@@ -176,7 +176,7 @@ class ConsoleContext implements Context
      */
     public function iExpectItToBeExecutedWithIt()
     {
-        Assertion::assertEquals($this->it['siteaccess'], $this->scriptOutput);
+        Assertion::eq($this->scriptOutput, $this->it['siteaccess']);
     }
 
     /**

--- a/src/bundle/Core/Features/Context/ContentPreviewContext.php
+++ b/src/bundle/Core/Features/Context/ContentPreviewContext.php
@@ -10,7 +10,7 @@ namespace Ibexa\Bundle\Core\Features\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 class ContentPreviewContext extends RawMinkContext
 {
@@ -86,7 +86,7 @@ class ContentPreviewContext extends RawMinkContext
                 $exceptionLines[] = trim($html);
             }
             $message = 'An exception occured during rendering:' . implode("\n", $exceptionLines);
-            Assertion::assertTrue(false, $message);
+            Assertion::true(false, $message);
         }
     }
 

--- a/src/bundle/Core/Features/Context/ContentTypeContext.php
+++ b/src/bundle/Core/Features/Context/ContentTypeContext.php
@@ -11,7 +11,7 @@ use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Exceptions as ApiExceptions;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 /**
  * Sentences for content types.
@@ -81,7 +81,7 @@ class ContentTypeContext implements Context
      */
     public function assertContentTypeExistsByIdentifier($identifier)
     {
-        Assertion::assertTrue(
+        Assertion::true(
             $this->checkContentTypeExistenceByIdentifier($identifier),
             "Couldn't find a content type with identifier '$identifier'."
         );
@@ -94,7 +94,7 @@ class ContentTypeContext implements Context
      */
     public function assertContentTypeDoesntExistsByIdentifier($identifier)
     {
-        Assertion::assertFalse(
+        Assertion::false(
             $this->checkContentTypeExistenceByIdentifier($identifier),
             "Found a content type with identifier '$identifier'."
         );
@@ -107,7 +107,7 @@ class ContentTypeContext implements Context
      */
     public function assertContentTypeExistsByIdentifierOnGroup($identifier, $groupIdentifier)
     {
-        Assertion::assertTrue(
+        Assertion::true(
             $this->checkContentTypeExistenceByIdentifier($identifier, $groupIdentifier),
             "Couldn't find content type with identifier '$identifier' on '$groupIdentifier."
         );

--- a/src/bundle/Core/Features/Context/QueryControllerContext.php
+++ b/src/bundle/Core/Features/Context/QueryControllerContext.php
@@ -8,7 +8,7 @@
 namespace Ibexa\Bundle\Core\Features\Context;
 
 use Behat\MinkExtension\Context\RawMinkContext;
-use PHPUnit\Framework\Assert;
+use Webmozart\Assert\Assert;
 
 class QueryControllerContext extends RawMinkContext
 {
@@ -19,7 +19,7 @@ class QueryControllerContext extends RawMinkContext
     {
         $variableTypes = $this->getVariableTypesFromTemplate();
 
-        Assert::assertArrayHasKey($twigVariableName, $variableTypes, "The $twigVariableName twig variable was not set");
+        Assert::keyExists($variableTypes, $twigVariableName, "The $twigVariableName twig variable was not set");
     }
 
     /**
@@ -29,8 +29,8 @@ class QueryControllerContext extends RawMinkContext
     {
         $variableTypes = $this->getVariableTypesFromTemplate();
 
-        Assert::assertArrayHasKey($twigVariableName, $variableTypes, "The $twigVariableName twig variable was not set");
-        Assert::assertEquals($className, $variableTypes[$twigVariableName], "The $twigVariableName twig variable does not have $className type");
+        Assert::keyExists($variableTypes, $twigVariableName, "The $twigVariableName twig variable was not set");
+        Assert::eq($variableTypes[$twigVariableName], $className, "The $twigVariableName twig variable does not have $className type");
     }
 
     /**
@@ -59,12 +59,12 @@ class QueryControllerContext extends RawMinkContext
             }
         }
 
-        Assert::assertTrue(
+        Assert::true(
             $pageLimitFound,
             "The maxPerPage $pageLimit twig variable was not set"
         );
 
-        Assert::assertTrue(
+        Assert::true(
             $currentPageFound,
             "The currentPage $pageValue twig variable  was not set"
         );

--- a/src/bundle/Core/Features/Context/RoleContext.php
+++ b/src/bundle/Core/Features/Context/RoleContext.php
@@ -10,7 +10,7 @@ namespace Ibexa\Bundle\Core\Features\Context;
 use Behat\Behat\Context\Context;
 use Ibexa\Contracts\Core\Repository\Exceptions as ApiExceptions;
 use Ibexa\Contracts\Core\Repository\RoleService;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 /**
  * Sentences for Roles.
@@ -85,7 +85,7 @@ class RoleContext implements Context
     public function iSeeRole($name)
     {
         $role = $this->getRole($name);
-        Assertion::assertNotNull(
+        Assertion::notNull(
             $role,
             "Couldn't find Role with name $name"
         );
@@ -97,12 +97,12 @@ class RoleContext implements Context
     public function noAssginedPolicies($name)
     {
         $role = $this->getRole($name);
-        Assertion::assertNotNull(
+        Assertion::notNull(
             $role,
             "Couldn't find Role with name $name"
         );
         $policies = $role->getPolicies();
-        Assertion::assertEmpty($policies, "Role $name has policies associated");
+        Assertion::isEmpty($policies, "Role $name has policies associated");
     }
 
     /**
@@ -111,12 +111,12 @@ class RoleContext implements Context
     public function noAssigneGroups($name)
     {
         $role = $this->getRole($name);
-        Assertion::assertNotNull(
+        Assertion::notNull(
             $role,
             "Couldn't find Role with name $name"
         );
         $roleAssigments = $this->roleService->getRoleAssignments($role);
-        Assertion::assertEmpty($roleAssigments, "Role $name has Users or groups associated");
+        Assertion::isEmpty($roleAssigments, "Role $name has Users or groups associated");
     }
 
     /**
@@ -127,7 +127,7 @@ class RoleContext implements Context
     public function iDontSeeRole($name)
     {
         $role = $this->getRole($name);
-        Assertion::assertNull(
+        Assertion::null(
             $role,
             "Found Role with name $name"
         );

--- a/src/bundle/Core/Features/Context/UserContext.php
+++ b/src/bundle/Core/Features/Context/UserContext.php
@@ -15,7 +15,7 @@ use Ibexa\Contracts\Core\Repository\SearchService;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
-use PHPUnit\Framework\Assert as Assertion;
+use Webmozart\Assert\Assert as Assertion;
 
 /**
  * Sentences for Users.
@@ -427,7 +427,7 @@ class UserContext implements Context
      */
     public function assertUserWithNameExists($username)
     {
-        Assertion::assertTrue(
+        Assertion::true(
             $this->checkUserExistenceByUsername($username),
             "Couldn't find User with name '$username'."
         );
@@ -440,7 +440,7 @@ class UserContext implements Context
      */
     public function assertUserWithNameDoesntExist($username)
     {
-        Assertion::assertFalse(
+        Assertion::false(
             $this->checkUserExistenceByUsername($username),
             "User with name '$username' was found."
         );
@@ -454,7 +454,7 @@ class UserContext implements Context
      */
     public function assertUserWithNameExistsInGroup($username, $parentGroup)
     {
-        Assertion::assertTrue(
+        Assertion::true(
             $this->checkUserExistenceByUsername($username, $parentGroup),
             "Couldn't find User with name '$username' in parent group '$parentGroup'."
         );
@@ -468,7 +468,7 @@ class UserContext implements Context
      */
     public function assertUserWithNameDoesntExistInGroup($username, $parentGroup)
     {
-        Assertion::assertFalse(
+        Assertion::false(
             $this->checkUserExistenceByUsername($username, $parentGroup),
             "User with name '$username' was found in parent group '$parentGroup'."
         );
@@ -490,7 +490,7 @@ class UserContext implements Context
         array_shift($groups);
         foreach ($groups as $group) {
             $parentGroupName = $group[0];
-            Assertion::assertFalse(
+            Assertion::false(
                 $this->checkUserExistenceByUsername($username, $parentGroupName),
                 "User with name '$username' was found in parent group '$parentGroupName'."
             );
@@ -510,7 +510,7 @@ class UserContext implements Context
      */
     public function assertUserWithNameExistsWithFields($username, TableNode $table)
     {
-        Assertion::assertTrue(
+        Assertion::true(
             $this->checkUserExistenceByUsername($username),
             "Couldn't find User with name '$username'."
         );
@@ -532,9 +532,9 @@ class UserContext implements Context
                 default:
                     $fieldValue = $user->getFieldValue($fieldName);
             }
-            Assertion::assertEquals(
-                $expectedValue,
+            Assertion::eq(
                 $fieldValue,
+                $expectedValue,
                 "Field '$fieldName' did not contain expected value '$expectedValue'."
             );
         }


### PR DESCRIPTION
:ticket: Issue | [IBX-11766](https://ibexa.atlassian.net/browse/IBX-11766) |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/behat/pull/184

#### Description:
Installed `webmozart/assert` library as require-dev dependency. It's still a bit "hidden" dependency (because behat package use assertions from /src directory), but at least it's defined in this specific library. Previously, phpunit was installed by indirect dependency from `ibexa/behat` package.

Replaced phpunit assertions with these from webmozart library.

#### For QA:
#### Documentation:

[IBX-11766]: https://ibexa.atlassian.net/browse/IBX-11766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ