### PR TITLE
IBX-12192: Added SiteAccess::MATCHING_TYPE_UNINITIALIZED constant

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15295,18 +15295,6 @@ parameters:
 			path: src/lib/MVC/Symfony/SiteAccess/SiteAccessProviderInterface.php
 
 		-
-			message: '#^Property Ibexa\\Core\\MVC\\Symfony\\SiteAccess\\SiteAccessService\:\:\$siteAccess \(Ibexa\\Core\\MVC\\Symfony\\SiteAccess\) does not accept Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
-
-		-
-			message: '#^Property Ibexa\\Core\\MVC\\Symfony\\SiteAccess\\SiteAccessService\:\:\$siteAccess \(Ibexa\\Core\\MVC\\Symfony\\SiteAccess\) on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.property
-			count: 1
-			path: src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
-
-		-
 			message: '#^Method Ibexa\\Core\\MVC\\Symfony\\Templating\\Exception\\InvalidResponseException\:\:addParameter\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
+++ b/src/bundle/Core/DependencyInjection/Configuration/ConfigResolver.php
@@ -222,7 +222,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
         $this->defaultScope = $scope;
 
         // On scope change check if siteaccess has been updated so we can log warnings if there are any
-        if ($this->siteAccess->matchingType !== 'uninitialized') {
+        if ($this->siteAccess->matchingType !== SiteAccess::MATCHING_TYPE_UNINITIALIZED) {
             $this->warnAboutTooEarlyLoadedParams();
         }
     }
@@ -259,7 +259,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
             return;
         }
 
-        if ($this->siteAccess->matchingType !== 'uninitialized') {
+        if ($this->siteAccess->matchingType !== SiteAccess::MATCHING_TYPE_UNINITIALIZED) {
             return;
         }
 

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
     # Siteaccess is injected in the container at runtime
     Ibexa\Core\MVC\Symfony\SiteAccess:
         class: Ibexa\Core\MVC\Symfony\SiteAccess
-        arguments: ['%ibexa.site_access.default.name%', 'uninitialized']
+        arguments: ['%ibexa.site_access.default.name%', !php/const Ibexa\Core\MVC\Symfony\SiteAccess::MATCHING_TYPE_UNINITIALIZED]
 
     Ibexa\Bundle\Core\DependencyInjection\Configuration\ConfigResolver\DefaultScopeConfigResolver:
         arguments:
@@ -392,4 +392,3 @@ services:
         decoration_priority: 500
         arguments:
             $inner: '@.inner'
-

--- a/src/lib/MVC/Symfony/SiteAccess.php
+++ b/src/lib/MVC/Symfony/SiteAccess.php
@@ -16,6 +16,8 @@ class SiteAccess extends ValueObject implements JsonSerializable
 {
     public const DEFAULT_MATCHING_TYPE = 'default';
 
+    public const MATCHING_TYPE_UNINITIALIZED = 'uninitialized';
+
     /**
      * Name of the siteaccess.
      *

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -17,7 +17,7 @@ class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
 {
     private SiteAccessProviderInterface $provider;
 
-    private SiteAccess $siteAccess;
+    private ?SiteAccess $siteAccess = null;
 
     private ConfigResolverInterface $configResolver;
 

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -15,14 +15,11 @@ use function iterator_to_array;
 
 class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
 {
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface */
-    private $provider;
+    private SiteAccessProviderInterface $provider;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
-    private $siteAccess;
+    private SiteAccess $siteAccess;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(
         SiteAccessProviderInterface $provider,

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Core\MVC\Symfony\SiteAccess;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use function iterator_to_array;
@@ -61,6 +62,10 @@ class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
     public function getSiteAccessesRelation(?SiteAccess $siteAccess = null): array
     {
         $siteAccess = $siteAccess ?? $this->siteAccess;
+        if ($siteAccess === null) {
+            throw new InvalidArgumentException('siteAccess', 'no SiteAccess given and none currently set');
+        }
+
         $saRelationMap = [];
 
         /** @var \Ibexa\Core\MVC\Symfony\SiteAccess[] $saList */

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessServiceInterface.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessServiceInterface.php
@@ -33,6 +33,8 @@ interface SiteAccessServiceInterface
      * Handles relation between SiteAccesses. Related SiteAccesses share the same repository and root location id.
      *
      * @return string[]
+     *
+     * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException if no SiteAccess is given and none is currently set
      */
     public function getSiteAccessesRelation(?SiteAccess $siteAccess = null): array;
 }

--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -70,7 +70,7 @@ services:
 
     Ibexa\Core\MVC\Symfony\SiteAccess:
         class: Ibexa\Core\MVC\Symfony\SiteAccess
-        arguments: ['default', 'uninitialized']
+        arguments: ['default', !php/const Ibexa\Core\MVC\Symfony\SiteAccess::MATCHING_TYPE_UNINITIALIZED]
 
     Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService:
         class: Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService


### PR DESCRIPTION
| :ticket: Issue | [IBX-12192](https://ibexa.atlassian.net/browse/IBX-12192) |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/messenger/pull/27

#### Description:
`SiteAccess::$matchingType` uses the magic string `'uninitialized'` in a couple of places (`ConfigResolver`'s scope-change checks, and the service wiring for the placeholder `SiteAccess` instance) as the sentinel for "this SiteAccess was never actually matched from a request." Added `SiteAccess::MATCHING_TYPE_UNINITIALIZED` so that check has a name instead of a repeated literal, and so other packages can compare against it without hardcoding the string.

Also fixed `SiteAccessService::$siteAccess` — it got typed as non-nullable `SiteAccess` in the same pass, but `setSiteAccess()` still accepts and assigns `null`, so that threw a `TypeError` (caught by `SiteAccessServiceTest::testGetCurrentSiteAccess`). Made it `?SiteAccess` again.

This unblocks the `ibexa/messenger` fix above, which needs to detect an uninitialized SiteAccess to avoid stamping console-dispatched messages with a bogus SiteAccess name.


[IBX-12192]: https://ibexa.atlassian.net/browse/IBX-12192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ