### PR TITLE
Fixed translations

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -10,13 +10,13 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-24.04"
+        runs-on: "ubuntu-26.04"
         strategy:
             matrix:
                 php:
                     - '8.1'
         steps:
-            -   uses: actions/checkout@v6
+            -   uses: actions/checkout@v7
 
             -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
@@ -30,7 +30,7 @@ jobs:
 
     tests:
         name: Unit tests & SQLite integration tests
-        runs-on: "ubuntu-24.04"
+        runs-on: "ubuntu-26.04"
         timeout-minutes: 15
 
         strategy:
@@ -42,7 +42,7 @@ jobs:
                     - '8.4'
 
         steps:
-            -   uses: actions/checkout@v6
+            -   uses: actions/checkout@v7
 
             -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
@@ -80,7 +80,7 @@ jobs:
                     --health-timeout 5s
                     --health-retries 5
                     --tmpfs /var/lib/postgres
-        runs-on: "ubuntu-24.04"
+        runs-on: "ubuntu-26.04"
         timeout-minutes: 60
 
         strategy:
@@ -98,7 +98,7 @@ jobs:
                     - 'postgres:18'
 
         steps:
-            -   uses: actions/checkout@v6
+            -   uses: actions/checkout@v7
 
             -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
@@ -137,7 +137,7 @@ jobs:
                     --health-timeout=5s
                     --health-retries=5
                     --tmpfs=/var/lib/mysql
-        runs-on: "ubuntu-24.04"
+        runs-on: "ubuntu-26.04"
         timeout-minutes: 60
 
         strategy:
@@ -155,7 +155,7 @@ jobs:
                     - 'mysql:8.4'
 
         steps:
-            -   uses: actions/checkout@v6
+            -   uses: actions/checkout@v7
 
             -   uses: ibexa/gh-workflows/actions/composer-install@main
                 with:
@@ -176,7 +176,7 @@ jobs:
 
     solr-integration:
         name: "Solr integration tests"
-        runs-on: "ubuntu-24.04"
+        runs-on: "ubuntu-26.04"
         timeout-minutes: 30
         permissions:
             packages: read
@@ -205,7 +205,7 @@ jobs:
                     - '8.3'
                     - '8.4'
         steps:
-            -   uses: actions/checkout@v6
+            -   uses: actions/checkout@v7
                 with:
                     fetch-depth: 0
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9349,7 +9349,7 @@ parameters:
 			path: src/lib/Base/Exceptions/ContentFieldValidationException.php
 
 		-
-			message: '#^PHPDoc tag @var with type callable\(Ibexa\\Contracts\\Core\\Repository\\Values\\Translation\|string\)\: string is not subtype of native type Closure\(mixed\)\: string\.$#'
+			message: '#^PHPDoc tag @var with type callable\(Ibexa\\Contracts\\Core\\Repository\\Values\\Translation\|string\)\: string is not subtype of native type static\-Closure\(mixed\)\: string\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: src/lib/Base/Exceptions/ContentFieldValidationException.php

--- a/src/bundle/Core/Resources/translations/forms.en.xlf
+++ b/src/bundle/Core/Resources/translations/forms.en.xlf
@@ -13,127 +13,127 @@
       </trans-unit>
       <trans-unit id="f52e45b25ff70b3d1d07c57911ceda58dcdf7431" resname="role.policy.class">
         <source>Content type</source>
-        <target>Content type</target>
+        <target state="new">Content type</target>
         <note>key: role.policy.class</note>
       </trans-unit>
       <trans-unit id="2f746c35c587bdc84cacf38d0e63e08855e831ab" resname="role.policy.class.all_functions">
         <source>Content type / All functions</source>
-        <target>Content type / All functions</target>
+        <target state="new">Content type / All functions</target>
         <note>key: role.policy.class.all_functions</note>
       </trans-unit>
       <trans-unit id="02049080d0f8dea3f723bbd1a280900b0657914e" resname="role.policy.class.create">
         <source>Content type / Create</source>
-        <target>Content type / Create</target>
+        <target state="new">Content type / Create</target>
         <note>key: role.policy.class.create</note>
       </trans-unit>
       <trans-unit id="17ee6a3320ad9ac02c376bdcb875b266c28e34db" resname="role.policy.class.delete">
         <source>Content type / Delete</source>
-        <target>Content type / Delete</target>
+        <target state="new">Content type / Delete</target>
         <note>key: role.policy.class.delete</note>
       </trans-unit>
       <trans-unit id="f47b14b0adc8b08abd44c37e801d6b2c3180a2ee" resname="role.policy.class.update">
         <source>Content type / Update</source>
-        <target>Content type / Update</target>
+        <target state="new">Content type / Update</target>
         <note>key: role.policy.class.update</note>
       </trans-unit>
       <trans-unit id="ffe83a713e8b33558df040efa1eeadd0b1cc18e0" resname="role.policy.content">
         <source>Content</source>
-        <target>Content</target>
+        <target state="new">Content</target>
         <note>key: role.policy.content</note>
       </trans-unit>
       <trans-unit id="ea72f76a43bc0ec3eff965e68279dab5597b19c0" resname="role.policy.content.all_functions">
         <source>Content / All functions</source>
-        <target>Content / All functions</target>
+        <target state="new">Content / All functions</target>
         <note>key: role.policy.content.all_functions</note>
       </trans-unit>
       <trans-unit id="e050709df5ae56b1e9168038182f4c52221ffab9" resname="role.policy.content.cleantrash">
         <source>Content / Clean trash</source>
-        <target>Content / Clean trash</target>
+        <target state="new">Content / Clean trash</target>
         <note>key: role.policy.content.cleantrash</note>
       </trans-unit>
       <trans-unit id="597c25abf1e2d91e50b82d2699f8b85f68c9f305" resname="role.policy.content.create">
         <source>Content / Create</source>
-        <target>Content / Create</target>
+        <target state="new">Content / Create</target>
         <note>key: role.policy.content.create</note>
       </trans-unit>
       <trans-unit id="019bae55ae37c03117c05eb25cc208e9b2396827" resname="role.policy.content.diff">
         <source>Content / Diff</source>
-        <target>Content / Diff</target>
+        <target state="new">Content / Diff</target>
         <note>key: role.policy.content.diff</note>
       </trans-unit>
       <trans-unit id="bdb3e6e10d770d20ffa7966acb58d3e9cf9805e2" resname="role.policy.content.edit">
         <source>Content / Edit</source>
-        <target>Content / Edit</target>
+        <target state="new">Content / Edit</target>
         <note>key: role.policy.content.edit</note>
       </trans-unit>
       <trans-unit id="1049e14eb7fec2dc053571f607e0eb044a06e455" resname="role.policy.content.hide">
         <source>Content / Hide</source>
-        <target>Content / Hide</target>
+        <target state="new">Content / Hide</target>
         <note>key: role.policy.content.hide</note>
       </trans-unit>
       <trans-unit id="d05f0b35c91f7d444c466871ff02886d74dc8f55" resname="role.policy.content.manage_locations">
         <source>Content / Manage locations</source>
-        <target>Content / Manage locations</target>
+        <target state="new">Content / Manage locations</target>
         <note>key: role.policy.content.manage_locations</note>
       </trans-unit>
       <trans-unit id="0c943bab11cd582ac439e67289d4efd86d8599e7" resname="role.policy.content.pendinglist">
         <source>Content / Pending list</source>
-        <target>Content / Pending list</target>
+        <target state="new">Content / Pending list</target>
         <note>key: role.policy.content.pendinglist</note>
       </trans-unit>
       <trans-unit id="6f595f392af03d8b2e46449d527530e3e1f8eb94" resname="role.policy.content.publish">
         <source>Content / Publish</source>
-        <target>Content / Publish</target>
+        <target state="new">Content / Publish</target>
         <note>key: role.policy.content.publish</note>
       </trans-unit>
       <trans-unit id="2b5e52d4783100540d791657f21d9dc1a9fbbb30" resname="role.policy.content.read">
         <source>Content / Read</source>
-        <target>Content / Read</target>
+        <target state="new">Content / Read</target>
         <note>key: role.policy.content.read</note>
       </trans-unit>
       <trans-unit id="967c7d2238b619a63fd0fe00bc0ccd4589e9de4f" resname="role.policy.content.remove">
         <source>Content / Remove</source>
-        <target>Content / Remove</target>
+        <target state="new">Content / Remove</target>
         <note>key: role.policy.content.remove</note>
       </trans-unit>
       <trans-unit id="4ce8821efab15ebdd683e28f0dcffaa352d1ef0f" resname="role.policy.content.restore">
         <source>Content / Restore</source>
-        <target>Content / Restore</target>
+        <target state="new">Content / Restore</target>
         <note>key: role.policy.content.restore</note>
       </trans-unit>
       <trans-unit id="7ad7cd36512ca57f6d6cb31b7de0740d4754961c" resname="role.policy.content.reverserelatedlist">
         <source>Content / Reverse related list</source>
-        <target>Content / Reverse related list</target>
+        <target state="new">Content / Reverse related list</target>
         <note>key: role.policy.content.reverserelatedlist</note>
       </trans-unit>
       <trans-unit id="c9a69e432793ed3480c2252f3ca1b4e6564e853e" resname="role.policy.content.translate">
         <source>Content / Translate</source>
-        <target>Content / Translate</target>
+        <target state="new">Content / Translate</target>
         <note>key: role.policy.content.translate</note>
       </trans-unit>
       <trans-unit id="3f9650d96394bc9e6d53360117d2dd3d6842735f" resname="role.policy.content.translations">
         <source>Content / Translations</source>
-        <target>Content / Translations</target>
+        <target state="new">Content / Translations</target>
         <note>key: role.policy.content.translations</note>
       </trans-unit>
       <trans-unit id="74ccbb06e1226201f9642eefa451b67360a4145b" resname="role.policy.content.unlock">
         <source>Content / Unlock</source>
-        <target>Content / Unlock</target>
+        <target state="new">Content / Unlock</target>
         <note>key: role.policy.content.unlock</note>
       </trans-unit>
       <trans-unit id="79ffa7a2f2449d08574ef7c5b1f447b439db97b2" resname="role.policy.content.urltranslator">
         <source>Content / Url translator</source>
-        <target>Content / Url translator</target>
+        <target state="new">Content / Url translator</target>
         <note>key: role.policy.content.urltranslator</note>
       </trans-unit>
       <trans-unit id="0a641d7ab31b48b6b87a9d2cd4763afae237219d" resname="role.policy.content.versionread">
         <source>Content / Version read</source>
-        <target>Content / Version read</target>
+        <target state="new">Content / Version read</target>
         <note>key: role.policy.content.versionread</note>
       </trans-unit>
       <trans-unit id="4e615fcc14a6f5b70fb3e7957518c27bc508d92f" resname="role.policy.content.versionremove">
         <source>Content / Version remove</source>
-        <target>Content / Version remove</target>
+        <target state="new">Content / Version remove</target>
         <note>key: role.policy.content.versionremove</note>
       </trans-unit>
       <trans-unit id="81703573067457c42db3d0c8cce70e1d1e0128a5" resname="role.policy.content.view_embed">
@@ -143,137 +143,137 @@
       </trans-unit>
       <trans-unit id="6ff0bcc1b70d0dbde113af7649393f667612cace" resname="role.policy.role">
         <source>Role</source>
-        <target>Role</target>
+        <target state="new">Role</target>
         <note>key: role.policy.role</note>
       </trans-unit>
       <trans-unit id="17f55c17c76ccfcf636ce429b867f89069609bcd" resname="role.policy.role.all_functions">
         <source>Role / All functions</source>
-        <target>Role / All functions</target>
+        <target state="new">Role / All functions</target>
         <note>key: role.policy.role.all_functions</note>
       </trans-unit>
       <trans-unit id="cf922ebcfc51ae098cb57a938984916e03c0481c" resname="role.policy.role.assign">
         <source>Role / Assign</source>
-        <target>Role / Assign</target>
+        <target state="new">Role / Assign</target>
         <note>key: role.policy.role.assign</note>
       </trans-unit>
       <trans-unit id="f12cc8bc381274c232a90deae7ce981dbc3634cb" resname="role.policy.role.create">
         <source>Role / Create</source>
-        <target>Role / Create</target>
+        <target state="new">Role / Create</target>
         <note>key: role.policy.role.create</note>
       </trans-unit>
       <trans-unit id="d17c0339a48c6e273c56673c31037427fd95ecee" resname="role.policy.role.delete">
         <source>Role / Delete</source>
-        <target>Role / Delete</target>
+        <target state="new">Role / Delete</target>
         <note>key: role.policy.role.delete</note>
       </trans-unit>
       <trans-unit id="1e809cc5ab4e914e5dc51fa2dc0a6b62a90bc2f1" resname="role.policy.role.read">
         <source>Role / Read</source>
-        <target>Role / Read</target>
+        <target state="new">Role / Read</target>
         <note>key: role.policy.role.read</note>
       </trans-unit>
       <trans-unit id="2f8dccfd705bd25a633826ff76f595e118a71dcf" resname="role.policy.role.update">
         <source>Role / Update</source>
-        <target>Role / Update</target>
+        <target state="new">Role / Update</target>
         <note>key: role.policy.role.update</note>
       </trans-unit>
       <trans-unit id="7153cdd53211bedab219659c1d1656693d3bb4ae" resname="role.policy.section">
         <source>Section</source>
-        <target>Section</target>
+        <target state="new">Section</target>
         <note>key: role.policy.section</note>
       </trans-unit>
       <trans-unit id="f5e387481bf702e73317dcbccff5d55fc111550e" resname="role.policy.section.all_functions">
         <source>Section / All functions</source>
-        <target>Section / All functions</target>
+        <target state="new">Section / All functions</target>
         <note>key: role.policy.section.all_functions</note>
       </trans-unit>
       <trans-unit id="2f63b236417b33905613e757497387c99e47a848" resname="role.policy.section.assign">
         <source>Section / Assign</source>
-        <target>Section / Assign</target>
+        <target state="new">Section / Assign</target>
         <note>key: role.policy.section.assign</note>
       </trans-unit>
       <trans-unit id="9ce67233e7377c7ac36c6ccbdf1a49a582aca59d" resname="role.policy.section.edit">
         <source>Section / Edit</source>
-        <target>Section / Edit</target>
+        <target state="new">Section / Edit</target>
         <note>key: role.policy.section.edit</note>
       </trans-unit>
       <trans-unit id="c80fb60940421ce0b94226255211ec10dc9208b4" resname="role.policy.section.view">
         <source>Section / View</source>
-        <target>Section / View</target>
+        <target state="new">Section / View</target>
         <note>key: role.policy.section.view</note>
       </trans-unit>
       <trans-unit id="5f165ef2e938f6710b56e2e8ee416414e430b77c" resname="role.policy.setting">
         <source>Setting</source>
-        <target>Setting</target>
+        <target state="new">Setting</target>
         <note>key: role.policy.setting</note>
       </trans-unit>
       <trans-unit id="8775d52b987252ee1ad0867fe4f9e23dec668b5b" resname="role.policy.setting.all_functions">
         <source>Setting / All functions</source>
-        <target>Setting / All functions</target>
+        <target state="new">Setting / All functions</target>
         <note>key: role.policy.setting.all_functions</note>
       </trans-unit>
       <trans-unit id="686f427740ca0cf4df247266b8a1300d747cf3a4" resname="role.policy.setting.create">
         <source>Setting / Create</source>
-        <target>Setting / Create</target>
+        <target state="new">Setting / Create</target>
         <note>key: role.policy.setting.create</note>
       </trans-unit>
       <trans-unit id="d41141e8fa3c214bc546a6925304c15ee9a28022" resname="role.policy.setting.remove">
         <source>Setting / Remove</source>
-        <target>Setting / Remove</target>
+        <target state="new">Setting / Remove</target>
         <note>key: role.policy.setting.remove</note>
       </trans-unit>
       <trans-unit id="14fa9c5afba9d51072c6a66dede46535b718f77e" resname="role.policy.setting.update">
         <source>Setting / Update</source>
-        <target>Setting / Update</target>
+        <target state="new">Setting / Update</target>
         <note>key: role.policy.setting.update</note>
       </trans-unit>
       <trans-unit id="33092ebd51699d4d3f598b8488e7bc5969038bff" resname="role.policy.setup">
         <source>Setup</source>
-        <target>Setup</target>
+        <target state="new">Setup</target>
         <note>key: role.policy.setup</note>
       </trans-unit>
       <trans-unit id="a72fa98205c4f68fc53506f9b57e645be450ce86" resname="role.policy.setup.administrate">
         <source>Setup / Administrate</source>
-        <target>Setup / Administrate</target>
+        <target state="new">Setup / Administrate</target>
         <note>key: role.policy.setup.administrate</note>
       </trans-unit>
       <trans-unit id="df52828e26336a4a6f3186e0d6eb75d98056aeaa" resname="role.policy.setup.all_functions">
         <source>Setup / All functions</source>
-        <target>Setup / All functions</target>
+        <target state="new">Setup / All functions</target>
         <note>key: role.policy.setup.all_functions</note>
       </trans-unit>
       <trans-unit id="32c1032c29386bcf41793f2542b3476887249bc5" resname="role.policy.setup.install">
         <source>Setup / Install</source>
-        <target>Setup / Install</target>
+        <target state="new">Setup / Install</target>
         <note>key: role.policy.setup.install</note>
       </trans-unit>
       <trans-unit id="4ce0aa17f80167751257ddb6e0cc8e06ca9c1bbb" resname="role.policy.setup.setup">
         <source>Setup / Setup</source>
-        <target>Setup / Setup</target>
+        <target state="new">Setup / Setup</target>
         <note>key: role.policy.setup.setup</note>
       </trans-unit>
       <trans-unit id="a77dcd2893dc76a7e94fe088b775045fde8651e4" resname="role.policy.setup.system_info">
         <source>Setup / System info</source>
-        <target>Setup / System info</target>
+        <target state="new">Setup / System info</target>
         <note>key: role.policy.setup.system_info</note>
       </trans-unit>
       <trans-unit id="012dce76ef569ba377ffe98ddbee8d3c3d270e15" resname="role.policy.state">
         <source>State</source>
-        <target>State</target>
+        <target state="new">State</target>
         <note>key: role.policy.state</note>
       </trans-unit>
       <trans-unit id="0dc3b2e6978f026be583bcf078e15c4157a51d19" resname="role.policy.state.administrate">
         <source>State / Administrate</source>
-        <target>State / Administrate</target>
+        <target state="new">State / Administrate</target>
         <note>key: role.policy.state.administrate</note>
       </trans-unit>
       <trans-unit id="5a57c4086c786d6c767dfca68486d64c60ec58bf" resname="role.policy.state.all_functions">
         <source>State / All functions</source>
-        <target>State / All functions</target>
+        <target state="new">State / All functions</target>
         <note>key: role.policy.state.all_functions</note>
       </trans-unit>
       <trans-unit id="8c144b2e58f6ba9388517a5929bfd12a0773ddd2" resname="role.policy.state.assign">
         <source>State / Assign</source>
-        <target>State / Assign</target>
+        <target state="new">State / Assign</target>
         <note>key: role.policy.state.assign</note>
       </trans-unit>
       <trans-unit id="73c3d3a21c7264a991abf4e6ffe68751a1dbdb58" resname="role.policy.url">
@@ -298,57 +298,57 @@
       </trans-unit>
       <trans-unit id="78b9d0d52e636ef2d0d1f919de16154404c2be0f" resname="role.policy.user">
         <source>User</source>
-        <target>User</target>
+        <target state="new">User</target>
         <note>key: role.policy.user</note>
       </trans-unit>
       <trans-unit id="647dfa7992026277b6d73295b2ffaefe4cfa12d0" resname="role.policy.user.activation">
         <source>User / Activation</source>
-        <target>User / Activation</target>
+        <target state="new">User / Activation</target>
         <note>key: role.policy.user.activation</note>
       </trans-unit>
       <trans-unit id="d44ce8c33cbc780cff9ca6f05ad2f70002550cd0" resname="role.policy.user.all_functions">
         <source>User / All functions</source>
-        <target>User / All functions</target>
+        <target state="new">User / All functions</target>
         <note>key: role.policy.user.all_functions</note>
       </trans-unit>
       <trans-unit id="587199065d14880416b8061b73788e731a201c27" resname="role.policy.user.invite">
         <source>User / Invite</source>
-        <target>User / Invite</target>
+        <target state="new">User / Invite</target>
         <note>key: role.policy.user.invite</note>
       </trans-unit>
       <trans-unit id="f25505dc2f59df21e3125664c4fdad951d82df3b" resname="role.policy.user.login">
         <source>User / Login</source>
-        <target>User / Login</target>
+        <target state="new">User / Login</target>
         <note>key: role.policy.user.login</note>
       </trans-unit>
       <trans-unit id="d971078868184d3d233fb14032fda9ef614c2baa" resname="role.policy.user.password">
         <source>User / Password</source>
-        <target>User / Password</target>
+        <target state="new">User / Password</target>
         <note>key: role.policy.user.password</note>
       </trans-unit>
       <trans-unit id="28d15501824f89951d4068af32fbc52eb1412b8d" resname="role.policy.user.preferences">
         <source>User / Preferences</source>
-        <target>User / Preferences</target>
+        <target state="new">User / Preferences</target>
         <note>key: role.policy.user.preferences</note>
       </trans-unit>
       <trans-unit id="8f79f6008557e588c0a8b13ccdc42d6babc073c9" resname="role.policy.user.register">
         <source>User / Register</source>
-        <target>User / Register</target>
+        <target state="new">User / Register</target>
         <note>key: role.policy.user.register</note>
       </trans-unit>
       <trans-unit id="106b2a3fa38c660c838efe1905c904ce689a2d75" resname="role.policy.user.selfedit">
         <source>User / Self edit</source>
-        <target>User / Self edit</target>
+        <target state="new">User / Self edit</target>
         <note>key: role.policy.user.selfedit</note>
       </trans-unit>
       <trans-unit id="caaf0c6eabe978a17eefcedf501b2506383a8267" resname="role.policy.user.update">
         <source>User / Update</source>
-        <target>User / Update</target>
+        <target state="new">User / Update</target>
         <note>key: role.policy.user.update</note>
       </trans-unit>
       <trans-unit id="b445a673ef3c893b783c58b6fd4b2469224a04db" resname="role.policy.user.view">
         <source>User / View</source>
-        <target>User / View</target>
+        <target state="new">User / View</target>
         <note>key: role.policy.user.view</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/ibexa_content_fields.en.xlf
+++ b/src/bundle/Core/Resources/translations/ibexa_content_fields.en.xlf
@@ -8,12 +8,12 @@
     <body>
       <trans-unit id="f337a8fd9042dbc4de8b5d305b6d8df3c0c374c4" resname="content-field.latitude.not_set">
         <source>Not set</source>
-        <target>Not set</target>
+        <target state="new">Not set</target>
         <note>key: content-field.latitude.not_set</note>
       </trans-unit>
       <trans-unit id="687973ca20983f27a99c50243e364e346c9c4814" resname="content-field.longitude.not_set">
         <source>Not set</source>
-        <target>Not set</target>
+        <target state="new">Not set</target>
         <note>key: content-field.longitude.not_set</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/ibexa_fielddefinition.en.xlf
+++ b/src/bundle/Core/Resources/translations/ibexa_fielddefinition.en.xlf
@@ -8,312 +8,312 @@
     <body>
       <trans-unit id="9c2eb5d844a5e2507a5c0f1ba534b5a392b1a40d" resname="fielddefinition.allowed-content-types.any">
         <source>Any</source>
-        <target>Any</target>
+        <target state="new">Any</target>
         <note>key: fielddefinition.allowed-content-types.any</note>
       </trans-unit>
       <trans-unit id="70d065216b588dd0cf8c624132941a29f1c1459f" resname="fielddefinition.allowed-content-types.label">
         <source>Allowed content types:</source>
-        <target>Allowed content types:</target>
+        <target state="new">Allowed content types:</target>
         <note>key: fielddefinition.allowed-content-types.label</note>
       </trans-unit>
       <trans-unit id="eb0eeb83b3f40e1293f0edd593a8cce658d9f35d" resname="fielddefinition.default-value.checked">
         <source>Checked</source>
-        <target>Checked</target>
+        <target state="new">Checked</target>
         <note>key: fielddefinition.default-value.checked</note>
       </trans-unit>
       <trans-unit id="aa6b4bece2c401e90fc0828a11ad372eaf2f3695" resname="fielddefinition.default-value.current_author">
         <source>Current User</source>
-        <target>Current User</target>
+        <target state="new">Current User</target>
         <note>key: fielddefinition.default-value.current_author</note>
       </trans-unit>
       <trans-unit id="3410f38fd1f44cb841ec374c13daca04dcc5910b" resname="fielddefinition.default-value.current_date">
         <source>Current date</source>
-        <target>Current date</target>
+        <target state="new">Current date</target>
         <note>key: fielddefinition.default-value.current_date</note>
       </trans-unit>
       <trans-unit id="d3cda4b47dfae160f1e7f982570b8b544a494701" resname="fielddefinition.default-value.current_datetime">
         <source>Current datetime</source>
-        <target>Current datetime</target>
+        <target state="new">Current datetime</target>
         <note>key: fielddefinition.default-value.current_datetime</note>
       </trans-unit>
       <trans-unit id="5cdfd0738c76b8fe520f77e56b819fd3a781a514" resname="fielddefinition.default-value.current_datetime_adjust_by">
         <source>Current datetime adjusted by</source>
-        <target>Current datetime adjusted by</target>
+        <target state="new">Current datetime adjusted by</target>
         <note>key: fielddefinition.default-value.current_datetime_adjust_by</note>
       </trans-unit>
       <trans-unit id="baf973c669d404a5aa072edce1d84deaaf936a0f" resname="fielddefinition.default-value.current_time">
         <source>Current time</source>
-        <target>Current time</target>
+        <target state="new">Current time</target>
         <note>key: fielddefinition.default-value.current_time</note>
       </trans-unit>
       <trans-unit id="fa5a2f0bf185c7e872f77b81a24867afb9ef0ec7" resname="fielddefinition.default-value.empty">
         <source>Empty</source>
-        <target>Empty</target>
+        <target state="new">Empty</target>
         <note>key: fielddefinition.default-value.empty</note>
       </trans-unit>
       <trans-unit id="ad6776fd58e0ae4b2ba44ff014986ec6b1ec4de4" resname="fielddefinition.default-value.label">
         <source>Default value:</source>
-        <target>Default value:</target>
+        <target state="new">Default value:</target>
         <note>key: fielddefinition.default-value.label</note>
       </trans-unit>
       <trans-unit id="232dd99b54158ff1f3be77113aae16e691ce406a" resname="fielddefinition.default-value.unchecked">
         <source>Unchecked</source>
-        <target>Unchecked</target>
+        <target state="new">Unchecked</target>
         <note>key: fielddefinition.default-value.unchecked</note>
       </trans-unit>
       <trans-unit id="908870d411d8599211d188e35d0240bfecb98b5e" resname="fielddefinition.default-value.undefined">
         <source>No default value</source>
-        <target>No default value</target>
+        <target state="new">No default value</target>
         <note>key: fielddefinition.default-value.undefined</note>
       </trans-unit>
       <trans-unit id="34ced944f5d7159b0597b98279e73be045c0ccd9" resname="fielddefinition.interval.day">
         <source>%default% %day% day(s)</source>
-        <target>%default% %day% day(s)</target>
+        <target state="new">%default% %day% day(s)</target>
         <note>key: fielddefinition.interval.day</note>
       </trans-unit>
       <trans-unit id="4b31f5a6cfde5d347f3ad264daa7db77e704a5e0" resname="fielddefinition.interval.hour">
         <source>%default% %hour% hour(s)</source>
-        <target>%default% %hour% hour(s)</target>
+        <target state="new">%default% %hour% hour(s)</target>
         <note>key: fielddefinition.interval.hour</note>
       </trans-unit>
       <trans-unit id="388ff2c36717a410a72060911657dce61108ed3c" resname="fielddefinition.interval.minute">
         <source>%default% %minute% minute(s)</source>
-        <target>%default% %minute% minute(s)</target>
+        <target state="new">%default% %minute% minute(s)</target>
         <note>key: fielddefinition.interval.minute</note>
       </trans-unit>
       <trans-unit id="b93b6a1548ffa873b1ef5a95c727f93d7be2fd0c" resname="fielddefinition.interval.month">
         <source>%default% %month% month(s)</source>
-        <target>%default% %month% month(s)</target>
+        <target state="new">%default% %month% month(s)</target>
         <note>key: fielddefinition.interval.month</note>
       </trans-unit>
       <trans-unit id="c410f54bc82c293dcce4b252928dc4a020ab1705" resname="fielddefinition.interval.second">
         <source>%default% %second% second(s)</source>
-        <target>%default% %second% second(s)</target>
+        <target state="new">%default% %second% second(s)</target>
         <note>key: fielddefinition.interval.second</note>
       </trans-unit>
       <trans-unit id="c88fa282a777c6f3a778f513fc9e46800ffe0198" resname="fielddefinition.interval.year">
         <source>%default% %year% year(s)</source>
-        <target>%default% %year% year(s)</target>
+        <target state="new">%default% %year% year(s)</target>
         <note>key: fielddefinition.interval.year</note>
       </trans-unit>
       <trans-unit id="fa2595f063cfd4284226372dc99eb3dfbbc36498" resname="fielddefinition.isbn.label">
         <source>Selected ISBN format:</source>
-        <target>Selected ISBN format:</target>
+        <target state="new">Selected ISBN format:</target>
         <note>key: fielddefinition.isbn.label</note>
       </trans-unit>
       <trans-unit id="c963dbac20e5526d70d08b17ebffdaaf44e1c2c3" resname="fielddefinition.max-length.label">
         <source>Max string length:</source>
-        <target>Max string length:</target>
+        <target state="new">Max string length:</target>
         <note>key: fielddefinition.max-length.label</note>
       </trans-unit>
       <trans-unit id="c8c3fa9b71c848069950539011a09b45abb1c11f" resname="fielddefinition.max-length.undefined">
         <source>No defined maximum string length</source>
-        <target>No defined maximum string length</target>
+        <target state="new">No defined maximum string length</target>
         <note>key: fielddefinition.max-length.undefined</note>
       </trans-unit>
       <trans-unit id="9a3d23487e45edf331407c501ead33d70461f9e3" resname="fielddefinition.max-length.value">
         <source>%max% characters</source>
-        <target>%max% characters</target>
+        <target state="new">%max% characters</target>
         <note>key: fielddefinition.max-length.value</note>
       </trans-unit>
       <trans-unit id="11e7b0a01edea69919ea6191acdbd5ad7c2bf279" resname="fielddefinition.max-value.label">
         <source>Maximum value:</source>
-        <target>Maximum value:</target>
+        <target state="new">Maximum value:</target>
         <note>key: fielddefinition.max-value.label</note>
       </trans-unit>
       <trans-unit id="444423d6eff78ccc1c92077813a212b4e5a002c8" resname="fielddefinition.max-value.undefined">
         <source>No defined maximum value</source>
-        <target>No defined maximum value</target>
+        <target state="new">No defined maximum value</target>
         <note>key: fielddefinition.max-value.undefined</note>
       </trans-unit>
       <trans-unit id="63f939a170c5c3675f13ca3e330ea981d4a5540c" resname="fielddefinition.maximum-file-size.label">
         <source>Maximum file size:</source>
-        <target>Maximum file size:</target>
+        <target state="new">Maximum file size:</target>
         <note>key: fielddefinition.maximum-file-size.label</note>
       </trans-unit>
       <trans-unit id="e58e37a5cd49fa5884d15ea8af61ad6973f33412" resname="fielddefinition.maximum-file-size.undefined">
         <source>No defined maximum size</source>
-        <target>No defined maximum size</target>
+        <target state="new">No defined maximum size</target>
         <note>key: fielddefinition.maximum-file-size.undefined</note>
       </trans-unit>
       <trans-unit id="3e08813722e7959e982f4d8624c98b83d077cd55" resname="fielddefinition.maximum-file-size.value">
         <source>%max% MB</source>
-        <target>%max% MB</target>
+        <target state="new">%max% MB</target>
         <note>key: fielddefinition.maximum-file-size.value</note>
       </trans-unit>
       <trans-unit id="b9bb83913e23ad5a59eb7485ca48386bd7fce66e" resname="fielddefinition.media-player-type.flash">
         <source>Flash</source>
-        <target>Flash</target>
+        <target state="new">Flash</target>
         <note>key: fielddefinition.media-player-type.flash</note>
       </trans-unit>
       <trans-unit id="1c31870437c9baa0d08c67140d35fa54c6223922" resname="fielddefinition.media-player-type.html5_audio">
         <source>HTML5 Audio</source>
-        <target>HTML5 Audio</target>
+        <target state="new">HTML5 Audio</target>
         <note>key: fielddefinition.media-player-type.html5_audio</note>
       </trans-unit>
       <trans-unit id="22881c3ebee12191bc6f269d943c1140eea4bfb1" resname="fielddefinition.media-player-type.html5_video">
         <source>HTML5 Video</source>
-        <target>HTML5 Video</target>
+        <target state="new">HTML5 Video</target>
         <note>key: fielddefinition.media-player-type.html5_video</note>
       </trans-unit>
       <trans-unit id="0aaa90efdf7cc5042723e7500891db70da3f8850" resname="fielddefinition.media-player-type.label">
         <source>Media player type:</source>
-        <target>Media player type:</target>
+        <target state="new">Media player type:</target>
         <note>key: fielddefinition.media-player-type.label</note>
       </trans-unit>
       <trans-unit id="c7a28f2ea418dc17e634bf386d5f1db091582fc8" resname="fielddefinition.media-player-type.quick_time">
         <source>Quicktime</source>
-        <target>Quicktime</target>
+        <target state="new">Quicktime</target>
         <note>key: fielddefinition.media-player-type.quick_time</note>
       </trans-unit>
       <trans-unit id="edd8db0307e234e095d1788540bd026e48e173f8" resname="fielddefinition.media-player-type.real_player">
         <source>Real Player</source>
-        <target>Real Player</target>
+        <target state="new">Real Player</target>
         <note>key: fielddefinition.media-player-type.real_player</note>
       </trans-unit>
       <trans-unit id="4ad14874021f1b806f9c93b41ef195b12fe5ab3f" resname="fielddefinition.media-player-type.silverlight">
         <source>Silverlight</source>
-        <target>Silverlight</target>
+        <target state="new">Silverlight</target>
         <note>key: fielddefinition.media-player-type.silverlight</note>
       </trans-unit>
       <trans-unit id="738ddf9e6b12ae22e5f8e62839f63221c24f1431" resname="fielddefinition.media-player-type.undefined">
         <source>No defined value</source>
-        <target>No defined value</target>
+        <target state="new">No defined value</target>
         <note>key: fielddefinition.media-player-type.undefined</note>
       </trans-unit>
       <trans-unit id="61d9fc8a2cbcb067d39496dba7e884caf51cf245" resname="fielddefinition.media-player-type.windows_media_player">
         <source>Window Media Player</source>
-        <target>Window Media Player</target>
+        <target state="new">Window Media Player</target>
         <note>key: fielddefinition.media-player-type.windows_media_player</note>
       </trans-unit>
       <trans-unit id="ee5c85f0dae011c10d9d2bfb1fcd86e529c55536" resname="fielddefinition.min-length.label">
         <source>Min string length:</source>
-        <target>Min string length:</target>
+        <target state="new">Min string length:</target>
         <note>key: fielddefinition.min-length.label</note>
       </trans-unit>
       <trans-unit id="09fff8d9a67512b01bb3e58b5d25cf5d042ba195" resname="fielddefinition.min-length.undefined">
         <source>No defined minimum string length</source>
-        <target>No defined minimum string length</target>
+        <target state="new">No defined minimum string length</target>
         <note>key: fielddefinition.min-length.undefined</note>
       </trans-unit>
       <trans-unit id="904a83f949dd73a0bed006f8e78a211c80b4816a" resname="fielddefinition.min-length.value">
         <source>%min% characters</source>
-        <target>%min% characters</target>
+        <target state="new">%min% characters</target>
         <note>key: fielddefinition.min-length.value</note>
       </trans-unit>
       <trans-unit id="1feb12108139bb4d34877c40ade8362c0872b528" resname="fielddefinition.min-value.label">
         <source>Minimum value:</source>
-        <target>Minimum value:</target>
+        <target state="new">Minimum value:</target>
         <note>key: fielddefinition.min-value.label</note>
       </trans-unit>
       <trans-unit id="625d3f00da19e0e839ad54eb5cc6b3504033b882" resname="fielddefinition.min-value.undefined">
         <source>No defined minimum value</source>
-        <target>No defined minimum value</target>
+        <target state="new">No defined minimum value</target>
         <note>key: fielddefinition.min-value.undefined</note>
       </trans-unit>
       <trans-unit id="694dc611591facca075a581721e399e272b758fe" resname="fielddefinition.multiple.label">
         <source>Allow multiple choices:</source>
-        <target>Allow multiple choices:</target>
+        <target state="new">Allow multiple choices:</target>
         <note>key: fielddefinition.multiple.label</note>
       </trans-unit>
       <trans-unit id="0b8ef090df7e5c7780364c51f060db3f5b8f076a" resname="fielddefinition.multiple.no">
         <source>No</source>
-        <target>No</target>
+        <target state="new">No</target>
         <note>key: fielddefinition.multiple.no</note>
       </trans-unit>
       <trans-unit id="ec31a6088a9e8cb3266bf0b99e057ca0677fcd82" resname="fielddefinition.multiple.yes">
         <source>Yes</source>
-        <target>Yes</target>
+        <target state="new">Yes</target>
         <note>key: fielddefinition.multiple.yes</note>
       </trans-unit>
       <trans-unit id="4d59776118124c81734aacab8a71198ee555479c" resname="fielddefinition.options.label">
         <source>Defined options</source>
-        <target>Defined options</target>
+        <target state="new">Defined options</target>
         <note>key: fielddefinition.options.label</note>
       </trans-unit>
       <trans-unit id="030aa959f56ae9ba0e1d84a99606995a02c5bd97" resname="fielddefinition.preferred-rows-number.label">
         <source>Preferred number of rows:</source>
-        <target>Preferred number of rows:</target>
+        <target state="new">Preferred number of rows:</target>
         <note>key: fielddefinition.preferred-rows-number.label</note>
       </trans-unit>
       <trans-unit id="f552c76a800b38e41d8b16afa53d3d22d3b37692" resname="fielddefinition.preferred-rows-number.undefined">
         <source>No preferred number of rows</source>
-        <target>No preferred number of rows</target>
+        <target state="new">No preferred number of rows</target>
         <note>key: fielddefinition.preferred-rows-number.undefined</note>
       </trans-unit>
       <trans-unit id="ac0aff5c558fb078621da0f46b2ae5b0e04afcaa" resname="fielddefinition.preferred-rows-number.value">
         <source>%rows% rows</source>
-        <target>%rows% rows</target>
+        <target state="new">%rows% rows</target>
         <note>key: fielddefinition.preferred-rows-number.value</note>
       </trans-unit>
       <trans-unit id="b21527196a76acac750d478bfe8137cae7aff914" resname="fielddefinition.selection-method.browse">
         <source>Browse</source>
-        <target>Browse</target>
+        <target state="new">Browse</target>
         <note>key: fielddefinition.selection-method.browse</note>
       </trans-unit>
       <trans-unit id="02c78e1886bdf844e359ddd54b190eb718286557" resname="fielddefinition.selection-method.checkbox">
         <source>List with checkboxes</source>
-        <target>List with checkboxes</target>
+        <target state="new">List with checkboxes</target>
         <note>key: fielddefinition.selection-method.checkbox</note>
       </trans-unit>
       <trans-unit id="a60c81e556aa14c00b3b44ffb6e49f90b882c286" resname="fielddefinition.selection-method.label">
         <source>Selection method:</source>
-        <target>Selection method:</target>
+        <target state="new">Selection method:</target>
         <note>key: fielddefinition.selection-method.label</note>
       </trans-unit>
       <trans-unit id="cd94d6146477b427bdc6dbbe19be20bd6db31542" resname="fielddefinition.selection-method.list">
         <source>Drop-down list</source>
-        <target>Drop-down list</target>
+        <target state="new">Drop-down list</target>
         <note>key: fielddefinition.selection-method.list</note>
       </trans-unit>
       <trans-unit id="7d8f219b8fc1dab2be8b6a82898b0e7a8920c928" resname="fielddefinition.selection-method.multi_template">
         <source>Template based, multi</source>
-        <target>Template based, multi</target>
+        <target state="new">Template based, multi</target>
         <note>key: fielddefinition.selection-method.multi_template</note>
       </trans-unit>
       <trans-unit id="1095b3a335cbfeed0e396f081895affe81e7b7fd" resname="fielddefinition.selection-method.multiple_list">
         <source>Multiple selection list</source>
-        <target>Multiple selection list</target>
+        <target state="new">Multiple selection list</target>
         <note>key: fielddefinition.selection-method.multiple_list</note>
       </trans-unit>
       <trans-unit id="60f06115f038572328285e2ca1fc5ad811105c49" resname="fielddefinition.selection-method.radio">
         <source>List with radio buttons</source>
-        <target>List with radio buttons</target>
+        <target state="new">List with radio buttons</target>
         <note>key: fielddefinition.selection-method.radio</note>
       </trans-unit>
       <trans-unit id="37121f3c9e8054432510a9f85fd3235e5f549734" resname="fielddefinition.selection-method.single_template">
         <source>Template based, single</source>
-        <target>Template based, single</target>
+        <target state="new">Template based, single</target>
         <note>key: fielddefinition.selection-method.single_template</note>
       </trans-unit>
       <trans-unit id="e0b6bc6950269d05c7318553912abe4042d6a423" resname="fielddefinition.selection-method.tree">
         <source>Drop-down tree</source>
-        <target>Drop-down tree</target>
+        <target state="new">Drop-down tree</target>
         <note>key: fielddefinition.selection-method.tree</note>
       </trans-unit>
       <trans-unit id="ccf4d68283a388e6a965caf9e507c6a39fffc46f" resname="fielddefinition.selection-root.label">
         <source>Selection root:</source>
-        <target>Selection root:</target>
+        <target state="new">Selection root:</target>
         <note>key: fielddefinition.selection-root.label</note>
       </trans-unit>
       <trans-unit id="c7b711d3eb6c197d83e064f309bd2e9791a0950d" resname="fielddefinition.selection-root.undefined">
         <source>No defined root</source>
-        <target>No defined root</target>
+        <target state="new">No defined root</target>
         <note>key: fielddefinition.selection-root.undefined</note>
       </trans-unit>
       <trans-unit id="4c9eb21a084528340d7944eeb0ffe525fc5e5e75" resname="fielddefinition.use-seconds.label">
         <source>Use seconds:</source>
-        <target>Use seconds:</target>
+        <target state="new">Use seconds:</target>
         <note>key: fielddefinition.use-seconds.label</note>
       </trans-unit>
       <trans-unit id="8c785cf266419d05f444b0e88bbf34f07c0b6fde" resname="fielddefinition.use-seconds.no">
         <source>No</source>
-        <target>No</target>
+        <target state="new">No</target>
         <note>key: fielddefinition.use-seconds.no</note>
       </trans-unit>
       <trans-unit id="edc26cd0186a48016fc5bc286c4d64e238043658" resname="fielddefinition.use-seconds.yes">
         <source>Yes</source>
-        <target>Yes</target>
+        <target state="new">Yes</target>
         <note>key: fielddefinition.use-seconds.yes</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/ibexa_fieldtypes.en.xlf
+++ b/src/bundle/Core/Resources/translations/ibexa_fieldtypes.en.xlf
@@ -8,117 +8,117 @@
     <body>
       <trans-unit id="06a34ac23ac86f7c4368380203e3dd4d91489fa0" resname="ezauthor.name">
         <source>Authors</source>
-        <target>Authors</target>
+        <target state="new">Authors</target>
         <note>key: ezauthor.name</note>
       </trans-unit>
       <trans-unit id="e4ca4a21a1e442e6a1232320b2184b9e4105c73f" resname="ezbinaryfile.name">
         <source>File</source>
-        <target>File</target>
+        <target state="new">File</target>
         <note>key: ezbinaryfile.name</note>
       </trans-unit>
       <trans-unit id="129dd46eabe280c49a0e9d424d9cbf676621aec9" resname="ezboolean.name">
         <source>Checkbox</source>
-        <target>Checkbox</target>
+        <target state="new">Checkbox</target>
         <note>key: ezboolean.name</note>
       </trans-unit>
       <trans-unit id="c4c3e3c536a09969467c7c9bb584459b47317fed" resname="ezcountry.name">
         <source>Country</source>
-        <target>Country</target>
+        <target state="new">Country</target>
         <note>key: ezcountry.name</note>
       </trans-unit>
       <trans-unit id="3bd547a05c5a7b5ee111cc5ca608df9199f04c51" resname="ezdate.name">
         <source>Date</source>
-        <target>Date</target>
+        <target state="new">Date</target>
         <note>key: ezdate.name</note>
       </trans-unit>
       <trans-unit id="42d9e26b6e8e65856f709461b589cb7925a9f43e" resname="ezdatetime.name">
         <source>Date and time</source>
-        <target>Date and time</target>
+        <target state="new">Date and time</target>
         <note>key: ezdatetime.name</note>
       </trans-unit>
       <trans-unit id="d772ac8909929964906cbefd41c468c9a5d2be26" resname="ezemail.name">
         <source>Email address</source>
-        <target>Email address</target>
+        <target state="new">Email address</target>
         <note>key: ezemail.name</note>
       </trans-unit>
       <trans-unit id="0a1f3297ccc08882f5a4610f9af8fc4148c74adc" resname="ezfloat.name">
         <source>Float</source>
-        <target>Float</target>
+        <target state="new">Float</target>
         <note>key: ezfloat.name</note>
       </trans-unit>
       <trans-unit id="fcabb29fdb097d916c88328daad461c1ea765121" resname="ezgmaplocation.name">
         <source>Map location</source>
-        <target>Map location</target>
+        <target state="new">Map location</target>
         <note>key: ezgmaplocation.name</note>
       </trans-unit>
       <trans-unit id="6300f890f00d9999466b4abc478857b0d29022b4" resname="ezimage.name">
         <source>Image</source>
-        <target>Image</target>
+        <target state="new">Image</target>
         <note>key: ezimage.name</note>
       </trans-unit>
       <trans-unit id="3afdca17c734ecb3a077bcc4ba7f75a7544e845d" resname="ezimageasset.name">
         <source>Image Asset</source>
-        <target>Image Asset</target>
+        <target state="new">Image Asset</target>
         <note>key: ezimageasset.name</note>
       </trans-unit>
       <trans-unit id="3b0f44cd332c71e78209a1a4b235bc6a1e6d374b" resname="ezinteger.name">
         <source>Integer</source>
-        <target>Integer</target>
+        <target state="new">Integer</target>
         <note>key: ezinteger.name</note>
       </trans-unit>
       <trans-unit id="b55e4568224820cbddc794f6c2bd002baec6a5d0" resname="ezisbn.name">
         <source>ISBN</source>
-        <target>ISBN</target>
+        <target state="new">ISBN</target>
         <note>key: ezisbn.name</note>
       </trans-unit>
       <trans-unit id="c564457bc5723491788fa3d0723e3716824b4a0d" resname="ezkeyword.name">
         <source>Keywords</source>
-        <target>Keywords</target>
+        <target state="new">Keywords</target>
         <note>key: ezkeyword.name</note>
       </trans-unit>
       <trans-unit id="fc0d2c8719e7c36f101ff6ddcbdfc804bf8f3da7" resname="ezmedia.name">
         <source>Media</source>
-        <target>Media</target>
+        <target state="new">Media</target>
         <note>key: ezmedia.name</note>
       </trans-unit>
       <trans-unit id="feb25b24199466f077038c5e6e38209deae21471" resname="ezobjectrelation.name">
         <source>Content relation (single)</source>
-        <target>Content relation (single)</target>
+        <target state="new">Content relation (single)</target>
         <note>key: ezobjectrelation.name</note>
       </trans-unit>
       <trans-unit id="44d2ac9ae83f6b73fa8f61fad66a77d76d2159f0" resname="ezobjectrelationlist.name">
         <source>Content relations (multiple)</source>
-        <target>Content relations (multiple)</target>
+        <target state="new">Content relations (multiple)</target>
         <note>key: ezobjectrelationlist.name</note>
       </trans-unit>
       <trans-unit id="3229c3fc41a4af84f0fd1636f0678aac770359bc" resname="ezselection.name">
         <source>Selection</source>
-        <target>Selection</target>
+        <target state="new">Selection</target>
         <note>key: ezselection.name</note>
       </trans-unit>
       <trans-unit id="d958019d9702d5e89f247c24563da97ea0205f58" resname="ezstring.name">
         <source>Text line</source>
-        <target>Text line</target>
+        <target state="new">Text line</target>
         <note>key: ezstring.name</note>
       </trans-unit>
       <trans-unit id="e35280b88546fdd18c84ce9c401e17cbfca56e72" resname="eztext.name">
         <source>Text block</source>
-        <target>Text block</target>
+        <target state="new">Text block</target>
         <note>key: eztext.name</note>
       </trans-unit>
       <trans-unit id="503c2801427b2d773d020ef953413d14c17968bd" resname="eztime.name">
         <source>Time</source>
-        <target>Time</target>
+        <target state="new">Time</target>
         <note>key: eztime.name</note>
       </trans-unit>
       <trans-unit id="69c0e446226061b7f2ca2b22fd4eb09e6b4e9518" resname="ezurl.name">
         <source>URL</source>
-        <target>URL</target>
+        <target state="new">URL</target>
         <note>key: ezurl.name</note>
       </trans-unit>
       <trans-unit id="0317c233c19b3c191acc92971bfb616c7fe298de" resname="ezuser.name">
         <source>User account</source>
-        <target>User account</target>
+        <target state="new">User account</target>
         <note>key: ezuser.name</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/ibexa_repository_exceptions.en.xlf
+++ b/src/bundle/Core/Resources/translations/ibexa_repository_exceptions.en.xlf
@@ -8,137 +8,137 @@
     <body>
       <trans-unit id="bdaae3444afba4eebebe2e0f684a0e56e81afafd" resname="'%actualValue%' is incorrect value">
         <source>'%actualValue%' is incorrect value</source>
-        <target>'%actualValue%' is incorrect value</target>
+        <target state="new">'%actualValue%' is incorrect value</target>
         <note>key: '%actualValue%' is incorrect value</note>
       </trans-unit>
       <trans-unit id="4769b7caf9489fa7d54ca298414c0f10a5f43a56" resname="'%actualValue%' is incorrect value in class '%className%'">
         <source>'%actualValue%' is incorrect value in class '%className%'</source>
-        <target>'%actualValue%' is incorrect value in class '%className%'</target>
+        <target state="new">'%actualValue%' is incorrect value in class '%className%'</target>
         <note>key: '%actualValue%' is incorrect value in class '%className%'</note>
       </trans-unit>
       <trans-unit id="80e5a0a47ac1df407b0218c2283872a86aba0fc1" resname="Argument '%argumentName%' has a bad state: %whatIsWrong%">
         <source>Argument '%argumentName%' has a bad state: %whatIsWrong%</source>
-        <target>Argument '%argumentName%' has a bad state: %whatIsWrong%</target>
+        <target state="new">Argument '%argumentName%' has a bad state: %whatIsWrong%</target>
         <note>key: Argument '%argumentName%' has a bad state: %whatIsWrong%</note>
       </trans-unit>
       <trans-unit id="ec22a1547bcd0b3131346b94db7783d8ba4fc12f" resname="Argument '%argumentName%' is invalid: %whatIsWrong%">
         <source>Argument '%argumentName%' is invalid: %whatIsWrong%</source>
-        <target>Argument '%argumentName%' is invalid: %whatIsWrong%</target>
+        <target state="new">Argument '%argumentName%' is invalid: %whatIsWrong%</target>
         <note>key: Argument '%argumentName%' is invalid: %whatIsWrong%</note>
       </trans-unit>
       <trans-unit id="ddc2eb42746874988689fbc618bce5487f245b5c" resname="Argument '%argumentName%' is invalid: value must be of type '%expectedType%'">
         <source>Argument '%argumentName%' is invalid: value must be of type '%expectedType%'</source>
-        <target>Argument '%argumentName%' is invalid: value must be of type '%expectedType%'</target>
+        <target state="new">Argument '%argumentName%' is invalid: value must be of type '%expectedType%'</target>
         <note>key: Argument '%argumentName%' is invalid: value must be of type '%expectedType%'</note>
       </trans-unit>
       <trans-unit id="ea737c09fcf59eb54ff1a1caca4242bdb2afda03" resname="Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'">
         <source>Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'</source>
-        <target>Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'</target>
+        <target state="new">Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'</target>
         <note>key: Argument '%argumentName%' is invalid: value must be of type '%expectedType%', not '%actualType%'</note>
       </trans-unit>
       <trans-unit id="6a5a5e4df0f09cc7587d11571aa90c31e68c15c6" resname="Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'">
         <source>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'</source>
-        <target>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'</target>
+        <target state="new">Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'</target>
         <note>key: Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, binary file ids can not begin with a '/'</note>
       </trans-unit>
       <trans-unit id="0afe736d44da00b87ed3fe777775661ddf10a455" resname="Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?">
         <source>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?</source>
-        <target>Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?</target>
+        <target state="new">Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?</target>
         <note>key: Argument 'BinaryFile::id' is invalid: '%id%' is wrong value, it does not contain prefix '%prefix%'. Is 'var_dir' config correct?</note>
       </trans-unit>
       <trans-unit id="e88ed78511f95299a41927e3ca7336fed174046b" resname="Content &quot;%contentName%&quot; fields did not validate: %errors%">
         <source>Content "%contentName%" fields did not validate: %errors%</source>
-        <target>Content "%contentName%" fields did not validate: %errors%</target>
+        <target state="new">Content "%contentName%" fields did not validate: %errors%</target>
         <note>key: Content "%contentName%" fields did not validate: %errors%</note>
       </trans-unit>
       <trans-unit id="8967aa151e1b84f60c505163d42350eb6a96e948" resname="Content fields did not validate">
         <source>Content fields did not validate</source>
-        <target>Content fields did not validate</target>
+        <target state="new">Content fields did not validate</target>
         <note>key: Content fields did not validate</note>
       </trans-unit>
       <trans-unit id="8f64e46d8c92143a1a8fde9790a6a2423759a0ce" resname="Content type field definitions did not validate">
         <source>Content type field definitions did not validate</source>
-        <target>Content type field definitions did not validate</target>
+        <target state="new">Content type field definitions did not validate</target>
         <note>key: Content type field definitions did not validate</note>
       </trans-unit>
       <trans-unit id="dbf0b883e33a6e7c433ffa9a536fd214cda39b5c" resname="Could not find %classType% class '%className%'">
         <source>Could not find %classType% class '%className%'</source>
-        <target>Could not find %classType% class '%className%'</target>
+        <target state="new">Could not find %classType% class '%className%'</target>
         <note>key: Could not find %classType% class '%className%'</note>
       </trans-unit>
       <trans-unit id="ff3e1dacaa764a0e94a86b173f9c93509fcaadeb" resname="Could not find '%what%' with identifier '%identifier%'">
         <source>Could not find '%what%' with identifier '%identifier%'</source>
-        <target>Could not find '%what%' with identifier '%identifier%'</target>
+        <target state="new">Could not find '%what%' with identifier '%identifier%'</target>
         <note>key: Could not find '%what%' with identifier '%identifier%'</note>
       </trans-unit>
       <trans-unit id="2b84fad03f5a98d0fa25c78b1d3717ba108835e6" resname="Could not find class '%className%'">
         <source>Could not find class '%className%'</source>
-        <target>Could not find class '%className%'</target>
+        <target state="new">Could not find class '%className%'</target>
         <note>key: Could not find class '%className%'</note>
       </trans-unit>
       <trans-unit id="c6136a74d1562ea6d15321ee75b9b307fc787e79" resname="Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%">
         <source>Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%</source>
-        <target>Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%</target>
+        <target state="new">Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%</target>
         <note>key: Field Type '%fieldType%' not found. It must be implemented or configured to use %nullType%</note>
       </trans-unit>
       <trans-unit id="5dc8e460be7495d772cdb7bc4d4bd2913e480273" resname="Field definition '%identifier%' does not exist in given content type">
         <source>Field definition '%identifier%' does not exist in given content type</source>
-        <target>Field definition '%identifier%' does not exist in given content type</target>
+        <target state="new">Field definition '%identifier%' does not exist in given content type</target>
         <note>key: Field definition '%identifier%' does not exist in given content type</note>
       </trans-unit>
       <trans-unit id="1469ef88c3de1616907207891c1611a07459534a" resname="Field definition '%identifier%' does not exist in the given content type">
         <source>Field definition '%identifier%' does not exist in the given content type</source>
-        <target>Field definition '%identifier%' does not exist in the given content type</target>
+        <target state="new">Field definition '%identifier%' does not exist in the given content type</target>
         <note>key: Field definition '%identifier%' does not exist in the given content type</note>
       </trans-unit>
       <trans-unit id="c6f0fd742d6b8ce0686dc4e7a3a070efbf924204" resname="Invalid URL wildcards provided.">
         <source>Invalid URL wildcards provided.</source>
-        <target>Invalid URL wildcards provided.</target>
+        <target state="new">Invalid URL wildcards provided.</target>
         <note>key: Invalid URL wildcards provided.</note>
       </trans-unit>
       <trans-unit id="87d1caa3303a7197201d77b1bcb03ae38356097b" resname="Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%">
         <source>Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</source>
-        <target>Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</target>
+        <target state="new">Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</target>
         <note>key: Limitation '%limitation%' not found. It must be implemented or configured to use %blockingLimitation%</note>
       </trans-unit>
       <trans-unit id="71fd5f8839faaadfe7c61def7e4b42d429959952" resname="Limitations did not validate">
         <source>Limitations did not validate</source>
-        <target>Limitations did not validate</target>
+        <target state="new">Limitations did not validate</target>
         <note>key: Limitations did not validate</note>
       </trans-unit>
       <trans-unit id="ef12e750e94380df0d1de86b1cc274b45dc94e94" resname="Path '%path%' already exists for the given context">
         <source>Path '%path%' already exists for the given context</source>
-        <target>Path '%path%' already exists for the given context</target>
+        <target state="new">Path '%path%' already exists for the given context</target>
         <note>key: Path '%path%' already exists for the given context</note>
       </trans-unit>
       <trans-unit id="300b5656b51de352e89aa5d7dd4ec6abb173bf6f" resname="Placeholders do not match the wildcards.">
         <source>Placeholders do not match the wildcards.</source>
-        <target>Placeholders do not match the wildcards.</target>
+        <target state="new">Placeholders do not match the wildcards.</target>
         <note>key: Placeholders do not match the wildcards.</note>
       </trans-unit>
       <trans-unit id="1677f5311a0f3fc35be40d540553e892d187618e" resname="The User does not have the '%function%' '%module%' permission">
         <source>The User does not have the '%function%' '%module%' permission</source>
-        <target>The User does not have the '%function%' '%module%' permission</target>
+        <target state="new">The User does not have the '%function%' '%module%' permission</target>
         <note>key: The User does not have the '%function%' '%module%' permission</note>
       </trans-unit>
       <trans-unit id="250a16261172f0d2985c8bec3a2b06280f7c863b" resname="The User does not have the '%function%' '%module%' permission with: %with%">
         <source>The User does not have the '%function%' '%module%' permission with: %with%</source>
-        <target>The User does not have the '%function%' '%module%' permission with: %with%</target>
+        <target state="new">The User does not have the '%function%' '%module%' permission with: %with%</target>
         <note>key: The User does not have the '%function%' '%module%' permission with: %with%</note>
       </trans-unit>
       <trans-unit id="3b2e044f9c9821aef27834972d90f59f28b1a0b4" resname="Token '%tokenType%:%token%' expired on '%when%'">
         <source>Token '%tokenType%:%token%' expired on '%when%'</source>
-        <target>Token '%tokenType%:%token%' expired on '%when%'</target>
+        <target state="new">Token '%tokenType%:%token%' expired on '%when%'</target>
         <note>key: Token '%tokenType%:%token%' expired on '%when%'</note>
       </trans-unit>
       <trans-unit id="27a77deaffe8551b169928675adc64ae8450937f" resname="User &quot;%login%&quot; already exists">
         <source>User "%login%" already exists</source>
-        <target>User "%login%" already exists</target>
+        <target state="new">User "%login%" already exists</target>
         <note>key: User "%login%" already exists</note>
       </trans-unit>
       <trans-unit id="e37bafa4a8807f7a425f8d967cadc8e704c629b3" resname="You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'">
         <source>You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'</source>
-        <target>You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'</target>
+        <target state="new">You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'</target>
         <note>key: You cannot set a value for the non-translatable Field definition '%identifier%' in language '%languageCode%'</note>
       </trans-unit>
     </body>

--- a/src/bundle/Core/Resources/translations/messages.en.xlf
+++ b/src/bundle/Core/Resources/translations/messages.en.xlf
@@ -8,27 +8,27 @@
     <body>
       <trans-unit id="e2b8dff16cf1b8ad7848630c4d7c42cc31ac5e21" resname="Enter login or email">
         <source>Enter login or email</source>
-        <target>Enter login or email</target>
+        <target state="new">Enter login or email</target>
         <note>key: Enter login or email</note>
       </trans-unit>
       <trans-unit id="570591c060a999e9ab1592763c74d881b7654ee1" resname="Enter password">
         <source>Enter password</source>
-        <target>Enter password</target>
+        <target state="new">Enter password</target>
         <note>key: Enter password</note>
       </trans-unit>
       <trans-unit id="4e5a2893bdcc7d239c1db72e4c4ffbe4bea73174" resname="Login">
         <source>Login</source>
-        <target>Login</target>
+        <target state="new">Login</target>
         <note>key: Login</note>
       </trans-unit>
       <trans-unit id="be81ab98cb9ccf753975f50fa70cd32581a821fc" resname="Password:">
         <source>Password:</source>
-        <target>Password:</target>
+        <target state="new">Password:</target>
         <note>key: Password:</note>
       </trans-unit>
       <trans-unit id="17dfb031e086e3415d71f3928e6ce08d6b1c1d4d" resname="Username:">
         <source>Username:</source>
-        <target>Username:</target>
+        <target state="new">Username:</target>
         <note>key: Username:</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXXX](https://issues.ibexa.co/browse/IBX-XXXXX)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

Added missing `state="new"` attribute to translation target elements. The JMS extractor adds this attribute automatically — it was missing because these files had not been re-extracted since the attribute was introduced.

Without this change, every run of the translation extractor would produce a noisy diff trying to add `state="new"` to all affected entries.