### PR TITLE
NameSchemaService: fix group pattern

### DIFF
--- a/src/lib/Repository/NameSchema/NameSchemaService.php
+++ b/src/lib/Repository/NameSchema/NameSchemaService.php
@@ -245,7 +245,7 @@ class NameSchemaService implements NameSchemaServiceInterface
     protected function filterNameSchema(string $nameSchema): array
     {
         $retNamePattern = $nameSchema;
-        $foundGroups = preg_match_all('/<.*\((.*<.+>.*)\).*>/U', $nameSchema, $groupArray);
+        $foundGroups = preg_match_all('/<[^>]*\((.*<.+>.*)\).*>/U', $nameSchema, $groupArray);
         $groupLookupTable = [];
 
         if ($foundGroups) {

--- a/tests/lib/Repository/NameSchema/NameSchemaServiceTest.php
+++ b/tests/lib/Repository/NameSchema/NameSchemaServiceTest.php
@@ -86,6 +86,10 @@ final class NameSchemaServiceTest extends BaseServiceMockTest
                     'cro-HR' => 'jedan (text)',
                 ],
                 [
+                    'eng-GB' => 'one (two) one',
+                    'cro-HR' => 'jedan (dva) jedan',
+                ],
+                [
                     'eng-GB' => 'one - two',
                     'cro-HR' => 'jedan - dva',
                 ],
@@ -115,6 +119,10 @@ final class NameSchemaServiceTest extends BaseServiceMockTest
                 [
                     'eng-GB' => ' (text)',
                     'cro-HR' => ' (text)',
+                ],
+                [
+                    'eng-GB' => ' (two) ',
+                    'cro-HR' => ' (Dva) ',
                 ],
                 [
                     'eng-GB' => 'three',
@@ -150,6 +158,7 @@ final class NameSchemaServiceTest extends BaseServiceMockTest
         $content = $this->buildTestContentObject();
         $schemas = [
             '<text1> (text)',
+            '<text1> (<text2>) <text1>',
             '<text3|(<text1> - <text2>)>',
             '<text3|(<text1> - <text2>)> (<text2>) <text2> (text2)',
             '<text3|(<text1> - <text2>)> (<text1> - <text2>) <text2>',


### PR DESCRIPTION
| :ticket: Issue | IBX-8897 |
|----------------|-----------|

#### Related PRs: 
- #449

#### Description:

With this fix, parenthesis can be used in name and URL alias patterns.

Before, in `<string1> (<string2>) | <datetime1> - <datetime2>`, the following "group" was found: `<string1> (<string2>) | <datetime1>`, but with this fix, nothing is found.

Pattern: `<string1> (<string2>) | <datetime1> - <datetime2>`
Before: seen as `<string1> (EZMETAGROUP_0) | <datetime1> - <datetime2>` but with no replacement
After: seen as `<string1> (<string2>) | <datetime1> - <datetime2>`

Pattern: `<empty|(<string1> <string2>)> | (<datetime1>)`
Before: seen as `<empty|(EZMETAGROUP_0)> | (<datetime1>)`
After: seen as `<empty|(EZMETAGROUP_0)> | (<datetime1>)` (no change, still as expected)

Before:
<img width="1293" height="133" alt="image" src="https://github.com/user-attachments/assets/d208d5fb-0a74-4f14-af33-ac8ea35798ab" />

After:
<img width="1285" height="127" alt="image" src="https://github.com/user-attachments/assets/bf103444-67ba-4bf7-88cc-68a163eb6bbd" />

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
