### PR TITLE
Added ContentTypeOwnedBySomeoneElseException for content type draft owned by another user

### DIFF
--- a/src/contracts/Repository/Exceptions/ContentTypeOwnedBySomeoneElseException.php
+++ b/src/contracts/Repository/Exceptions/ContentTypeOwnedBySomeoneElseException.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Exceptions;
+
+interface ContentTypeOwnedBySomeoneElseException extends Exception
+{
+}

--- a/src/lib/Base/Exceptions/ContentTypeOwnedBySomeoneElseException.php
+++ b/src/lib/Base/Exceptions/ContentTypeOwnedBySomeoneElseException.php
@@ -6,12 +6,12 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Core\Repository\ContentType\Exception;
+namespace Ibexa\Core\Base\Exceptions;
 
-use Ibexa\Core\Base\Exceptions\NotFoundException;
+use Ibexa\Contracts\Core\Repository\Exceptions\ContentTypeOwnedBySomeoneElseException as APIContentTypeOwnedBySomeoneElseException;
 use Throwable;
 
-final class ContentTypeOwnedBySomeoneElseException extends NotFoundException
+final class ContentTypeOwnedBySomeoneElseException extends NotFoundException implements APIContentTypeOwnedBySomeoneElseException
 {
     public function __construct(int $contentTypeId, ?Throwable $previous = null)
     {

--- a/src/lib/Repository/ContentType/Exception/ContentTypeOwnedBySomeoneElseException.php
+++ b/src/lib/Repository/ContentType/Exception/ContentTypeOwnedBySomeoneElseException.php
@@ -11,9 +11,6 @@ namespace Ibexa\Core\Repository\ContentType\Exception;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Throwable;
 
-/**
- * Exception thrown when a Content Type draft is owned by a different user than the current one.
- */
 final class ContentTypeOwnedBySomeoneElseException extends NotFoundException
 {
     public function __construct(int $contentTypeId, ?Throwable $previous = null)

--- a/src/lib/Repository/ContentType/Exception/ContentTypeOwnedBySomeoneElseException.php
+++ b/src/lib/Repository/ContentType/Exception/ContentTypeOwnedBySomeoneElseException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Core\Repository\ContentType\Exception;
+
+use Ibexa\Core\Base\Exceptions\NotFoundException;
+use Throwable;
+
+/**
+ * Exception thrown when a Content Type draft is owned by a different user than the current one.
+ */
+final class ContentTypeOwnedBySomeoneElseException extends NotFoundException
+{
+    public function __construct(int $contentTypeId, ?Throwable $previous = null)
+    {
+        parent::__construct('The content type is owned by someone else', $contentTypeId, $previous);
+    }
+}

--- a/src/lib/Repository/ContentTypeService.php
+++ b/src/lib/Repository/ContentTypeService.php
@@ -37,6 +37,7 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\SearchResult;
 use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Ibexa\Core\Base\Exceptions\BadStateException;
 use Ibexa\Core\Base\Exceptions\ContentTypeFieldDefinitionValidationException;
+use Ibexa\Core\Base\Exceptions\ContentTypeOwnedBySomeoneElseException;
 use Ibexa\Core\Base\Exceptions\ContentTypeValidationException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
@@ -45,7 +46,6 @@ use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Base\Exceptions\UnauthorizedException;
 use Ibexa\Core\FieldType\FieldTypeRegistry;
 use Ibexa\Core\FieldType\ValidationError;
-use Ibexa\Core\Repository\ContentType\Exception\ContentTypeOwnedBySomeoneElseException;
 use Ibexa\Core\Repository\Values\ContentType\ContentTypeCreateStruct;
 use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 

--- a/src/lib/Repository/ContentTypeService.php
+++ b/src/lib/Repository/ContentTypeService.php
@@ -45,6 +45,7 @@ use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\Base\Exceptions\UnauthorizedException;
 use Ibexa\Core\FieldType\FieldTypeRegistry;
 use Ibexa\Core\FieldType\ValidationError;
+use Ibexa\Core\Repository\ContentType\Exception\ContentTypeOwnedBySomeoneElseException;
 use Ibexa\Core\Repository\Values\ContentType\ContentTypeCreateStruct;
 use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 
@@ -767,8 +768,6 @@ class ContentTypeService implements ContentTypeServiceInterface
      * @param int $contentTypeId
      * @param bool $ignoreOwnership if true, method will return draft even if the owner is different than currently logged in user
      *
-     * @todo Use another exception when user of draft is someone else
-     *
      * @return \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeDraft
      */
     public function loadContentTypeDraft(int $contentTypeId, bool $ignoreOwnership = false): APIContentTypeDraft
@@ -779,7 +778,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         );
 
         if (!$ignoreOwnership && $spiContentType->modifierId != $this->permissionResolver->getCurrentUserReference()->getUserId()) {
-            throw new NotFoundException('The content type is owned by someone else', $contentTypeId);
+            throw new ContentTypeOwnedBySomeoneElseException($contentTypeId);
         }
 
         return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject($spiContentType);


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description

`ContentTypeService::loadContentTypeDraft()` threw a generic `NotFoundException` with the message
`'The content type is owned by someone else'` when a draft existed but was owned by a different user,
carrying a long-standing `@todo Use another exception when user of draft is someone else`.

Consumers had no way to distinguish that ownership case from a genuinely missing draft other than by
matching the exception **message**, which is fragile — the message can change here and silently break
those consumers.

This PR introduces a dedicated `Ibexa\Core\Repository\ContentType\Exception\ContentTypeOwnedBySomeoneElseException`
(extending `Ibexa\Core\Base\Exceptions\NotFoundException`) and throws it from `loadContentTypeDraft()`,
resolving the `@todo`. Callers can now branch on the exception type via `instanceof`.

The exception passes the same `'The content type is owned by someone else'` description to its parent,
so the resulting message is unchanged and existing `catch (NotFoundException $e)` blocks keep working.

#### Motivation

Raised in review of the MCP `get_content_type_draft` tool:
https://github.com/ibexa/mcp/pull/14#discussion_r3466283486
