### PR TITLE
IBX-11797: [4.6] Testing ibexa/gh-workflows#96

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -18,7 +18,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: ibexa/gh-workflows/actions/composer-install@main
+            -   uses: ibexa/gh-workflows/actions/composer-install@ibx-11717-composer-audit-ignore-action
                 with:
                     gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                     gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
@@ -44,7 +44,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: ibexa/gh-workflows/actions/composer-install@main
+            -   uses: ibexa/gh-workflows/actions/composer-install@ibx-11717-composer-audit-ignore-action
                 with:
                     gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                     gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
@@ -100,7 +100,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: ibexa/gh-workflows/actions/composer-install@main
+            -   uses: ibexa/gh-workflows/actions/composer-install@ibx-11717-composer-audit-ignore-action
                 with:
                     gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                     gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
@@ -157,7 +157,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
 
-            -   uses: ibexa/gh-workflows/actions/composer-install@main
+            -   uses: ibexa/gh-workflows/actions/composer-install@ibx-11717-composer-audit-ignore-action
                 with:
                     gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                     gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
@@ -221,7 +221,7 @@ jobs:
                     composer require --no-update "ibexa/solr:$VERSION"
 
             -   name: Install Composer dependencies
-                uses: ibexa/gh-workflows/actions/composer-install@main
+                uses: ibexa/gh-workflows/actions/composer-install@ibx-11717-composer-audit-ignore-action
                 with:
                     gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                     gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}


### PR DESCRIPTION
> [!CAUTION]
> # Do not merge, for testing purposes only
 
| :ticket: Issue | IBX-11797 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/gh-workflows/pull/96


#### Description:

Testing ibexa/gh-workflows#96 with the set of twig/twig advisories.

Failing build: https://github.com/ibexa/core/actions/runs/26192084413/job/77062753593?pr=754
The error is not straightforward - there's simply no viable candidate of twig/twig for PHP 7.4 as v3.11.3 - the last supporting PHP 7, was marked as vulnerable today.

