### PR TITLE
IBX-11951: Deprecated ChainConfigResolver::addResolver() method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -403,32 +403,8 @@ parameters:
 			path: src/bundle/Core/DependencyInjection/Configuration/AbstractParser.php
 
 		-
-			message: '#^Cannot access an offset on array\|Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ChainConfigResolver\:\:addResolver\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
-
-		-
-			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
-
-		-
-			message: '#^Property Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ChainConfigResolver\:\:\$resolvers \(array\<Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface\>\) does not accept array\<Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface\|list\<Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface\>\>\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
-
-		-
-			message: '#^Property Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ChainConfigResolver\:\:\$resolvers \(array\<Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface\>\) does not accept array\<array\|Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface\>\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
 
@@ -19715,96 +19691,6 @@ parameters:
 			identifier: staticMethod.alreadyNarrowedType
 			count: 1
 			path: tests/bundle/Core/ApiLoader/StorageConnectionFactoryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:buildMock\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:buildMock\(\) has parameter \$class with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:buildMock\(\) has parameter \$methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:getParameterProvider\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testGetDefaultNamespace\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testGetParameter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testGetParameterInvalid\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testHasParameterFalse\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testHasParameterTrue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testPriority\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testReSortResolvers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testSetDefaultNamespace\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ChainConfigResolverTest\:\:testSortResolvers\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Parameter \#1 \$resolver of method Ibexa\\Bundle\\Core\\DependencyInjection\\Configuration\\ChainConfigResolver\:\:addResolver\(\) expects Ibexa\\Contracts\\Core\\SiteAccess\\ConfigResolverInterface, PHPUnit\\Framework\\MockObject\\MockObject given\.$#'
-			identifier: argument.type
-			count: 4
-			path: tests/bundle/Core/ChainConfigResolverTest.php
-
-		-
-			message: '#^Unable to resolve the template type T in call to method PHPUnit\\Framework\\TestCase\:\:getMockBuilder\(\)$#'
-			identifier: argument.templateType
-			count: 1
-			path: tests/bundle/Core/ChainConfigResolverTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\ConfigResolverTest\:\:getResolver\(\) has parameter \$groupsBySiteAccess with no value type specified in iterable type array\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19885,18 +19885,6 @@ parameters:
 			path: tests/bundle/Core/ConfigResolverTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\DependencyInjection\\Compiler\\ChainConfigResolverPassTest\:\:addResolverProvider\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\DependencyInjection\\Compiler\\ChainConfigResolverPassTest\:\:testAddResolver\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\Core\\DependencyInjection\\Compiler\\ChainRoutingPassTest\:\:addRouterProvider\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
@@ -12,6 +12,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * @deprecated 5.0.9 "ChainConfigResolverPass" is deprecated. Use service 'ibexa.site.config.resolver' tag instead.
+ */
 class ChainConfigResolverPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
@@ -21,9 +24,10 @@ class ChainConfigResolverPass implements CompilerPassInterface
         }
 
         $chainResolver = $container->getDefinition(ChainConfigResolver::class);
+        $references = [];
 
         foreach ($container->findTaggedServiceIds('ibexa.site.config.resolver') as $id => $attributes) {
-            $priority = isset($attributes[0]['priority']) ? (int)$attributes[0]['priority'] : 0;
+            $priority = (int)($attributes[0]['priority'] ?? 0);
             if ($priority > 255) {
                 $priority = 255;
             }
@@ -31,13 +35,9 @@ class ChainConfigResolverPass implements CompilerPassInterface
                 $priority = -255;
             }
 
-            $chainResolver->addMethodCall(
-                'addResolver',
-                [
-                    new Reference($id),
-                    $priority,
-                ]
-            );
+            $references[$priority] = new Reference($id);
         }
+
+        $chainResolver->setArgument('$resolvers', $references);
     }
 }

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPass.php
@@ -35,7 +35,7 @@ class ChainConfigResolverPass implements CompilerPassInterface
                 $priority = -255;
             }
 
-            $references[$priority] = new Reference($id);
+            $references[$priority][] = new Reference($id);
         }
 
         $chainResolver->setArgument('$resolvers', $references);

--- a/src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
@@ -10,19 +10,44 @@ namespace Ibexa\Bundle\Core\DependencyInjection\Configuration;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
 
+/**
+ * @final "ChainConfigResolver" class will be final in 6.0
+ */
 class ChainConfigResolver implements ConfigResolverInterface
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface[] */
+    /**
+     * @private 5.0.9 "ChainConfigResolver::$resolvers" property will be private in 6.0
+     *
+     * @var array<int, array<\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface>>
+     */
     protected $resolvers = [];
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface[] */
+    /**
+     * @deprecated 5.0.9 "ChainConfigResolver::$sortedResolvers" property is deprecated, will be removed in 6.0
+     *
+     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface[]
+     */
     protected $sortedResolvers;
 
     /**
+     * Note: in 6.0, resolvers will be ordered by priority on injection, using tag with priority.
+     *
+     * @param iterable<int, \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface> $resolvers
+     */
+    public function __construct(
+        iterable $resolvers = [],
+    ) {
+        foreach ($resolvers as $priority => $resolver) {
+            $this->addResolver($resolver, $priority);
+        }
+    }
+
+    /**
+     * @deprecated 5.0.9 The "ChainConfigResolver::addResolver()" method is deprecated, will be removed in 6.0. Use service 'ibexa.site.config.resolver' tag instead.
+     *
      * Registers $mapper as a valid mapper to be used in the configuration mapping chain.
      * When this mapper will be called in the chain depends on $priority. The highest $priority is, the earliest the router will be called.
      *
-     * @param \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface $resolver
      * @param int $priority
      */
     public function addResolver(ConfigResolverInterface $resolver, $priority = 0)
@@ -37,6 +62,8 @@ class ChainConfigResolver implements ConfigResolverInterface
     }
 
     /**
+     * @deprecated 5.0.9 "ChainConfigResolver::getAllResolvers" method is deprecated, will be removed in 6.0.
+     *
      * @return \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface[]
      */
     public function getAllResolvers()
@@ -49,6 +76,8 @@ class ChainConfigResolver implements ConfigResolverInterface
     }
 
     /**
+     * @deprecated 5.0.9 The "ChainConfigResolver::sortResolvers()" method is deprecated, will be removed in 6.0.
+     *
      * Sort the registered mappers by priority.
      * The highest priority number is the highest priority (reverse sorting).
      *

--- a/src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ChainConfigResolver.php
@@ -32,13 +32,15 @@ class ChainConfigResolver implements ConfigResolverInterface
     /**
      * Note: in 6.0, resolvers will be ordered by priority on injection, using tag with priority.
      *
-     * @param iterable<int, \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface> $resolvers
+     * @param iterable<int, array<\Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface>> $resolvers
      */
     public function __construct(
         iterable $resolvers = [],
     ) {
-        foreach ($resolvers as $priority => $resolver) {
-            $this->addResolver($resolver, $priority);
+        foreach ($resolvers as $priority => $priorityResolvers) {
+            foreach ($priorityResolvers as $resolver) {
+                $this->addResolver($resolver, $priority);
+            }
         }
     }
 

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -54,6 +54,10 @@ services:
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ChainConfigResolver:
         public: true # @todo should be private
+        arguments:
+            $resolvers: !abstract configured in Ibexa\Bundle\Core\DependencyInjection\Compiler\ChainConfigResolverPass
+            # in 6.0
+            # $resolvers: !tagged_iterator ibexa.site.config.resolver
 
     ibexa.config.resolver:
         public: true # @todo should be private

--- a/tests/bundle/Core/ChainConfigResolverTest.php
+++ b/tests/bundle/Core/ChainConfigResolverTest.php
@@ -10,26 +10,26 @@ namespace Ibexa\Tests\Bundle\Core;
 use Ibexa\Bundle\Core\DependencyInjection\Configuration\ChainConfigResolver;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Ibexa\Bundle\Core\DependencyInjection\Configuration\ChainConfigResolver
  */
-class ChainConfigResolverTest extends TestCase
+final class ChainConfigResolverTest extends TestCase
 {
-    /** @var \Ibexa\Bundle\Core\DependencyInjection\Configuration\ChainConfigResolver */
-    private $chainResolver;
+    private ChainConfigResolver $chainResolver;
 
     protected function setUp(): void
     {
         $this->chainResolver = new ChainConfigResolver();
     }
 
-    public function testPriority()
+    public function testPriority(): void
     {
         self::assertEquals([], $this->chainResolver->getAllResolvers());
 
-        list($low, $high) = $this->createResolverMocks();
+        [$low, $high] = $this->createResolverMocks();
 
         $this->chainResolver->addResolver($low, 10);
         $this->chainResolver->addResolver($high, 100);
@@ -47,22 +47,15 @@ class ChainConfigResolverTest extends TestCase
      * Resolvers are supposed to be sorted only once.
      * This test will check that by trying to get all resolvers several times.
      */
-    public function testSortResolvers()
+    public function testSortResolvers(): void
     {
-        list($low, $medium, $high) = $this->createResolverMocks();
+        [$low, $medium, $high] = $this->createResolverMocks();
         // We're using a mock here and not $this->chainResolver because we need to ensure that the sorting operation is done only once.
-        $resolver = $this->buildMock(
-            ChainConfigResolver::class,
-            ['sortResolvers']
-        );
+        $resolver = $this->buildMock();
         $resolver
             ->expects(self::once())
             ->method('sortResolvers')
-            ->will(
-                self::returnValue(
-                    [$high, $medium, $low]
-                )
-            );
+            ->willReturn([$high, $medium, $low]);
 
         $resolver->addResolver($low, 10);
         $resolver->addResolver($medium, 50);
@@ -77,32 +70,24 @@ class ChainConfigResolverTest extends TestCase
     /**
      * This test ensures that if a resolver is being added on the fly, the sorting is reset.
      */
-    public function testReSortResolvers()
+    public function testReSortResolvers(): void
     {
-        list($low, $medium, $high) = $this->createResolverMocks();
+        [$low, $medium, $high] = $this->createResolverMocks();
         $highest = clone $high;
         // We're using a mock here and not $this->chainResolver because we need to ensure that the sorting operation is done only once.
-        $resolver = $this->buildMock(
-            ChainConfigResolver::class,
-            ['sortResolvers']
-        );
+        $resolver = $this->buildMock();
+        $counter = self::exactly(2);
+
         $resolver
-            ->expects(self::at(0))
+            ->expects($counter)
             ->method('sortResolvers')
-            ->will(
-                self::returnValue(
-                    [$high, $medium, $low]
-                )
-            );
-        // The second time sortResolvers() is called, we're supposed to get the newly added router ($highest)
-        $resolver
-            ->expects(self::at(1))
-            ->method('sortResolvers')
-            ->will(
-                self::returnValue(
-                    [$highest, $high, $medium, $low]
-                )
-            );
+            ->willReturnCallback(static function () use ($counter, $highest, $high, $medium, $low): array {
+                return match ($counter->getInvocationCount()) {
+                    1 => [$high, $medium, $low],
+                    2 => [$highest, $high, $medium, $low],
+                    default => throw new \LogicException('Unexpected call to sortResolvers'),
+                };
+            });
 
         $resolver->addResolver($low, 10);
         $resolver->addResolver($medium, 50);
@@ -120,14 +105,14 @@ class ChainConfigResolverTest extends TestCase
         );
     }
 
-    public function testGetDefaultNamespace()
+    public function testGetDefaultNamespace(): void
     {
         $this->expectException(\LogicException::class);
 
         $this->chainResolver->getDefaultNamespace();
     }
 
-    public function testSetDefaultNamespace()
+    public function testSetDefaultNamespace(): void
     {
         $namespace = 'foo';
         foreach ($this->createResolverMocks() as $i => $resolver) {
@@ -141,10 +126,8 @@ class ChainConfigResolverTest extends TestCase
         $this->chainResolver->setDefaultNamespace($namespace);
     }
 
-    public function testGetParameterInvalid()
+    public function testGetParameterInvalid(): void
     {
-        $this->expectException(ParameterNotFoundException::class);
-
         $paramName = 'foo';
         $namespace = 'namespace';
         $scope = 'scope';
@@ -153,23 +136,23 @@ class ChainConfigResolverTest extends TestCase
                 ->expects(self::once())
                 ->method('getParameter')
                 ->with($paramName, $namespace, $scope)
-                ->will(self::throwException(new ParameterNotFoundException($paramName, $namespace)));
+                ->willThrowException(new ParameterNotFoundException($paramName, $namespace));
             $this->chainResolver->addResolver($resolver);
         }
 
+        $this->expectException(ParameterNotFoundException::class);
         $this->chainResolver->getParameter($paramName, $namespace, $scope);
     }
 
     /**
      * @dataProvider getParameterProvider
-     *
-     * @param string $paramName
-     * @param string $namespace
-     * @param string $scope
-     * @param mixed $expectedValue
      */
-    public function testGetParameter($paramName, $namespace, $scope, $expectedValue)
-    {
+    public function testGetParameter(
+        string $paramName,
+        string $namespace,
+        string $scope,
+        mixed $expectedValue,
+    ): void {
         $resolver = $this->createMock(ConfigResolverInterface::class);
         $resolver
             ->expects(self::once())
@@ -181,7 +164,10 @@ class ChainConfigResolverTest extends TestCase
         self::assertSame($expectedValue, $this->chainResolver->getParameter($paramName, $namespace, $scope));
     }
 
-    public function getParameterProvider()
+    /**
+     * @return iterable<array{string, string, string, mixed}>
+     */
+    public function getParameterProvider(): iterable
     {
         return [
             ['foo', 'namespace', 'scope', 'someValue'],
@@ -191,7 +177,7 @@ class ChainConfigResolverTest extends TestCase
         ];
     }
 
-    public function testHasParameterTrue()
+    public function testHasParameterTrue(): void
     {
         $paramName = 'foo';
         $namespace = 'yetAnotherNamespace';
@@ -222,7 +208,7 @@ class ChainConfigResolverTest extends TestCase
         self::assertTrue($this->chainResolver->hasParameter($paramName, $namespace, $scope));
     }
 
-    public function testHasParameterFalse()
+    public function testHasParameterFalse(): void
     {
         $paramName = 'foo';
         $namespace = 'yetAnotherNamespace';
@@ -240,9 +226,9 @@ class ChainConfigResolverTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject[]
+     * @phpstan-return array<\PHPUnit\Framework\MockObject\MockObject & ConfigResolverInterface>
      */
-    private function createResolverMocks()
+    private function createResolverMocks(): array
     {
         return [
             $this->createMock(ConfigResolverInterface::class),
@@ -251,12 +237,12 @@ class ChainConfigResolverTest extends TestCase
         ];
     }
 
-    private function buildMock($class, array $methods = [])
+    private function buildMock(): MockObject & ChainConfigResolver
     {
         return $this
-            ->getMockBuilder($class)
+            ->getMockBuilder(ChainConfigResolver::class)
             ->disableOriginalConstructor()
-            ->setMethods($methods)
+            ->onlyMethods(['sortResolvers'])
             ->getMock();
     }
 }

--- a/tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
@@ -41,22 +41,33 @@ final class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
      */
     public function testTaggedResolverAddedToConstructor(?int $declaredPriority, int $expectedPriority): void
     {
-        $resolverDef = new Definition();
-        $serviceId = 'some_service_id';
-        $resolverDef->addTag(
+        $resolverDef1 = new Definition();
+        $resolverDef1->addTag(
             'ibexa.site.config.resolver',
             null !== $declaredPriority
                 ? ['priority' => $declaredPriority]
                 : []
         );
 
-        $this->setDefinition($serviceId, $resolverDef);
+        $resolverDef2 = new Definition();
+        $resolverDef2->addTag(
+            'ibexa.site.config.resolver',
+            null !== $declaredPriority
+                ? ['priority' => $declaredPriority]
+                : []
+        );
+
+        $this->setDefinition('some_service_id', $resolverDef1);
+        $this->setDefinition('some_service_id_2', $resolverDef2);
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             ChainConfigResolver::class,
             '$resolvers',
-            [$expectedPriority => new Reference($serviceId)],
+            [$expectedPriority => [
+                new Reference('some_service_id'),
+                new Reference('some_service_id_2'),
+            ]],
         );
     }
 

--- a/tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @covers \Ibexa\Bundle\Core\DependencyInjection\Compiler\ChainConfigResolverPass
  */
-class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
+final class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
 {
     protected function setUp(): void
     {
@@ -37,12 +37,9 @@ class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
     }
 
     /**
-     * @param int|null $declaredPriority
-     * @param int $expectedPriority
-     *
      * @dataProvider addResolverProvider
      */
-    public function testAddResolver($declaredPriority, $expectedPriority)
+    public function testTaggedResolverAddedToConstructor(?int $declaredPriority, int $expectedPriority): void
     {
         $resolverDef = new Definition();
         $serviceId = 'some_service_id';
@@ -56,14 +53,17 @@ class ChainConfigResolverPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition($serviceId, $resolverDef);
         $this->compile();
 
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             ChainConfigResolver::class,
-            'addResolver',
-            [new Reference($serviceId), $expectedPriority]
+            '$resolvers',
+            [$expectedPriority => new Reference($serviceId)],
         );
     }
 
-    public function addResolverProvider()
+    /**
+     * @return iterable<array{int|null, int}>
+     */
+    public function addResolverProvider(): iterable
     {
         return [
             [null, 0],


### PR DESCRIPTION
| :ticket: Issue | IBX-11951 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
`ChainConfigResolver` should not change at runtime. Resolvers should only be added during construction, and should not be changed after.

Otherwise, the `ChainConfigResolver` becomes stateful and can potentially cause issues in contexts where application should reset it's state, like in Messenger workers.

> [!WARNING]
> **When merging up, remove deprecations.**

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:

Deprecations for 6.x should probably be documented, if we have a place for that.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
