### PR TITLE
IBX-11959: Added message template accessors to Translation value objects

### DIFF
--- a/src/contracts/Repository/Values/Translation.php
+++ b/src/contracts/Repository/Values/Translation.php
@@ -18,4 +18,13 @@ use Stringable;
  */
 abstract class Translation extends ValueObject implements Stringable
 {
+    /**
+     * The message template to translate, with %placeholder% parameters.
+     */
+    abstract public function getMessageTemplate(): string;
+
+    /**
+     * @return array<string, scalar|null>
+     */
+    abstract public function getValues(): array;
 }

--- a/src/contracts/Repository/Values/Translation/Message.php
+++ b/src/contracts/Repository/Values/Translation/Message.php
@@ -47,6 +47,16 @@ class Message extends Translation
         parent::__construct();
     }
 
+    public function getMessageTemplate(): string
+    {
+        return $this->message;
+    }
+
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
     #[\Override]
     public function __toString(): string
     {

--- a/src/contracts/Repository/Values/Translation/Plural.php
+++ b/src/contracts/Repository/Values/Translation/Plural.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Contracts\Core\Repository\Values\Translation;
 
 use Ibexa\Contracts\Core\Repository\Values\Translation;
+use Override;
 
 /**
  * Class for translatable messages, which may contain plural forms.
@@ -68,7 +69,17 @@ class Plural extends Translation
         parent::__construct();
     }
 
-    #[\Override]
+    public function getMessageTemplate(): string
+    {
+        return $this->plural;
+    }
+
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    #[Override]
     public function __toString(): string
     {
         $firstValue = !empty($this->values) ? current(array_values($this->values)) : null;

--- a/tests/lib/Repository/Values/Translation/MessageTest.php
+++ b/tests/lib/Repository/Values/Translation/MessageTest.php
@@ -17,44 +17,56 @@ use PHPUnit\Framework\TestCase;
 final class MessageTest extends TestCase
 {
     /**
-     * @dataProvider getDataForTestStringable
+     * @dataProvider getDataForTestMessage
+     *
+     * @param array<string, scalar|null> $values
      */
-    public function testStringable(Message $message, string $expectedString): void
-    {
-        self::assertSame($expectedString, (string)$message);
+    public function testStringable(
+        string $message,
+        array $values,
+        string $expectedString
+    ): void {
+        self::assertSame($expectedString, (string)new Message($message, $values));
     }
 
     /**
-     * @return iterable<string, array{\Ibexa\Contracts\Core\Repository\Values\Translation\Message, string}>
+     * @dataProvider getDataForTestMessage
+     *
+     * @param array<string, scalar|null> $values
      */
-    public static function getDataForTestStringable(): iterable
+    public function testGetters(string $message, array $values): void
+    {
+        $translation = new Message($message, $values);
+
+        self::assertSame($message, $translation->getMessageTemplate());
+        self::assertSame($values, $translation->getValues());
+    }
+
+    /**
+     * @return iterable<string, array{string, array<string, scalar|null>, string}>
+     */
+    public static function getDataForTestMessage(): iterable
     {
         yield 'message with substitution values' => [
-            new Message(
-                'Anna has some oranges in %object%',
-                [
-                    '%object%' => 'a basket',
-                ]
-            ),
+            'Anna has some oranges in %object%',
+            [
+                '%object%' => 'a basket',
+            ],
             'Anna has some oranges in a basket',
         ];
 
         yield 'message with multiple substitution values' => [
-            new Message(
-                '%first_name% has some data in %storage_type%',
-                [
-                    '%first_name%' => 'Anna',
-                    '%storage_type%' => 'her database',
-                ]
-            ),
+            '%first_name% has some data in %storage_type%',
+            [
+                '%first_name%' => 'Anna',
+                '%storage_type%' => 'her database',
+            ],
             'Anna has some data in her database',
         ];
 
         yield 'message with no substitution values' => [
-            new Message(
-                'This value is not correct',
-                []
-            ),
+            'This value is not correct',
+            [],
             'This value is not correct',
         ];
     }

--- a/tests/lib/Repository/Values/Translation/PluralTest.php
+++ b/tests/lib/Repository/Values/Translation/PluralTest.php
@@ -17,46 +17,62 @@ use PHPUnit\Framework\TestCase;
 final class PluralTest extends TestCase
 {
     /**
-     * @dataProvider getDataForTestStringable
+     * @dataProvider getDataForTestPlural
+     *
+     * @param array<string, scalar|null> $values
      */
-    public function testStringable(Plural $message, string $expectedString): void
-    {
-        self::assertSame($expectedString, (string)$message);
+    public function testStringable(
+        string $singular,
+        string $plural,
+        array $values,
+        string $expectedString
+    ): void {
+        self::assertSame($expectedString, (string)new Plural($singular, $plural, $values));
     }
 
     /**
-     * @return iterable<string, array{\Ibexa\Contracts\Core\Repository\Values\Translation\Plural, string}>
+     * @dataProvider getDataForTestPlural
+     *
+     * @param array<string, scalar|null> $values
      */
-    public static function getDataForTestStringable(): iterable
+    public function testGetters(
+        string $singular,
+        string $plural,
+        array $values
+    ): void {
+        $translation = new Plural($singular, $plural, $values);
+
+        self::assertSame($plural, $translation->getMessageTemplate());
+        self::assertSame($values, $translation->getValues());
+    }
+
+    /**
+     * @return iterable<string, array{string, string, array<string, scalar|null>, string}>
+     */
+    public static function getDataForTestPlural(): iterable
     {
         yield 'singular form' => [
-            new Plural(
-                'John has %apple_count% apple',
-                'John has %apple_count% apples',
-                [
-                    '%apple_count%' => 1,
-                ]
-            ),
+            'John has %apple_count% apple',
+            'John has %apple_count% apples',
+            [
+                '%apple_count%' => 1,
+            ],
             'John has 1 apple',
         ];
 
         yield 'plural form' => [
-            new Plural(
-                'John has %apple_count% apple',
-                'John has %apple_count% apples',
-                [
-                    '%apple_count%' => 2,
-                ]
-            ),
+            'John has %apple_count% apple',
+            'John has %apple_count% apples',
+            [
+                '%apple_count%' => 2,
+            ],
             'John has 2 apples',
         ];
 
         yield 'no substitution values' => [
-            new Plural(
-                'John has some apples',
-                'John has a lot of apples',
-                []
-            ),
+            'John has some apples',
+            'John has a lot of apples',
+            [],
             'John has a lot of apples',
         ];
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-11959 |
|----------------|-----------|

#### Description:
Added a shared contract to the `Translation` base class: `getMessageTemplate()` + `getValues()`, implemented by `Message` and `Plural`. Consumers no longer need to distinguish the two or rely on magic `ValueObject::__get` property access.

Needed by the follow-up `ibexa/user` PR for IBX-11959 (https://github.com/ibexa/user/pull/132). No behavior change.

#### For QA:
No user-facing change, covered by unit tests. End-to-end QA on the `ibexa/user` PR.

#### Documentation:
For 6.0.0 release notes: new abstract methods `getMessageTemplate()` and `getValues()` on `Ibexa\Contracts\Core\Repository\Values\Translation` — third-party subclasses must implement them.
