### PR TITLE
IBX-11848: Fixed filtering by content types in `ibexa:reindex` command

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9349,7 +9349,7 @@ parameters:
 			path: src/lib/Base/Exceptions/ContentFieldValidationException.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\(Ibexa\\Contracts\\Core\\Repository\\Values\\Translation\|string\)\: string is not subtype of native type Closure\(mixed\)\: string\.$#'
+			message: '#^PHPDoc tag @var with type callable\(Ibexa\\Contracts\\Core\\Repository\\Values\\Translation\|string\)\: string is not subtype of native type static\-Closure\(mixed\)\: string\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: src/lib/Base/Exceptions/ContentFieldValidationException.php

--- a/src/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategy.php
+++ b/src/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategy.php
@@ -11,6 +11,7 @@ namespace Ibexa\Bundle\Core\Command\Indexer\ContentIdList;
 use Generator;
 use Ibexa\Bundle\Core\Command\Indexer\ContentIdListGeneratorStrategyInterface;
 use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentList;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Filter\Filter;
@@ -24,9 +25,12 @@ final class ContentTypeInputGeneratorStrategy implements ContentIdListGeneratorS
 {
     private ContentService $contentService;
 
-    public function __construct(ContentService $contentService)
+    private Repository $repository;
+
+    public function __construct(ContentService $contentService, Repository $repository)
     {
         $this->contentService = $contentService;
+        $this->repository = $repository;
     }
 
     /**
@@ -74,6 +78,8 @@ final class ContentTypeInputGeneratorStrategy implements ContentIdListGeneratorS
             )
         ;
 
-        return $this->contentService->find($filter);
+        return  $this->repository->sudo(
+            fn (): ContentList => $this->contentService->find($filter)
+        );
     }
 }

--- a/tests/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategyTest.php
+++ b/tests/bundle/Core/Command/Indexer/ContentIdList/ContentTypeInputGeneratorStrategyTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Bundle\Core\Command\Indexer\ContentIdList;
 
 use Ibexa\Bundle\Core\Command\Indexer\ContentIdList\ContentTypeInputGeneratorStrategy;
 use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentList;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
@@ -32,10 +33,20 @@ final class ContentTypeInputGeneratorStrategyTest extends TestCase
         $contentServiceMock = $this->createMock(ContentService::class);
         $contentServiceMock->method('find')->willReturn($contentList);
 
+        $repositoryMock = $this->createMock(Repository::class);
+        $repositoryMock
+            ->method('sudo')
+            ->willReturnCallback(
+                static fn (callable $callback) => $callback()
+            );
+
         $inputMock = $this->createMock(InputInterface::class);
         $inputMock->method('getOption')->with('content-type')->willReturn(uniqid('type', true));
 
-        $strategy = new ContentTypeInputGeneratorStrategy($contentServiceMock);
+        $strategy = new ContentTypeInputGeneratorStrategy(
+            $contentServiceMock,
+            $repositoryMock
+        );
 
         self::assertSame(
             $expectedBatches,


### PR DESCRIPTION

| :ticket: Issue | IBX-11848 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
The `--content-type` parameter for `ibexa:reindex` will execute a filter search (`ContentService::find()`), and this only returns content that is available to current user ( script is running as `anonymous` )

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->
Instructions on how to reproduce is provided in ticket description

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
