### PR TITLE
IBX-11681: Added filename validation in DownloadController and corresponding tests

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -181,12 +181,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Matcher/ContentBased/UrlAlias.php
 
 		-
-			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\DateAndTimeConverter\:\:getDateIntervalFromXML\(\) should return DateInterval but returns DateInterval\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
-
-		-
 			message: '#^Cannot access property \$ownerDocument on DOMElement\|false\.$#'
 			identifier: property.nonObject
 			count: 2

--- a/phpstan-baseline-lte-8.1.neon
+++ b/phpstan-baseline-lte-8.1.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\DateAndTimeConverter\:\:getDateIntervalFromXML\(\) should return DateInterval but returns DateInterval\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+
+		-
 			message: "#^Class SensitiveParameterValue not found\\.$#"
 			count: 1
 			path: tests/lib/Repository/User/PasswordHashServiceTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -69662,6 +69662,12 @@ parameters:
 			path: tests/lib/Repository/Service/Mock/ContentTest.php
 
 		-
+			message: '#^Call to new Ibexa\\Core\\Repository\\ContentService\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/lib/Repository/Service/Mock/ContentTest.php
+
+		-
 			message: '#^Method Ibexa\\Tests\\Core\\Repository\\Service\\Mock\\ContentTest\:\:assertForCreateContentContentValidationException\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/lib/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/DownloadController.php
@@ -8,15 +8,17 @@ namespace Ibexa\Core\MVC\Symfony\Controller\Content;
 
 use Ibexa\Bundle\IO\BinaryStreamResponse;
 use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException as RepositoryNotFoundException;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
-use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Helper\TranslationHelper;
 use Ibexa\Core\IO\IOServiceInterface;
 use Ibexa\Core\MVC\Symfony\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 class DownloadController extends Controller
 {
@@ -48,15 +50,15 @@ class DownloadController extends Controller
         $versionNo = $request->query->has('version') ? $request->query->getInt('version') : null;
         $language = $request->query->has('inLanguage') ? $request->query->get('inLanguage') : null;
 
-        $content = $this->contentService->loadContent(
-            $contentId,
-            $language !== null ? [$language] : null,
-            $versionNo,
-        );
         try {
+            $content = $this->contentService->loadContent(
+                $contentId,
+                $language !== null ? [$language] : null,
+                $versionNo,
+            );
             $field = $this->findFieldInContent($fieldId, $content);
-        } catch (InvalidArgumentException $e) {
-            throw new NotFoundException('File', $fieldId);
+        } catch (RepositoryNotFoundException | InvalidArgumentException $e) {
+            throw $this->createFileNotFoundException($e);
         }
 
         return $this->downloadBinaryFileAction($contentId, $field->fieldDefIdentifier, $field->value->fileName, $request);
@@ -90,18 +92,22 @@ class DownloadController extends Controller
      */
     public function downloadBinaryFileAction(int $contentId, string $fieldIdentifier, string $filename, Request $request): BinaryStreamResponse
     {
-        if ($request->query->has('version')) {
-            $version = (int) $request->query->get('version');
-            if ($version <= 0) {
-                throw new NotFoundException('File', $filename);
+        try {
+            if ($request->query->has('version')) {
+                $version = (int) $request->query->get('version');
+                if ($version <= 0) {
+                    throw $this->createFileNotFoundException();
+                }
+                $content = $this->contentService->loadContent($contentId, null, $version);
+            } else {
+                $content = $this->contentService->loadContent($contentId);
             }
-            $content = $this->contentService->loadContent($contentId, null, $version);
-        } else {
-            $content = $this->contentService->loadContent($contentId);
+        } catch (RepositoryNotFoundException $e) {
+            throw $this->createFileNotFoundException($e);
         }
 
         if ($content->contentInfo->isTrashed()) {
-            throw new NotFoundException('File', $filename);
+            throw $this->createFileNotFoundException();
         }
 
         $field = $this->translationHelper->getTranslatedField(
@@ -110,14 +116,11 @@ class DownloadController extends Controller
             $request->query->has('inLanguage') ? $request->query->get('inLanguage') : null
         );
         if (!$field instanceof Field) {
-            throw new InvalidArgumentException(
-                '$fieldIdentifier',
-                "'{$fieldIdentifier}' field not present on content #{$content->contentInfo->id} '{$content->contentInfo->name}'"
-            );
+            throw $this->createFileNotFoundException();
         }
 
         if ($field->value->fileName !== $filename) {
-            throw new NotFoundException('File', $filename);
+            throw $this->createFileNotFoundException();
         }
 
         $response = new BinaryStreamResponse($this->ioService->loadBinaryFile($field->value->id), $this->ioService);
@@ -128,6 +131,11 @@ class DownloadController extends Controller
         );
 
         return $response;
+    }
+
+    private function createFileNotFoundException(?Throwable $previous = null): NotFoundHttpException
+    {
+        return new NotFoundHttpException('File not found', $previous);
     }
 }
 

--- a/src/lib/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/DownloadController.php
@@ -116,6 +116,10 @@ class DownloadController extends Controller
             );
         }
 
+        if ($field->value->fileName !== $filename) {
+            throw new NotFoundException('File', $filename);
+        }
+
         $response = new BinaryStreamResponse($this->ioService->loadBinaryFile($field->value->id), $this->ioService);
         $response->setContentDisposition(
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,

--- a/tests/integration/Core/MVC/Symfony/Controller/Content/DownloadControllerRequestFlowTest.php
+++ b/tests/integration/Core/MVC/Symfony/Controller/Content/DownloadControllerRequestFlowTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\MVC\Symfony\Controller\Content;
+
+use DateTime;
+use Ibexa\Bundle\IO\BinaryStreamResponse;
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Contracts\Core\Test\IbexaKernelTestCase;
+use Ibexa\Core\FieldType\BinaryFile\Value as BinaryFileValue;
+use Ibexa\Core\Helper\TranslationHelper;
+use Ibexa\Core\IO\IOServiceInterface;
+use Ibexa\Core\IO\Values\BinaryFile;
+use Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController;
+use Ibexa\Core\Repository\Values\Content\Content;
+use Ibexa\Core\Repository\Values\Content\VersionInfo;
+use Ibexa\Tests\Integration\Core\MVC\Symfony\InternalRoutingTestKernel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\EventListener\RouterListener;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @group integration
+ *
+ * @covers \Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController
+ */
+final class DownloadControllerRequestFlowTest extends IbexaKernelTestCase
+{
+    private const FILENAME = 'Q1 report #1 + 100%.jpg';
+
+    /** @var \Ibexa\Contracts\Core\Repository\ContentService&\PHPUnit\Framework\MockObject\MockObject */
+    private $contentService;
+
+    /** @var \Ibexa\Core\IO\IOServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $ioService;
+
+    /** @var \Ibexa\Core\Helper\TranslationHelper&\PHPUnit\Framework\MockObject\MockObject */
+    private $translationHelper;
+
+    protected static function getKernelClass(): string
+    {
+        return InternalRoutingTestKernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->ioService = $this->createMock(IOServiceInterface::class);
+        $this->translationHelper = $this->createMock(TranslationHelper::class);
+    }
+
+    public function testDownloadsFileWithUrlEncodedFilename(): void
+    {
+        $routes = $this->createRouteCollection();
+        $context = new RequestContext();
+        $url = (new UrlGenerator($routes, $context))->generate(
+            'ibexa.content.download',
+            [
+                'contentId' => 42,
+                'fieldIdentifier' => 'file',
+                'filename' => self::FILENAME,
+                'inLanguage' => 'eng-GB',
+            ]
+        );
+
+        self::assertStringContainsString('Q1%20report%20%231%20+%20100%25.jpg', $url);
+
+        $content = $this->createContent();
+        $field = $content->getField('file', 'eng-GB');
+        self::assertInstanceOf(Field::class, $field);
+
+        $binaryFile = new BinaryFile([
+            'id' => 'binary-file-id',
+            'mtime' => new DateTime(),
+            'size' => 123,
+            'uri' => 'binary-file-uri',
+        ]);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with(42)
+            ->willReturn($content);
+        $this->translationHelper
+            ->expects($this->once())
+            ->method('getTranslatedField')
+            ->with($content, 'file', 'eng-GB')
+            ->willReturn($field);
+        $this->ioService
+            ->expects($this->once())
+            ->method('loadBinaryFile')
+            ->with('binary-file-id')
+            ->willReturn($binaryFile);
+
+        $this->configureDownloadController($routes);
+
+        $response = $this->createHttpKernel($routes, $context)->handle(
+            Request::create($url),
+            HttpKernelInterface::MAIN_REQUEST,
+            false
+        );
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertInstanceOf(BinaryStreamResponse::class, $response);
+    }
+
+    private function configureDownloadController(RouteCollection $routes): void
+    {
+        $route = $routes->get('ibexa.content.download');
+        self::assertNotNull($route);
+        $route->setDefault('_controller', [$this->createController(), 'downloadBinaryFileAction']);
+    }
+
+    private function createController(): DownloadController
+    {
+        return new DownloadController(
+            $this->contentService,
+            $this->ioService,
+            $this->translationHelper
+        );
+    }
+
+    private function createHttpKernel(RouteCollection $routes, RequestContext $context): HttpKernel
+    {
+        $requestStack = new RequestStack();
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new RouterListener(
+            new UrlMatcher($routes, $context),
+            $requestStack,
+            $context
+        ));
+
+        $controllerResolver = self::getContainer()->get('controller_resolver');
+        self::assertInstanceOf(ControllerResolverInterface::class, $controllerResolver);
+
+        return new HttpKernel($dispatcher, $controllerResolver, $requestStack, new ArgumentResolver());
+    }
+
+    private function createRouteCollection(): RouteCollection
+    {
+        $routes = new RouteCollection();
+        $routes->add('ibexa.content.download', new Route(
+            '/content/download/{contentId}/{fieldIdentifier}/{filename}',
+            [],
+            ['contentId' => '\d+']
+        ));
+
+        return $routes;
+    }
+
+    private function createContent(): Content
+    {
+        return new Content([
+            'internalFields' => [
+                new Field([
+                    'fieldDefIdentifier' => 'file',
+                    'languageCode' => 'eng-GB',
+                    'value' => new BinaryFileValue([
+                        'id' => 'binary-file-id',
+                        'fileName' => self::FILENAME,
+                    ]),
+                ]),
+            ],
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo([
+                    'id' => 42,
+                    'mainLanguageCode' => 'eng-GB',
+                    'name' => 'Test content',
+                    'status' => ContentInfo::STATUS_PUBLISHED,
+                ]),
+            ]),
+        ]);
+    }
+}

--- a/tests/integration/Core/MVC/Symfony/Controller/Content/DownloadControllerRequestFlowTest.php
+++ b/tests/integration/Core/MVC/Symfony/Controller/Content/DownloadControllerRequestFlowTest.php
@@ -47,13 +47,13 @@ final class DownloadControllerRequestFlowTest extends IbexaKernelTestCase
     private const FILENAME = 'Q1 report #1 + 100%.jpg';
 
     /** @var \Ibexa\Contracts\Core\Repository\ContentService&\PHPUnit\Framework\MockObject\MockObject */
-    private $contentService;
+    private ContentService $contentService;
 
     /** @var \Ibexa\Core\IO\IOServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private $ioService;
+    private IOServiceInterface $ioService;
 
     /** @var \Ibexa\Core\Helper\TranslationHelper&\PHPUnit\Framework\MockObject\MockObject */
-    private $translationHelper;
+    private TranslationHelper $translationHelper;
 
     protected static function getKernelClass(): string
     {
@@ -99,17 +99,17 @@ final class DownloadControllerRequestFlowTest extends IbexaKernelTestCase
         ]);
 
         $this->contentService
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('loadContent')
             ->with(42)
             ->willReturn($content);
         $this->translationHelper
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslatedField')
             ->with($content, 'file', 'eng-GB')
             ->willReturn($field);
         $this->ioService
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('loadBinaryFile')
             ->with('binary-file-id')
             ->willReturn($binaryFile);
@@ -155,7 +155,12 @@ final class DownloadControllerRequestFlowTest extends IbexaKernelTestCase
         $controllerResolver = self::getContainer()->get('controller_resolver');
         self::assertInstanceOf(ControllerResolverInterface::class, $controllerResolver);
 
-        return new HttpKernel($dispatcher, $controllerResolver, $requestStack, new ArgumentResolver());
+        return new HttpKernel(
+            $dispatcher,
+            $controllerResolver,
+            $requestStack,
+            new ArgumentResolver()
+        );
     }
 
     private function createRouteCollection(): RouteCollection

--- a/tests/integration/Core/MVC/Symfony/InternalRoutingTestKernel.php
+++ b/tests/integration/Core/MVC/Symfony/InternalRoutingTestKernel.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\MVC\Symfony;
+
+use Ibexa\Contracts\Core\Test\IbexaTestKernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class InternalRoutingTestKernel extends IbexaTestKernel
+{
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        parent::registerContainerConfiguration($loader);
+
+        $loader->load(static function (ContainerBuilder $container): void {
+            self::loadRouting($container);
+        });
+    }
+
+    private static function loadRouting(ContainerBuilder $container): void
+    {
+        $container->loadFromExtension('framework', [
+            'router' => [
+                'resource' => '@IbexaCoreBundle/Resources/config/routing/internal.yml',
+            ],
+        ]);
+    }
+}

--- a/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
+++ b/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Tests\Core\MVC\Symfony\Controller\Controller\Content;
 
 use DateTime;
@@ -26,13 +28,13 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class DownloadControllerTest extends TestCase
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Contracts\Core\Repository\ContentService&\PHPUnit\Framework\MockObject\MockObject */
     private $contentService;
 
-    /** @var \Ibexa\Core\IO\IOServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Core\IO\IOServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
     private $ioService;
 
-    /** @var \Ibexa\Core\Helper\TranslationHelper|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Core\Helper\TranslationHelper&\PHPUnit\Framework\MockObject\MockObject */
     private $translationHelper;
 
     protected function setUp(): void

--- a/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
+++ b/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Tests\Core\MVC\Symfony\Controller\Controller\Content;
+
+use DateTime;
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
+use Ibexa\Core\Base\Exceptions\NotFoundException;
+use Ibexa\Core\FieldType\BinaryFile\Value as BinaryFileValue;
+use Ibexa\Core\Helper\TranslationHelper;
+use Ibexa\Core\IO\IOServiceInterface;
+use Ibexa\Core\IO\Values\BinaryFile;
+use Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController;
+use Ibexa\Core\Repository\Values\Content\Content;
+use Ibexa\Core\Repository\Values\Content\VersionInfo;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController
+ */
+final class DownloadControllerTest extends TestCase
+{
+    /** @var \Ibexa\Contracts\Core\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentService;
+
+    /** @var \Ibexa\Core\IO\IOServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $ioService;
+
+    /** @var \Ibexa\Core\Helper\TranslationHelper|\PHPUnit\Framework\MockObject\MockObject */
+    private $translationHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->ioService = $this->createMock(IOServiceInterface::class);
+        $this->translationHelper = $this->createMock(TranslationHelper::class);
+    }
+
+    public function testDownloadBinaryFileActionReturnsBinaryResponseWhenFilenameMatches(): void
+    {
+        $content = $this->createContent();
+        $field = $content->getField('file', 'eng-GB');
+        self::assertInstanceOf(Field::class, $field);
+
+        $request = new Request(['inLanguage' => 'eng-GB']);
+        $binaryFile = new BinaryFile([
+            'id' => 'binary-file-id',
+            'mtime' => new DateTime(),
+            'size' => 123,
+            'uri' => 'binary-file-uri',
+        ]);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with(42)
+            ->willReturn($content);
+        $this->translationHelper
+            ->expects($this->once())
+            ->method('getTranslatedField')
+            ->with($content, 'file', 'eng-GB')
+            ->willReturn($field);
+        $this->ioService
+            ->expects($this->once())
+            ->method('loadBinaryFile')
+            ->with('binary-file-id')
+            ->willReturn($binaryFile);
+
+        $response = $this->createController()->downloadBinaryFileAction(42, 'file', 'Test-file.pdf', $request);
+
+        self::assertStringContainsString('attachment;', (string) $response->headers->get('Content-Disposition'));
+        self::assertStringContainsString('Test-file.pdf', (string) $response->headers->get('Content-Disposition'));
+    }
+
+    public function testDownloadBinaryFileActionReturnsNotFoundWhenFilenameDoesNotMatch(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        $content = $this->createContent();
+        $field = $content->getField('file', 'eng-GB');
+        self::assertInstanceOf(Field::class, $field);
+
+        $request = new Request(['inLanguage' => 'eng-GB']);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContent')
+            ->with(42)
+            ->willReturn($content);
+        $this->translationHelper
+            ->expects($this->once())
+            ->method('getTranslatedField')
+            ->with($content, 'file', 'eng-GB')
+            ->willReturn($field);
+        $this->ioService
+            ->expects($this->never())
+            ->method('loadBinaryFile');
+
+        $this->createController()->downloadBinaryFileAction(42, 'file', 'SomeRandomText.txt', $request);
+    }
+
+    private function createController(): DownloadController
+    {
+        return new DownloadController(
+            $this->contentService,
+            $this->ioService,
+            $this->translationHelper
+        );
+    }
+
+    private function createContent(): Content
+    {
+        return new Content([
+            'internalFields' => [
+                new Field([
+                    'fieldDefIdentifier' => 'file',
+                    'languageCode' => 'eng-GB',
+                    'value' => new BinaryFileValue([
+                        'id' => 'binary-file-id',
+                        'fileName' => 'Test-file.pdf',
+                    ]),
+                ]),
+            ],
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo([
+                    'id' => 42,
+                    'mainLanguageCode' => 'eng-GB',
+                    'name' => 'Test content',
+                    'status' => ContentInfo::STATUS_PUBLISHED,
+                ]),
+            ]),
+        ]);
+    }
+}

--- a/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
+++ b/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
@@ -29,13 +29,13 @@ use Symfony\Component\HttpFoundation\Request;
 final class DownloadControllerTest extends TestCase
 {
     /** @var \Ibexa\Contracts\Core\Repository\ContentService&\PHPUnit\Framework\MockObject\MockObject */
-    private $contentService;
+    private ContentService $contentService;
 
     /** @var \Ibexa\Core\IO\IOServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private $ioService;
+    private IOServiceInterface $ioService;
 
     /** @var \Ibexa\Core\Helper\TranslationHelper&\PHPUnit\Framework\MockObject\MockObject */
-    private $translationHelper;
+    private TranslationHelper $translationHelper;
 
     protected function setUp(): void
     {
@@ -61,17 +61,17 @@ final class DownloadControllerTest extends TestCase
         ]);
 
         $this->contentService
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('loadContent')
             ->with(42)
             ->willReturn($content);
         $this->translationHelper
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslatedField')
             ->with($content, 'file', 'eng-GB')
             ->willReturn($field);
         $this->ioService
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('loadBinaryFile')
             ->with('binary-file-id')
             ->willReturn($binaryFile);
@@ -84,8 +84,6 @@ final class DownloadControllerTest extends TestCase
 
     public function testDownloadBinaryFileActionReturnsNotFoundWhenFilenameDoesNotMatch(): void
     {
-        $this->expectException(NotFoundException::class);
-
         $content = $this->createContent();
         $field = $content->getField('file', 'eng-GB');
         self::assertInstanceOf(Field::class, $field);
@@ -93,12 +91,12 @@ final class DownloadControllerTest extends TestCase
         $request = new Request(['inLanguage' => 'eng-GB']);
 
         $this->contentService
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('loadContent')
             ->with(42)
             ->willReturn($content);
         $this->translationHelper
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getTranslatedField')
             ->with($content, 'file', 'eng-GB')
             ->willReturn($field);
@@ -106,6 +104,7 @@ final class DownloadControllerTest extends TestCase
             ->expects($this->never())
             ->method('loadBinaryFile');
 
+        $this->expectException(NotFoundException::class);
         $this->createController()->downloadBinaryFileAction(42, 'file', 'SomeRandomText.txt', $request);
     }
 

--- a/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
+++ b/tests/lib/MVC/Symfony/Controller/Controller/Content/DownloadControllerTest.php
@@ -12,7 +12,7 @@ use DateTime;
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
-use Ibexa\Core\Base\Exceptions\NotFoundException;
+use Ibexa\Core\Base\Exceptions\NotFoundException as BaseNotFoundException;
 use Ibexa\Core\FieldType\BinaryFile\Value as BinaryFileValue;
 use Ibexa\Core\Helper\TranslationHelper;
 use Ibexa\Core\IO\IOServiceInterface;
@@ -22,6 +22,7 @@ use Ibexa\Core\Repository\Values\Content\Content;
 use Ibexa\Core\Repository\Values\Content\VersionInfo;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @covers \Ibexa\Core\MVC\Symfony\Controller\Content\DownloadController
@@ -104,8 +105,76 @@ final class DownloadControllerTest extends TestCase
             ->expects($this->never())
             ->method('loadBinaryFile');
 
-        $this->expectException(NotFoundException::class);
-        $this->createController()->downloadBinaryFileAction(42, 'file', 'SomeRandomText.txt', $request);
+        $this->assertFileNotFound(function () use ($request): void {
+            $this->createController()->downloadBinaryFileAction(42, 'file', 'SomeRandomText.txt', $request);
+        });
+    }
+
+    public function testDownloadBinaryFileActionReturnsNotFoundWhenFieldIdentifierDoesNotMatch(): void
+    {
+        $content = $this->createContent(393, 'New file');
+        $request = new Request(['inLanguage' => 'eng-GB']);
+
+        $this->contentService
+            ->expects(self::once())
+            ->method('loadContent')
+            ->with(393)
+            ->willReturn($content);
+        $this->translationHelper
+            ->expects(self::once())
+            ->method('getTranslatedField')
+            ->with($content, 'file5', 'eng-GB')
+            ->willReturn(null);
+        $this->ioService
+            ->expects($this->never())
+            ->method('loadBinaryFile');
+
+        $this->assertFileNotFound(function () use ($request): void {
+            $this->createController()->downloadBinaryFileAction(393, 'file5', 'snorelax_snooze.png', $request);
+        });
+    }
+
+    public function testDownloadBinaryFileActionReturnsNotFoundWhenContentDoesNotExist(): void
+    {
+        $request = new Request(['inLanguage' => 'eng-GB']);
+
+        $this->contentService
+            ->expects(self::once())
+            ->method('loadContent')
+            ->with(393)
+            ->willThrowException(new BaseNotFoundException('Content', 393));
+        $this->translationHelper
+            ->expects($this->never())
+            ->method('getTranslatedField');
+        $this->ioService
+            ->expects($this->never())
+            ->method('loadBinaryFile');
+
+        $this->assertFileNotFound(function () use ($request): void {
+            $this->createController()->downloadBinaryFileAction(393, 'file', 'snorelax_snooze.png', $request);
+        });
+    }
+
+    public function testDownloadBinaryFileByIdActionReturnsNotFoundWhenFieldIdDoesNotMatch(): void
+    {
+        $content = $this->createContent();
+        $request = new Request();
+
+        $this->contentService
+            ->expects(self::once())
+            ->method('loadContent')
+            ->with(42, null, null)
+            ->willReturn($content);
+        $this->translationHelper
+            ->expects($this->never())
+            ->method('getTranslatedField');
+        $this->ioService
+            ->expects($this->never())
+            ->method('loadBinaryFile');
+
+        $this->assertFileNotFound(function () use ($request): void {
+            $this->createController()->downloadBinaryFileByIdAction($request, 42, 123);
+        });
     }
 
     private function createController(): DownloadController
@@ -117,11 +186,22 @@ final class DownloadControllerTest extends TestCase
         );
     }
 
-    private function createContent(): Content
+    private function assertFileNotFound(callable $callback): void
+    {
+        try {
+            $callback();
+            self::fail(sprintf('Expected %s to be thrown.', NotFoundHttpException::class));
+        } catch (NotFoundHttpException $e) {
+            self::assertSame('File not found', $e->getMessage());
+        }
+    }
+
+    private function createContent(int $contentId = 42, string $contentName = 'Test content'): Content
     {
         return new Content([
             'internalFields' => [
                 new Field([
+                    'id' => 7,
                     'fieldDefIdentifier' => 'file',
                     'languageCode' => 'eng-GB',
                     'value' => new BinaryFileValue([
@@ -132,9 +212,9 @@ final class DownloadControllerTest extends TestCase
             ],
             'versionInfo' => new VersionInfo([
                 'contentInfo' => new ContentInfo([
-                    'id' => 42,
+                    'id' => $contentId,
                     'mainLanguageCode' => 'eng-GB',
-                    'name' => 'Test content',
+                    'name' => $contentName,
                     'status' => ContentInfo::STATUS_PUBLISHED,
                 ]),
             ]),

--- a/tests/lib/Repository/Service/Mock/ContentTest.php
+++ b/tests/lib/Repository/Service/Mock/ContentTest.php
@@ -89,7 +89,6 @@ class ContentTest extends BaseServiceMockTest
             'remove_archived_versions_on_publish' => true,
         ];
 
-        /** @phpstan-ignore new.resultUnused */
         new ContentService(
             $repositoryMock,
             $persistenceHandlerMock,


### PR DESCRIPTION
| :ticket: Issue | IBX-11681 |
|----------------|-----------|


#### Description:
Added filename validation to the content download endpoint for binary files.

Previously, `/content/download/{contentId}/{fieldIdentifier}/{filename}` accepted any `filename` value from the URL and still returned the file as long as `contentId` and `fieldIdentifier` matched an accessible field. This made it possible to enumerate downloadable files more easily by guessing content identifiers and reusing common field identifiers such as `file`.

This change makes the download controller verify that the filename provided in the URL matches the actual file name stored in the field value. If it does not match, the controller now returns a generic 404 response before loading the binary file from storage.

The error handling around download validation was also tightened to avoid leaking information about existing content. Invalid field identifiers, invalid filenames, missing content, unavailable versions, trashed content, and repository-level not found cases are now normalized to the same generic "File not found" response. This prevents the endpoint from revealing whether a guessed content ID exists or which part of the download URL was valid.
