### PR TITLE
IBX-11818: Fixed error on empty DateAndTime field with missing timestamp key

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10849,12 +10849,6 @@ parameters:
 			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/CountryConverter.php
 
 		-
-			message: '#^Cannot access offset ''timestamp'' on array\|bool\|float\|int\|string\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
-
-		-
 			message: '#^Method Ibexa\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\DateAndTimeConverter\:\:getDateIntervalFromXML\(\) should return DateInterval but empty return statement found\.$#'
 			identifier: return.empty
 			count: 1

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -30,8 +30,6 @@ class DateAndTimeConverter implements Converter
      */
     public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
     {
-        // @todo: One should additionally store the timezone here. This could
-        // be done in a backwards compatible way, I think…
         $storageFieldValue->dataInt = is_array($value->data) ? ($value->data['timestamp'] ?? null) : null;
         $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -32,7 +32,7 @@ class DateAndTimeConverter implements Converter
     {
         // @todo: One should additionally store the timezone here. This could
         // be done in a backwards compatible way, I think…
-        $storageFieldValue->dataInt = ($value->data['timestamp'] ?? null);
+        $storageFieldValue->dataInt = is_array($value->data) ? ($value->data['timestamp'] ?? null) : null;
         $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -32,7 +32,7 @@ class DateAndTimeConverter implements Converter
     {
         // @todo: One should additionally store the timezone here. This could
         // be done in a backwards compatible way, I think…
-        $storageFieldValue->dataInt = ($value->data !== null ? $value->data['timestamp'] : null);
+        $storageFieldValue->dataInt = ($value->data['timestamp'] ?? null);
         $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -85,33 +85,35 @@ class DateAndTimeTest extends TestCase
     }
 
     /**
-     * @group fieldType
-     * @group dateTime
+     * @return mixed[]
      */
-    public function testToStorageValueNoTimestampKey(): void
+    public function providerForTestToStorageValueMissingData(): array
     {
-        $value = new FieldValue();
-        $value->data = [
-            'current_time' => $this->date->getTimestamp(),
-            'rfc850' => $this->date->format(DateTime::RFC850),
+        return [
+            [
+                [
+                    'current_time' => 1048633200,
+                    'rfc850' => 'Thu, 01 Jan 2003 00:00:00 GMT',
+                ],
+            ],
+            [
+                null,
+            ]
         ];
-        $value->sortKey = $this->date->getTimestamp();
-        $storageFieldValue = new StorageFieldValue();
-
-        $this->converter->toStorageValue($value, $storageFieldValue);
-        self::assertNull($storageFieldValue->dataInt);
-        self::assertSame($value->sortKey, $storageFieldValue->sortKeyInt);
-        self::assertSame('', $storageFieldValue->sortKeyString);
     }
 
     /**
      * @group fieldType
      * @group dateTime
+     *
+     * @dataProvider providerForTestToStorageValueMissingData
+     *
+     * @param mixed[]|null $data
      */
-    public function testToStorageValueValueDataNull(): void
+    public function testToStorageValueNoTimestampKey(?array $data): void
     {
         $value = new FieldValue();
-        $value->data = null;
+        $value->data = $data;
         $value->sortKey = $this->date->getTimestamp();
         $storageFieldValue = new StorageFieldValue();
 

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -90,15 +90,8 @@ class DateAndTimeTest extends TestCase
     public function providerForTestToStorageValueMissingData(): array
     {
         return [
-            [
-                [
-                    'current_time' => 1048633200,
-                    'rfc850' => 'Thu, 01 Jan 2003 00:00:00 GMT',
-                ],
-            ],
-            [
-                null,
-            ]
+            [['current_time' => 1048633200, 'rfc850' => 'Thu, 01 Jan 2003 00:00:00 GMT']],
+            [null],
         ];
     }
 

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -88,6 +88,43 @@ class DateAndTimeTest extends TestCase
      * @group fieldType
      * @group dateTime
      */
+    public function testToStorageValueNoTimestampKey(): void
+    {
+        $value = new FieldValue();
+        $value->data = [
+            'current_time' => $this->date->getTimestamp(),
+            'rfc850' => $this->date->format(DateTime::RFC850),
+        ];
+        $value->sortKey = $this->date->getTimestamp();
+        $storageFieldValue = new StorageFieldValue();
+
+        $this->converter->toStorageValue($value, $storageFieldValue);
+        self::assertNull($storageFieldValue->dataInt);
+        self::assertSame($value->sortKey, $storageFieldValue->sortKeyInt);
+        self::assertSame('', $storageFieldValue->sortKeyString);
+    }
+
+    /**
+     * @group fieldType
+     * @group dateTime
+     */
+    public function testToStorageValueValueDataNull(): void
+    {
+        $value = new FieldValue();
+        $value->data = null;
+        $value->sortKey = $this->date->getTimestamp();
+        $storageFieldValue = new StorageFieldValue();
+
+        $this->converter->toStorageValue($value, $storageFieldValue);
+        self::assertNull($storageFieldValue->dataInt);
+        self::assertSame($value->sortKey, $storageFieldValue->sortKeyInt);
+        self::assertSame('', $storageFieldValue->sortKeyString);
+    }
+
+    /**
+     * @group fieldType
+     * @group dateTime
+     */
     public function testToStorageFieldDefinitionWithAdjustment()
     {
         $storageFieldDef = new StorageFieldDefinition();


### PR DESCRIPTION
| :ticket: Issue | IBX-11818 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
\Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTimeConverter:toStorageValue()
throws an error of a missing array key when the content was created before the field was added to the content type.
Added fallback to null when the data array has no 'timestamp' key


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
