### PR TITLE
IBX-11687: Fixed ContentTypeDomainMapper to not unset the default field value

### DIFF
--- a/src/contracts/Repository/Values/ContentType/FieldDefinitionUpdateStruct.php
+++ b/src/contracts/Repository/Values/ContentType/FieldDefinitionUpdateStruct.php
@@ -97,6 +97,10 @@ class FieldDefinitionUpdateStruct extends ValueObject
     /**
      * If set the default value for this field is changed to the given value.
      *
+     * Null value is treated as "not provided" and the field definition's current
+     * default value is preserved. To clear an existing default value, set
+     * this to the field type's empty value instead of null.
+     *
      * @var mixed
      */
     public $defaultValue;

--- a/src/lib/Repository/Mapper/ContentTypeDomainMapper.php
+++ b/src/lib/Repository/Mapper/ContentTypeDomainMapper.php
@@ -425,8 +425,9 @@ class ContentTypeDomainMapper extends ProxyAwareDomainMapper
 
         $spiFieldDefinition->fieldTypeConstraints->validators = $validatorConfiguration;
         $spiFieldDefinition->fieldTypeConstraints->fieldSettings = $fieldSettings;
+        $defaultValue = $fieldDefinitionUpdateStruct->defaultValue ?? $fieldDefinition->defaultValue;
         $spiFieldDefinition->defaultValue = $fieldType->toPersistenceValue(
-            $fieldType->acceptValue($fieldDefinitionUpdateStruct->defaultValue)
+            $fieldType->acceptValue($defaultValue)
         );
 
         return $spiFieldDefinition;

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -2464,6 +2464,31 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         self::assertSame(100, $updatedFieldDefinition->position);
     }
 
+    public function testUpdateFieldDefinitionClearsDefaultValueWhenExplicitlySetToEmptyValue(): void
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $fieldCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct('my_name', 'ezstring');
+        $fieldCreateStruct->defaultValue = 'Foo';
+
+        $contentTypeDraft = $this->createContentTypeDraft([$fieldCreateStruct]);
+        $fieldDefinition = $contentTypeDraft->getFieldDefinition('my_name');
+
+        self::assertNotNull($fieldDefinition);
+        self::assertEquals(new TextLineValue('Foo'), $fieldDefinition->defaultValue);
+
+        $updateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
+        $updateStruct->defaultValue = '';
+
+        $contentTypeService->updateFieldDefinition($contentTypeDraft, $fieldDefinition, $updateStruct);
+        $contentTypeDraft = $contentTypeService->loadContentTypeDraft($contentTypeDraft->id);
+        $updatedFieldDefinition = $contentTypeDraft->getFieldDefinition('my_name');
+
+        self::assertNotNull($updatedFieldDefinition);
+        self::assertEquals(new TextLineValue(''), $updatedFieldDefinition->defaultValue);
+    }
+
     /**
      * Test for the updateFieldDefinition() method with already defined field identifier.
      *

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -2440,6 +2440,29 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         );
     }
 
+    public function testUpdateFieldDefinitionPreservesDefaultValueWhenNotInUpdateStruct(): void
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $contentTypeDraft = $this->createContentTypeDraft();
+        $fieldDefinition = $contentTypeDraft->getFieldDefinition('body');
+
+        self::assertNotNull($fieldDefinition);
+        self::assertNotNull($fieldDefinition->defaultValue);
+
+        $updateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
+        $updateStruct->position = 100;
+
+        $contentTypeService->updateFieldDefinition($contentTypeDraft, $fieldDefinition, $updateStruct);
+        $contentTypeDraft = $contentTypeService->loadContentTypeDraft($contentTypeDraft->id);
+        $updatedFieldDefinition = $contentTypeDraft->getFieldDefinition('body');
+
+        self::assertNotNull($updatedFieldDefinition);
+        self::assertEquals($fieldDefinition->defaultValue, $updatedFieldDefinition->defaultValue);
+        self::assertSame(100, $updatedFieldDefinition->position);
+    }
+
     /**
      * Test for the updateFieldDefinition() method with already defined field identifier.
      *

--- a/tests/integration/Core/Repository/ContentTypeServiceTest.php
+++ b/tests/integration/Core/Repository/ContentTypeServiceTest.php
@@ -2450,6 +2450,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
         self::assertNotNull($fieldDefinition);
         self::assertNotNull($fieldDefinition->defaultValue);
+        self::assertSame(2, $fieldDefinition->position);
 
         $updateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
         $updateStruct->position = 100;

--- a/tests/lib/Repository/Mapper/ContentTypeDomainMapperTest.php
+++ b/tests/lib/Repository/Mapper/ContentTypeDomainMapperTest.php
@@ -60,11 +60,13 @@ final class ContentTypeDomainMapperTest extends TestCase
         self::assertSame(100, $spiFieldDefinition->position);
     }
 
-    public function testBuildSPIFieldDefinitionFromUpdateStructOverridesDefaultValueWhenExplicitlySet(): void
-    {
-        $newDefaultValue = new TextLineValue('Bar');
-        $persistedValue = new FieldValue(['data' => 'Bar']);
-
+    /**
+     * @dataProvider provideExplicitDefaultValues
+     */
+    public function testBuildSPIFieldDefinitionFromUpdateStructOverridesDefaultValueWhenExplicitlySet(
+        TextLineValue $newDefaultValue,
+        FieldValue $persistedValue
+    ): void {
         $this->configureFieldTypeRegistry($newDefaultValue, $persistedValue);
 
         $updateStruct = new FieldDefinitionUpdateStruct();
@@ -77,6 +79,22 @@ final class ContentTypeDomainMapperTest extends TestCase
         );
 
         self::assertSame($persistedValue, $spiFieldDefinition->defaultValue);
+    }
+
+    /**
+     * @return iterable<string, array{TextLineValue, FieldValue}>
+     */
+    public function provideExplicitDefaultValues(): iterable
+    {
+        yield 'new non-empty value overrides the existing default value' => [
+            new TextLineValue('Bar'),
+            new FieldValue(['data' => 'Bar']),
+        ];
+
+        yield 'empty value clears the existing default value' => [
+            new TextLineValue(''),
+            new FieldValue(['data' => '']),
+        ];
     }
 
     private function buildFieldDefinition(TextLineValue $defaultValue): FieldDefinition

--- a/tests/lib/Repository/Mapper/ContentTypeDomainMapperTest.php
+++ b/tests/lib/Repository/Mapper/ContentTypeDomainMapperTest.php
@@ -101,8 +101,16 @@ final class ContentTypeDomainMapperTest extends TestCase
         $fieldType->method('validateValidatorConfiguration')->willReturn([]);
         $fieldType->method('validateFieldSettings')->willReturn([]);
         $fieldType->method('isSearchable')->willReturn(true);
-        $fieldType->expects(self::once())->method('acceptValue')->with($expectedInput)->willReturn($expectedInput);
-        $fieldType->expects(self::once())->method('toPersistenceValue')->with($expectedInput)->willReturn($persistedValue);
+        $fieldType
+            ->expects(self::once())
+            ->method('acceptValue')
+            ->with($expectedInput)
+            ->willReturn($expectedInput);
+        $fieldType
+            ->expects(self::once())
+            ->method('toPersistenceValue')
+            ->with($expectedInput)
+            ->willReturn($persistedValue);
 
         $this->fieldTypeRegistry->method('getFieldType')->with('ezstring')->willReturn($fieldType);
     }

--- a/tests/lib/Repository/Mapper/ContentTypeDomainMapperTest.php
+++ b/tests/lib/Repository/Mapper/ContentTypeDomainMapperTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository\Mapper;
+
+use Ibexa\Contracts\Core\FieldType\FieldType as FieldTypeInterface;
+use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
+use Ibexa\Contracts\Core\Persistence\Content\Language\Handler as SPILanguageHandler;
+use Ibexa\Contracts\Core\Persistence\Content\Type\Handler as SPITypeHandler;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
+use Ibexa\Core\FieldType\FieldTypeRegistry;
+use Ibexa\Core\FieldType\TextLine\Value as TextLineValue;
+use Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper;
+use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Ibexa\Core\Repository\Mapper\ContentTypeDomainMapper
+ */
+final class ContentTypeDomainMapperTest extends TestCase
+{
+    private ContentTypeDomainMapper $mapper;
+
+    /** @var \Ibexa\Core\FieldType\FieldTypeRegistry&\PHPUnit\Framework\MockObject\MockObject */
+    private FieldTypeRegistry $fieldTypeRegistry;
+
+    protected function setUp(): void
+    {
+        $this->fieldTypeRegistry = $this->createMock(FieldTypeRegistry::class);
+
+        $this->mapper = new ContentTypeDomainMapper(
+            $this->createMock(SPITypeHandler::class),
+            $this->createMock(SPILanguageHandler::class),
+            $this->fieldTypeRegistry,
+        );
+    }
+
+    public function testBuildSPIFieldDefinitionFromUpdateStructPreservesDefaultValueWhenNotSet(): void
+    {
+        $existingDefaultValue = new TextLineValue('Foo');
+        $persistedValue = new FieldValue(['data' => 'Foo']);
+
+        $this->configureFieldTypeRegistry($existingDefaultValue, $persistedValue);
+
+        $updateStruct = new FieldDefinitionUpdateStruct();
+        $updateStruct->position = 100;
+
+        $spiFieldDefinition = $this->mapper->buildSPIFieldDefinitionFromUpdateStruct(
+            $updateStruct,
+            $this->buildFieldDefinition($existingDefaultValue),
+            'eng-GB'
+        );
+
+        self::assertSame($persistedValue, $spiFieldDefinition->defaultValue);
+        self::assertSame(100, $spiFieldDefinition->position);
+    }
+
+    public function testBuildSPIFieldDefinitionFromUpdateStructOverridesDefaultValueWhenExplicitlySet(): void
+    {
+        $newDefaultValue = new TextLineValue('Bar');
+        $persistedValue = new FieldValue(['data' => 'Bar']);
+
+        $this->configureFieldTypeRegistry($newDefaultValue, $persistedValue);
+
+        $updateStruct = new FieldDefinitionUpdateStruct();
+        $updateStruct->defaultValue = $newDefaultValue;
+
+        $spiFieldDefinition = $this->mapper->buildSPIFieldDefinitionFromUpdateStruct(
+            $updateStruct,
+            $this->buildFieldDefinition(new TextLineValue('Foo')),
+            'eng-GB'
+        );
+
+        self::assertSame($persistedValue, $spiFieldDefinition->defaultValue);
+    }
+
+    private function buildFieldDefinition(TextLineValue $defaultValue): FieldDefinition
+    {
+        return new FieldDefinition([
+            'id' => 1,
+            'identifier' => 'my_name',
+            'fieldTypeIdentifier' => 'ezstring',
+            'defaultValue' => $defaultValue,
+            'isTranslatable' => false,
+            'isRequired' => false,
+            'isInfoCollector' => false,
+            'isThumbnail' => false,
+            'isSearchable' => true,
+            'position' => 1,
+        ]);
+    }
+
+    private function configureFieldTypeRegistry(TextLineValue $expectedInput, FieldValue $persistedValue): void
+    {
+        $fieldType = $this->createMock(FieldTypeInterface::class);
+        $fieldType->method('validateValidatorConfiguration')->willReturn([]);
+        $fieldType->method('validateFieldSettings')->willReturn([]);
+        $fieldType->method('isSearchable')->willReturn(true);
+        $fieldType->expects(self::once())->method('acceptValue')->with($expectedInput)->willReturn($expectedInput);
+        $fieldType->expects(self::once())->method('toPersistenceValue')->with($expectedInput)->willReturn($persistedValue);
+
+        $this->fieldTypeRegistry->method('getFieldType')->with('ezstring')->willReturn($fieldType);
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-11687 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This is a fix to prevent `ContentTypeDomainMapper` from unsetting the default field value when updating content type through API. This happens when the default value is not provided during the update.

Added test coverage for this case as well.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
