### PR TITLE
IBX-12204: SiteAccessService owns a scope-change stack, SiteAccessAware deprecated

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,11 @@
+{
+    "recipesEndpoint": "",
+    "packages": [
+        {
+            "requirement": "dev-IBX-12204-siteaccessservice-scope-stack as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/behat.git",
+            "package": "ibexa/behat",
+            "shouldBeAddedAsVCS": false
+        }
+    ]
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1609,18 +1609,6 @@ parameters:
 			path: src/bundle/Core/EventListener/ConfigScopeListener.php
 
 		-
-			message: '#^Cannot access property \$matchingType on Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: src/bundle/Core/EventListener/ConsoleCommandListener.php
-
-		-
-			message: '#^Cannot access property \$name on Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null\.$#'
-			identifier: property.nonObject
-			count: 3
-			path: src/bundle/Core/EventListener/ConsoleCommandListener.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\Core\\EventListener\\ConsoleCommandListener\:\:onConsoleCommand\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1635,18 +1623,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Bundle\\Core\\EventListener\\ConsoleCommandListener\:\:setDebug\(\) has parameter \$debug with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: src/bundle/Core/EventListener/ConsoleCommandListener.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\EventListener\\ConsoleCommandListener\:\:setSiteAccess\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/EventListener/ConsoleCommandListener.php
-
-		-
-			message: '#^Parameter \#1 \$siteAccess of class Ibexa\\Core\\MVC\\Symfony\\Event\\ScopeChangeEvent constructor expects Ibexa\\Core\\MVC\\Symfony\\SiteAccess, Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/bundle/Core/EventListener/ConsoleCommandListener.php
 
@@ -2983,12 +2959,6 @@ parameters:
 			path: src/bundle/Core/Fragment/InlineFragmentRenderer.php
 
 		-
-			message: '#^Property Ibexa\\Bundle\\Core\\Fragment\\InlineFragmentRenderer\:\:\$siteAccess is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/bundle/Core/Fragment/InlineFragmentRenderer.php
-
-		-
 			message: '#^Trait Ibexa\\Bundle\\Core\\Fragment\\SiteAccessSerializationTrait is used zero times and is not analysed\.$#'
 			identifier: trait.unused
 			count: 1
@@ -3034,24 +3004,6 @@ parameters:
 			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\Cache\\AliasGeneratorDecorator\:\:getVariation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\Core\\Imagine\\Cache\\AliasGeneratorDecorator\:\:setSiteAccess\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
-
-		-
-			message: '#^Property Ibexa\\Bundle\\Core\\Imagine\\Cache\\AliasGeneratorDecorator\:\:\$siteAccess \(Ibexa\\Core\\MVC\\Symfony\\SiteAccess\) does not accept Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
-
-		-
-			message: '#^Property Ibexa\\Core\\MVC\\Symfony\\SiteAccess\:\:\$name \(string\) on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.property
-			count: 2
 			path: src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
 
 		-
@@ -3407,12 +3359,6 @@ parameters:
 			identifier: class.extendsFinalByPhpDoc
 			count: 1
 			path: src/bundle/Core/Routing/DefaultRouter.php
-
-		-
-			message: '#^Cannot access property \$name on Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: src/bundle/Core/SiteAccess/Config/ComplexConfigProcessor.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\Core\\SiteAccess\\Matcher\:\:setMatchingConfiguration\(\) has no return type specified\.$#'
@@ -7359,18 +7305,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Core\\Helper\\ContentPreviewHelper\:\:setPreviewedLocation\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/lib/Helper/ContentPreviewHelper.php
-
-		-
-			message: '#^Method Ibexa\\Core\\Helper\\ContentPreviewHelper\:\:setSiteAccess\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Helper/ContentPreviewHelper.php
-
-		-
-			message: '#^Property Ibexa\\Core\\Helper\\ContentPreviewHelper\:\:\$originalSiteAccess \(Ibexa\\Core\\MVC\\Symfony\\SiteAccess\) does not accept Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: src/lib/Helper/ContentPreviewHelper.php
 

--- a/src/bundle/Core/Command/DebugConfigResolverCommand.php
+++ b/src/bundle/Core/Command/DebugConfigResolverCommand.php
@@ -8,7 +8,7 @@
 namespace Ibexa\Bundle\Core\Command;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
-use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -28,15 +28,14 @@ class DebugConfigResolverCommand extends Command
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
     private $configResolver;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
-    private $siteAccess;
+    private SiteAccessServiceInterface $siteAccessService;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
-        SiteAccess $siteAccess
+        SiteAccessServiceInterface $siteAccessService
     ) {
         $this->configResolver = $configResolver;
-        $this->siteAccess = $siteAccess;
+        $this->siteAccessService = $siteAccessService;
 
         parent::__construct();
     }
@@ -102,7 +101,8 @@ EOM
             return self::SUCCESS;
         }
 
-        $output->writeln('<comment>SiteAccess name:</comment> ' . $this->siteAccess->name);
+        $siteAccess = $this->siteAccessService->getCurrent();
+        $output->writeln('<comment>SiteAccess name:</comment> ' . ($siteAccess !== null ? $siteAccess->name : ''));
 
         $output->writeln('<comment>Parameter:</comment>');
         $cloner = new VarCloner();

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
@@ -28,7 +28,7 @@ class ChainRoutingPass implements CompilerPassInterface
         // The default router will be given the highest priority so that it will be used by default
         if ($container->hasDefinition('router.default')) {
             $defaultRouter = $container->getDefinition('router.default');
-            $defaultRouter->addMethodCall('setSiteAccessService', [new Reference(SiteAccessServiceInterface::class)]);
+            $defaultRouter->setArgument('$siteAccessService', new Reference(SiteAccessServiceInterface::class));
             $defaultRouter->addMethodCall('setConfigResolver', [new Reference('ibexa.config.resolver')]);
             $defaultRouter->addMethodCall(
                 'setNonSiteAccessAwareRoutes',

--- a/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/ChainRoutingPass.php
@@ -8,8 +8,8 @@
 namespace Ibexa\Bundle\Core\DependencyInjection\Compiler;
 
 use Ibexa\Core\MVC\Symfony\Routing\ChainRouter;
-use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -28,7 +28,7 @@ class ChainRoutingPass implements CompilerPassInterface
         // The default router will be given the highest priority so that it will be used by default
         if ($container->hasDefinition('router.default')) {
             $defaultRouter = $container->getDefinition('router.default');
-            $defaultRouter->addMethodCall('setSiteAccess', [new Reference(SiteAccess::class)]);
+            $defaultRouter->addMethodCall('setSiteAccessService', [new Reference(SiteAccessServiceInterface::class)]);
             $defaultRouter->addMethodCall('setConfigResolver', [new Reference('ibexa.config.resolver')]);
             $defaultRouter->addMethodCall(
                 'setNonSiteAccessAwareRoutes',

--- a/src/bundle/Core/DependencyInjection/Compiler/FragmentPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/FragmentPass.php
@@ -11,6 +11,7 @@ use Ibexa\Bundle\Core\Fragment\DecoratedFragmentRenderer;
 use Ibexa\Bundle\Core\Fragment\FragmentListenerFactory;
 use Ibexa\Bundle\Core\Fragment\InlineFragmentRenderer;
 use Ibexa\Bundle\Core\Fragment\SiteAccessSerializerInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -49,10 +50,16 @@ class FragmentPass implements CompilerPassInterface
             $container->setDefinition($renamedId, $definition);
 
             $decoratedDef = new ChildDefinition(DecoratedFragmentRenderer::class);
-            $decoratedDef->setArguments([new Reference($renamedId), new Reference(SiteAccessSerializerInterface::class)]);
+            $decoratedDef->setArguments([
+                new Reference($renamedId),
+                new Reference(SiteAccessSerializerInterface::class),
+                new Reference(SiteAccessServiceInterface::class),
+            ]);
             $decoratedDef->setPublic($public);
             $decoratedDef->setTags($tags);
             // Special treatment for inline fragment renderer, to fit ESI renderer constructor type hinting (forced to InlineFragmentRenderer)
+            // Note: InlineFragmentRenderer's constructor only declares the first 2 arguments (it has
+            // no use for SiteAccessServiceInterface); PHP silently ignores the extra 3rd argument.
             if ($id === 'fragment.renderer.inline') {
                 $decoratedDef->setClass(InlineFragmentRenderer::class);
             }

--- a/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
@@ -12,7 +12,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\AnonymousUserAccessListener;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\DefaultAuthenticationSuccessHandler;
 use Ibexa\Core\MVC\Symfony\Security\HttpUtils;
-use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
@@ -40,8 +40,8 @@ final class SecurityPass implements CompilerPassInterface
         $httpUtilsDef = $container->findDefinition('security.http_utils');
         $httpUtilsDef->setClass(HttpUtils::class);
         $httpUtilsDef->addMethodCall(
-            'setSiteAccess',
-            [new Reference(SiteAccess::class)]
+            'setSiteAccessService',
+            [new Reference(SiteAccessServiceInterface::class)]
         );
     }
 

--- a/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
+++ b/src/bundle/Core/DependencyInjection/Compiler/SecurityPass.php
@@ -39,10 +39,7 @@ final class SecurityPass implements CompilerPassInterface
 
         $httpUtilsDef = $container->findDefinition('security.http_utils');
         $httpUtilsDef->setClass(HttpUtils::class);
-        $httpUtilsDef->addMethodCall(
-            'setSiteAccessService',
-            [new Reference(SiteAccessServiceInterface::class)]
-        );
+        $httpUtilsDef->setArgument('$siteAccessService', new Reference(SiteAccessServiceInterface::class));
     }
 
     private function registerSecurityAuthenticationSuccessHandler(ContainerBuilder $container): void

--- a/src/bundle/Core/EventListener/ConsoleCommandListener.php
+++ b/src/bundle/Core/EventListener/ConsoleCommandListener.php
@@ -22,9 +22,6 @@ class ConsoleCommandListener implements EventSubscriberInterface
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface */
     private $siteAccessProvider;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
-    private $siteAccess;
-
     private SiteAccessServiceInterface $siteAccessService;
 
     /** @var bool */
@@ -33,13 +30,11 @@ class ConsoleCommandListener implements EventSubscriberInterface
     public function __construct(
         string $defaultSiteAccessName,
         SiteAccess\SiteAccessProviderInterface $siteAccessProvider,
-        SiteAccess $siteAccess,
         SiteAccessServiceInterface $siteAccessService,
         bool $debug = false
     ) {
         $this->defaultSiteAccessName = $defaultSiteAccessName;
         $this->siteAccessProvider = $siteAccessProvider;
-        $this->siteAccess = $siteAccess;
         $this->siteAccessService = $siteAccessService;
         $this->debug = $debug;
     }
@@ -55,23 +50,19 @@ class ConsoleCommandListener implements EventSubscriberInterface
 
     public function onConsoleCommand(ConsoleCommandEvent $event)
     {
-        // Note: this mutates the shared SiteAccess singleton in place (rather than only calling
-        // changeSiteAccess() below), because consumers that still read that singleton directly
-        // (e.g. the config resolver chain, for its MATCHING_TYPE_UNINITIALIZED early-access guard)
-        // never receive a SiteAccess through SiteAccessService and would otherwise never see it change.
-        $this->siteAccess->name = $event->getInput()->getParameterOption('--siteaccess', $this->defaultSiteAccessName);
-        $this->siteAccess->matchingType = 'cli';
+        $siteAccessName = $event->getInput()->getParameterOption('--siteaccess', $this->defaultSiteAccessName);
+        $siteAccess = new SiteAccess($siteAccessName, 'cli');
 
-        if (!$this->siteAccessProvider->isDefined($this->siteAccess->name)) {
+        if (!$this->siteAccessProvider->isDefined($siteAccess->name)) {
             throw new InvalidSiteAccessException(
-                $this->siteAccess->name,
+                $siteAccess->name,
                 $this->siteAccessProvider,
-                $this->siteAccess->matchingType,
+                $siteAccess->matchingType,
                 $this->debug
             );
         }
 
-        $this->siteAccessService->changeSiteAccess($this->siteAccess);
+        $this->siteAccessService->changeSiteAccess($siteAccess);
     }
 
     public function setDebug($debug = false)

--- a/src/bundle/Core/EventListener/ConsoleCommandListener.php
+++ b/src/bundle/Core/EventListener/ConsoleCommandListener.php
@@ -8,16 +8,13 @@
 namespace Ibexa\Bundle\Core\EventListener;
 
 use Ibexa\Core\MVC\Exception\InvalidSiteAccessException;
-use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
-use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConsoleCommandListener implements EventSubscriberInterface, SiteAccessAware
+class ConsoleCommandListener implements EventSubscriberInterface
 {
     /** @var string */
     private $defaultSiteAccessName;
@@ -25,11 +22,10 @@ class ConsoleCommandListener implements EventSubscriberInterface, SiteAccessAwar
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface */
     private $siteAccessProvider;
 
-    /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
-    private $eventDispatcher;
-
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess|null */
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteAccess;
+
+    private SiteAccessServiceInterface $siteAccessService;
 
     /** @var bool */
     private $debug;
@@ -37,12 +33,14 @@ class ConsoleCommandListener implements EventSubscriberInterface, SiteAccessAwar
     public function __construct(
         string $defaultSiteAccessName,
         SiteAccess\SiteAccessProviderInterface $siteAccessProvider,
-        EventDispatcherInterface $eventDispatcher,
+        SiteAccess $siteAccess,
+        SiteAccessServiceInterface $siteAccessService,
         bool $debug = false
     ) {
         $this->defaultSiteAccessName = $defaultSiteAccessName;
         $this->siteAccessProvider = $siteAccessProvider;
-        $this->eventDispatcher = $eventDispatcher;
+        $this->siteAccess = $siteAccess;
+        $this->siteAccessService = $siteAccessService;
         $this->debug = $debug;
     }
 
@@ -57,6 +55,10 @@ class ConsoleCommandListener implements EventSubscriberInterface, SiteAccessAwar
 
     public function onConsoleCommand(ConsoleCommandEvent $event)
     {
+        // Note: this mutates the shared SiteAccess singleton in place (rather than only calling
+        // changeSiteAccess() below), because consumers that still read that singleton directly
+        // (e.g. the config resolver chain, for its MATCHING_TYPE_UNINITIALIZED early-access guard)
+        // never receive a SiteAccess through SiteAccessService and would otherwise never see it change.
         $this->siteAccess->name = $event->getInput()->getParameterOption('--siteaccess', $this->defaultSiteAccessName);
         $this->siteAccess->matchingType = 'cli';
 
@@ -69,12 +71,7 @@ class ConsoleCommandListener implements EventSubscriberInterface, SiteAccessAwar
             );
         }
 
-        $this->eventDispatcher->dispatch(new ScopeChangeEvent($this->siteAccess), MVCEvents::CONFIG_SCOPE_CHANGE);
-    }
-
-    public function setSiteAccess(?SiteAccess $siteAccess = null)
-    {
-        $this->siteAccess = $siteAccess;
+        $this->siteAccessService->changeSiteAccess($this->siteAccess);
     }
 
     public function setDebug($debug = false)

--- a/src/bundle/Core/Features/Console/console.feature
+++ b/src/bundle/Core/Features/Console/console.feature
@@ -1,10 +1,4 @@
 Feature: app/console
-    # IBX-12204: ConsoleCommandListener no longer mutates the shared SiteAccess singleton in place
-    # (it only calls SiteAccessService::changeSiteAccess() now), so any command that reads the
-    # CLI-resolved siteaccess by type-hinting that shared service directly no longer sees it change.
-    # The ibexa:behat:test-siteaccess fixture command does exactly that; it needs to switch to
-    # SiteAccessServiceInterface::getCurrent() before this scenario can pass again.
-    @broken
     Scenario: Commands use the default siteaccess if not specified
         When I run a console script without specifying a siteaccess
         Then it is executed with the default one

--- a/src/bundle/Core/Features/Console/console.feature
+++ b/src/bundle/Core/Features/Console/console.feature
@@ -1,4 +1,10 @@
 Feature: app/console
+    # IBX-12204: ConsoleCommandListener no longer mutates the shared SiteAccess singleton in place
+    # (it only calls SiteAccessService::changeSiteAccess() now), so any command that reads the
+    # CLI-resolved siteaccess by type-hinting that shared service directly no longer sees it change.
+    # The ibexa:behat:test-siteaccess fixture command does exactly that; it needs to switch to
+    # SiteAccessServiceInterface::getCurrent() before this scenario can pass again.
+    @broken
     Scenario: Commands use the default siteaccess if not specified
         When I run a console script without specifying a siteaccess
         Then it is executed with the default one

--- a/src/bundle/Core/Fragment/DecoratedFragmentRenderer.php
+++ b/src/bundle/Core/Fragment/DecoratedFragmentRenderer.php
@@ -8,32 +8,29 @@
 namespace Ibexa\Bundle\Core\Fragment;
 
 use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
-class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccessAware
+class DecoratedFragmentRenderer implements FragmentRendererInterface
 {
     private FragmentRendererInterface $innerRenderer;
 
-    private ?SiteAccess $siteAccess = null;
-
     private SiteAccessSerializerInterface $siteAccessSerializer;
+
+    private SiteAccessServiceInterface $siteAccessService;
 
     public function __construct(
         FragmentRendererInterface $innerRenderer,
-        SiteAccessSerializerInterface $siteAccessSerializer
+        SiteAccessSerializerInterface $siteAccessSerializer,
+        SiteAccessServiceInterface $siteAccessService
     ) {
         $this->innerRenderer = $innerRenderer;
         $this->siteAccessSerializer = $siteAccessSerializer;
-    }
-
-    public function setSiteAccess(?SiteAccess $siteAccess = null): void
-    {
-        $this->siteAccess = $siteAccess;
+        $this->siteAccessService = $siteAccessService;
     }
 
     public function setFragmentPath(string $path): void
@@ -42,7 +39,7 @@ class DecoratedFragmentRenderer implements FragmentRendererInterface, SiteAccess
             return;
         }
 
-        $matcher = $this->siteAccess?->matcher;
+        $matcher = $this->siteAccessService->getCurrent()?->matcher;
         if ($matcher instanceof SiteAccess\URILexer) {
             $path = $matcher->analyseLink($path);
         }

--- a/src/bundle/Core/Fragment/InlineFragmentRenderer.php
+++ b/src/bundle/Core/Fragment/InlineFragmentRenderer.php
@@ -7,8 +7,6 @@
 
 namespace Ibexa\Bundle\Core\Fragment;
 
-use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
@@ -16,11 +14,9 @@ use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 use Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer as BaseRenderer;
 use Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer;
 
-class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware, FragmentRendererInterface
+class InlineFragmentRenderer extends BaseRenderer implements FragmentRendererInterface
 {
     protected FragmentRendererInterface $innerRenderer;
-
-    private ?SiteAccess $siteAccess = null;
 
     private SiteAccessSerializerInterface $siteAccessSerializer;
 
@@ -37,11 +33,6 @@ class InlineFragmentRenderer extends BaseRenderer implements SiteAccessAware, Fr
         if ($this->innerRenderer instanceof RoutableFragmentRenderer) {
             $this->innerRenderer->setFragmentPath($path);
         }
-    }
-
-    public function setSiteAccess(?SiteAccess $siteAccess = null): void
-    {
-        $this->siteAccess = $siteAccess;
     }
 
     /**

--- a/src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/src/bundle/Core/Imagine/Cache/AliasGeneratorDecorator.php
@@ -11,8 +11,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Variation\Values\Variation;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
-use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -20,7 +19,7 @@ use Symfony\Component\Routing\RequestContext;
 /**
  * Persistence Cache layer for AliasGenerator.
  */
-class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
+class AliasGeneratorDecorator implements VariationHandler
 {
     private const IMAGE_VARIATION_IDENTIFIER = 'image_variation';
     private const IMAGE_VARIATION_SITEACCESS_IDENTIFIER = 'image_variation_siteaccess';
@@ -36,14 +35,13 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
     /** @var \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface */
     private $cache;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
-    private $siteAccess;
-
     /** @var \Symfony\Component\Routing\RequestContext */
     private $requestContext;
 
     /** @var \Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface */
     private $cacheIdentifierGenerator;
+
+    private SiteAccessServiceInterface $siteAccessService;
 
     /**
      * @param \Ibexa\Contracts\Core\Variation\VariationHandler $aliasGenerator
@@ -55,12 +53,14 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
         VariationHandler $aliasGenerator,
         TagAwareAdapterInterface $cache,
         RequestContext $requestContext,
-        CacheIdentifierGeneratorInterface $cacheIdentifierGenerator
+        CacheIdentifierGeneratorInterface $cacheIdentifierGenerator,
+        SiteAccessServiceInterface $siteAccessService
     ) {
         $this->aliasGenerator = $aliasGenerator;
         $this->cache = $cache;
         $this->requestContext = $requestContext;
         $this->cacheIdentifierGenerator = $cacheIdentifierGenerator;
+        $this->siteAccessService = $siteAccessService;
     }
 
     /**
@@ -88,14 +88,6 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
     }
 
     /**
-     * @param \Ibexa\Core\MVC\Symfony\SiteAccess|null $siteAccess
-     */
-    public function setSiteAccess(?SiteAccess $siteAccess = null)
-    {
-        $this->siteAccess = $siteAccess;
-    }
-
-    /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Field $field
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo $versionInfo
      * @param string $variationName
@@ -104,9 +96,11 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
      */
     private function getCacheKey(Field $field, VersionInfo $versionInfo, $variationName): string
     {
+        $siteAccess = $this->siteAccessService->getCurrent();
+
         return sprintf(
             $this->cacheIdentifierGenerator->generateKey(self::IMAGE_VARIATION_IDENTIFIER, [], true) . '-%s-%s-%s-%d-%d-%d-%s-%s',
-            $this->siteAccess->name ?? 'default',
+            $siteAccess !== null ? $siteAccess->name : 'default',
             $this->requestContext->getScheme(),
             $this->requestContext->getHost(),
             $this->requestContext->getScheme() === 'https' ? $this->requestContext->getHttpsPort() : $this->requestContext->getHttpPort(),
@@ -120,11 +114,12 @@ class AliasGeneratorDecorator implements VariationHandler, SiteAccessAware
     private function getTagsForVariation(Field $field, VersionInfo $versionInfo, string $variationName): array
     {
         $contentId = $versionInfo->getContentInfo()->id;
+        $siteAccess = $this->siteAccessService->getCurrent();
 
         return [
             $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_IDENTIFIER),
             $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_NAME_IDENTIFIER, [$variationName]),
-            $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_SITEACCESS_IDENTIFIER, [$this->siteAccess->name ?? 'default']),
+            $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_SITEACCESS_IDENTIFIER, [$siteAccess !== null ? $siteAccess->name : 'default']),
             $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_CONTENT_IDENTIFIER, [$contentId]),
             $this->cacheIdentifierGenerator->generateTag(self::IMAGE_VARIATION_FIELD_IDENTIFIER, [$field->id]),
             $this->cacheIdentifierGenerator->generateTag(self::CONTENT_IDENTIFIER, [$contentId]),

--- a/src/bundle/Core/Resources/config/commands.yml
+++ b/src/bundle/Core/Resources/config/commands.yml
@@ -12,7 +12,7 @@ services:
         class: Ibexa\Bundle\Core\Command\DebugConfigResolverCommand
         arguments:
             - '@ibexa.config.resolver'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface'
         tags:
             - { name: console.command }
 

--- a/src/bundle/Core/Resources/config/helpers.yml
+++ b/src/bundle/Core/Resources/config/helpers.yml
@@ -16,9 +16,9 @@ services:
         arguments: ['@Ibexa\Core\Helper\TranslationHelper', '@ibexa.api.service.field_type']
 
     Ibexa\Core\Helper\ContentPreviewHelper:
-        arguments: ["@event_dispatcher", '@Ibexa\Core\MVC\Symfony\SiteAccess\Router']
-        calls:
-            - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
+        arguments:
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\Router'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
 
     Ibexa\Bundle\Core\EventListener\ConfigScopeListener:
         arguments:

--- a/src/bundle/Core/Resources/config/helpers.yml
+++ b/src/bundle/Core/Resources/config/helpers.yml
@@ -18,7 +18,7 @@ services:
     Ibexa\Core\Helper\ContentPreviewHelper:
         arguments:
             - '@Ibexa\Core\MVC\Symfony\SiteAccess\Router'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface'
 
     Ibexa\Bundle\Core\EventListener\ConfigScopeListener:
         arguments:
@@ -50,7 +50,7 @@ services:
     Ibexa\Bundle\Core\SiteAccess\Config\ComplexConfigProcessor:
         arguments:
             $configResolver: '@ibexa.config.resolver'
-            $siteAccessService: '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
+            $siteAccessService: '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface'
 
     Ibexa\Contracts\Core\SiteAccess\ConfigProcessor:
         alias: Ibexa\Bundle\Core\SiteAccess\Config\ComplexConfigProcessor

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -68,7 +68,7 @@ services:
             - '@ibexa.cache_pool'
             - '@router.request_context'
             - '@Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface'
 
     ibexa.image_alias.imagine.alias_generator:
         class: Ibexa\Bundle\Core\Imagine\AliasGenerator

--- a/src/bundle/Core/Resources/config/image.yml
+++ b/src/bundle/Core/Resources/config/image.yml
@@ -68,8 +68,7 @@ services:
             - '@ibexa.cache_pool'
             - '@router.request_context'
             - '@Ibexa\Core\Persistence\Cache\Identifier\CacheIdentifierGeneratorInterface'
-        calls:
-            - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
 
     ibexa.image_alias.imagine.alias_generator:
         class: Ibexa\Bundle\Core\Imagine\AliasGenerator

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -89,6 +89,7 @@ services:
             - '@ibexa.siteaccess.provider'
             - '@ibexa.config.resolver'
             - '@event_dispatcher'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -54,7 +54,7 @@ services:
             - '@ibexa.api.repository'
             - "@router.default"
             - '@ibexa.config.resolver'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface'
             - '%ibexa.urlalias_generator.charmap%'
         parent: Ibexa\Core\MVC\Symfony\Routing\Generator
 

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -89,7 +89,6 @@ services:
             - '@ibexa.siteaccess.provider'
             - '@ibexa.config.resolver'
             - '@event_dispatcher'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -31,7 +31,6 @@ services:
         abstract: true
         calls:
             - [setRequestContext, ["@router.request_context"]]
-            - [setSiteAccessService, ['@?Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService']]
             - [setSiteAccessRouter, ['@Ibexa\Core\MVC\Symfony\SiteAccess\Router']]
             - [setLogger, ["@?logger"]]
 
@@ -55,6 +54,7 @@ services:
             - '@ibexa.api.repository'
             - "@router.default"
             - '@ibexa.config.resolver'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
             - '%ibexa.urlalias_generator.charmap%'
         parent: Ibexa\Core\MVC\Symfony\Routing\Generator
 

--- a/src/bundle/Core/Resources/config/routing.yml
+++ b/src/bundle/Core/Resources/config/routing.yml
@@ -31,7 +31,7 @@ services:
         abstract: true
         calls:
             - [setRequestContext, ["@router.request_context"]]
-            - [setSiteAccess, ['@?Ibexa\Core\MVC\Symfony\SiteAccess']]
+            - [setSiteAccessService, ['@?Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService']]
             - [setSiteAccessRouter, ['@Ibexa\Core\MVC\Symfony\SiteAccess\Router']]
             - [setLogger, ["@?logger"]]
 
@@ -88,8 +88,9 @@ services:
         arguments:
             - '@ibexa.siteaccess.provider'
             - '@ibexa.config.resolver'
-        calls:
-            - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
+            - '@event_dispatcher'
+        tags:
+            - { name: kernel.event_subscriber }
 
     Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface:
         alias: 'Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -74,10 +74,9 @@ services:
         arguments:
             - '%ibexa.site_access.default%'
             - '@ibexa.siteaccess.provider'
-            - "@event_dispatcher"
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
             - "%kernel.debug%"
-        calls:
-            - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -165,7 +164,6 @@ services:
         arguments: []
         calls:
             - [setFragmentPath, ["%fragment.path%"]]
-            - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
         abstract: true
 
     Ibexa\Bundle\Core\Fragment\DirectFragmentRenderer:

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -74,7 +74,7 @@ services:
         arguments:
             - '%ibexa.site_access.default%'
             - '@ibexa.siteaccess.provider'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface'
             - "%kernel.debug%"
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Core/Resources/config/services.yml
+++ b/src/bundle/Core/Resources/config/services.yml
@@ -74,7 +74,6 @@ services:
         arguments:
             - '%ibexa.site_access.default%'
             - '@ibexa.siteaccess.provider'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess'
             - '@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'
             - "%kernel.debug%"
         tags:

--- a/src/bundle/Core/Routing/DefaultRouter.php
+++ b/src/bundle/Core/Routing/DefaultRouter.php
@@ -11,8 +11,8 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Routing\RequestContextFactory;
 use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess\URILexer;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,10 +22,8 @@ use Symfony\Component\Routing\RequestContext;
 /**
  * Extension of Symfony default router implementing RequestMatcherInterface.
  */
-class DefaultRouter extends Router implements SiteAccessAware
+class DefaultRouter extends Router
 {
-    protected ?SiteAccess $siteAccess = null;
-
     /** @var string[] */
     protected array $nonSiteAccessAwareRoutes = [];
 
@@ -33,14 +31,16 @@ class DefaultRouter extends Router implements SiteAccessAware
 
     protected SiteAccessRouterInterface $siteAccessRouter;
 
+    private ?SiteAccessServiceInterface $siteAccessService = null;
+
     public function setConfigResolver(ConfigResolverInterface $configResolver): void
     {
         $this->configResolver = $configResolver;
     }
 
-    public function setSiteAccess(?SiteAccess $siteAccess = null): void
+    public function setSiteAccessService(?SiteAccessServiceInterface $siteAccessService = null): void
     {
-        $this->siteAccess = $siteAccess;
+        $this->siteAccessService = $siteAccessService;
     }
 
     /**
@@ -80,7 +80,7 @@ class DefaultRouter extends Router implements SiteAccessAware
      */
     public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
     {
-        $siteAccess = $this->siteAccess;
+        $siteAccess = $this->siteAccessService?->getCurrent();
         $originalContext = $context = $this->getContext();
         $isSiteAccessAware = $this->isSiteAccessAwareRoute($name);
 
@@ -92,7 +92,7 @@ class DefaultRouter extends Router implements SiteAccessAware
                 $context = $this->getContextBySimplifiedRequest($siteAccess->matcher->getRequest());
                 $this->setContext($context);
             } elseif ($this->logger) {
-                $siteAccess = $this->siteAccess;
+                $siteAccess = $this->siteAccessService?->getCurrent();
                 $this->logger->notice("Could not generate a link using provided 'siteaccess' parameter: {$parameters['siteaccess']}. Generating using current context.");
             }
 

--- a/src/bundle/Core/Routing/DefaultRouter.php
+++ b/src/bundle/Core/Routing/DefaultRouter.php
@@ -14,6 +14,8 @@ use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess\URILexer;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -31,16 +33,25 @@ class DefaultRouter extends Router
 
     protected SiteAccessRouterInterface $siteAccessRouter;
 
-    private ?SiteAccessServiceInterface $siteAccessService = null;
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(
+        ContainerInterface $container,
+        mixed $resource,
+        array $options = [],
+        ?RequestContext $context = null,
+        ?ContainerInterface $parameters = null,
+        ?LoggerInterface $logger = null,
+        ?string $defaultLocale = null,
+        private ?SiteAccessServiceInterface $siteAccessService = null,
+    ) {
+        parent::__construct($container, $resource, $options, $context, $parameters, $logger, $defaultLocale);
+    }
 
     public function setConfigResolver(ConfigResolverInterface $configResolver): void
     {
         $this->configResolver = $configResolver;
-    }
-
-    public function setSiteAccessService(?SiteAccessServiceInterface $siteAccessService = null): void
-    {
-        $this->siteAccessService = $siteAccessService;
     }
 
     /**

--- a/src/bundle/Core/SiteAccess/Config/ComplexConfigProcessor.php
+++ b/src/bundle/Core/SiteAccess/Config/ComplexConfigProcessor.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigProcessor;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use function str_replace;
 
 final class ComplexConfigProcessor implements ConfigProcessor
@@ -23,7 +23,7 @@ final class ComplexConfigProcessor implements ConfigProcessor
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
     private $configResolver;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService */
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface */
     private $siteAccessService;
 
     /** @var \Ibexa\Bundle\Core\DependencyInjection\Configuration\ComplexSettings\ComplexSettingParserInterface */
@@ -31,7 +31,7 @@ final class ComplexConfigProcessor implements ConfigProcessor
 
     public function __construct(
         ConfigResolverInterface $configResolver,
-        SiteAccessService $siteAccessService
+        SiteAccessServiceInterface $siteAccessService
     ) {
         $this->configResolver = $configResolver;
         $this->siteAccessService = $siteAccessService;

--- a/src/bundle/Core/SiteAccess/Config/ComplexConfigProcessor.php
+++ b/src/bundle/Core/SiteAccess/Config/ComplexConfigProcessor.php
@@ -11,6 +11,7 @@ namespace Ibexa\Bundle\Core\SiteAccess\Config;
 use Ibexa\Bundle\Core\DependencyInjection\Configuration\ComplexSettings\ComplexSettingParser;
 use Ibexa\Contracts\Core\SiteAccess\ConfigProcessor;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
 use function str_replace;
@@ -41,7 +42,7 @@ final class ComplexConfigProcessor implements ConfigProcessor
 
     public function processComplexSetting(string $setting): string
     {
-        $siteAccessName = $this->siteAccessService->getCurrent()->name;
+        $siteAccessName = $this->getCurrentSiteAccessName();
 
         if (!$this->configResolver->hasParameter($setting, null, $siteAccessName)) {
             throw new ParameterNotFoundException($setting, null, [$siteAccessName]);
@@ -74,12 +75,22 @@ final class ComplexConfigProcessor implements ConfigProcessor
             $dynamicSettingValue = $this->configResolver->getParameter(
                 $parts['param'],
                 $parts['namespace'],
-                $parts['scope'] ?? $this->siteAccessService->getCurrent()->name
+                $parts['scope'] ?? $this->getCurrentSiteAccessName()
             );
 
             $value = str_replace($dynamicSetting, $dynamicSettingValue, $value);
         }
 
         return $value;
+    }
+
+    private function getCurrentSiteAccessName(): string
+    {
+        $siteAccess = $this->siteAccessService->getCurrent();
+        if ($siteAccess === null) {
+            throw new InvalidArgumentException('siteAccess', 'no SiteAccess given and none currently set');
+        }
+
+        return $siteAccess->name;
     }
 }

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -17,6 +17,8 @@ use Ibexa\Contracts\Core\Persistence\Handler;
 use Ibexa\Contracts\Core\Persistence\TransactionHandler;
 use Ibexa\Contracts\Core\Repository;
 use Ibexa\Contracts\Core\Test\Persistence\Fixture\YamlFixture;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
 use Ibexa\Tests\Integration\Core\IO\FlysystemTestAdapter;
 use Ibexa\Tests\Integration\Core\IO\FlysystemTestAdapterInterface;
 use JMS\TranslationBundle\JMSTranslationBundle;
@@ -28,6 +30,7 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -168,6 +171,21 @@ class IbexaTestKernel extends Kernel implements IbexaTestKernelInterface
         });
     }
 
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        // Registered as a compiler pass (rather than done directly in registerContainerConfiguration())
+        // because SiteAccessService's definition doesn't exist yet at that point: bundle extensions
+        // (which register it) only run once the container compiles.
+        $container->addCompilerPass(new class() implements CompilerPassInterface {
+            public function process(ContainerBuilder $container): void
+            {
+                IbexaTestKernel::seedDefaultSiteAccess($container);
+            }
+        });
+    }
+
     /**
      * @throws \Exception
      */
@@ -268,6 +286,23 @@ class IbexaTestKernel extends Kernel implements IbexaTestKernelInterface
     private static function setUpTestLogger(ContainerBuilder $container): void
     {
         $container->setDefinition('logger', new Definition(NullLogger::class));
+    }
+
+    /**
+     * Test cases using this kernel never dispatch a real request, so SiteAccessService would
+     * otherwise never have a current SiteAccess. Seed it the same way ConsoleCommandListener does
+     * for CLI: a fresh SiteAccess passed to changeSiteAccess(), not a shared/mutated singleton.
+     */
+    public static function seedDefaultSiteAccess(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(SiteAccessService::class)) {
+            return;
+        }
+
+        $container->getDefinition(SiteAccessService::class)->addMethodCall(
+            'changeSiteAccess',
+            [new Definition(SiteAccess::class, ['default'])]
+        );
     }
 
     /**

--- a/src/lib/Helper/ContentPreviewHelper.php
+++ b/src/lib/Helper/ContentPreviewHelper.php
@@ -9,23 +9,15 @@ namespace Ibexa\Core\Helper;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
-use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
-use Ibexa\Core\MVC\Symfony\MVCEvents;
-use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 
-class ContentPreviewHelper implements SiteAccessAware
+class ContentPreviewHelper
 {
-    /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface */
-    protected $eventDispatcher;
-
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface */
     protected $siteAccessRouter;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
-    protected $originalSiteAccess;
+    private SiteAccessServiceInterface $siteAccessService;
 
     /** @var bool */
     private $previewActive = false;
@@ -36,25 +28,20 @@ class ContentPreviewHelper implements SiteAccessAware
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location */
     private $previewedLocation;
 
-    public function __construct(EventDispatcherInterface $eventDispatcher, SiteAccessRouterInterface $siteAccessRouter)
+    public function __construct(SiteAccessRouterInterface $siteAccessRouter, SiteAccessServiceInterface $siteAccessService)
     {
-        $this->eventDispatcher = $eventDispatcher;
         $this->siteAccessRouter = $siteAccessRouter;
-    }
-
-    public function setSiteAccess(?SiteAccess $siteAccess = null)
-    {
-        $this->originalSiteAccess = $siteAccess;
+        $this->siteAccessService = $siteAccessService;
     }
 
     /**
      * Return original SiteAccess.
      *
-     * @return \Ibexa\Core\MVC\Symfony\SiteAccess
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess|null
      */
     public function getOriginalSiteAccess()
     {
-        return $this->originalSiteAccess;
+        return $this->siteAccessService->getCurrent();
     }
 
     /**
@@ -66,23 +53,17 @@ class ContentPreviewHelper implements SiteAccessAware
      */
     public function changeConfigScope($siteAccessName)
     {
-        $event = new ScopeChangeEvent($this->siteAccessRouter->matchByName($siteAccessName));
-        $this->eventDispatcher->dispatch($event, MVCEvents::CONFIG_SCOPE_CHANGE);
-
-        return $event->getSiteAccess();
+        return $this->siteAccessService->changeSiteAccess($this->siteAccessRouter->matchByName($siteAccessName));
     }
 
     /**
      * Restores original config scope.
      *
-     * @return \Ibexa\Core\MVC\Symfony\SiteAccess
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess|null
      */
     public function restoreConfigScope()
     {
-        $event = new ScopeChangeEvent($this->originalSiteAccess);
-        $this->eventDispatcher->dispatch($event, MVCEvents::CONFIG_SCOPE_RESTORE);
-
-        return $event->getSiteAccess();
+        return $this->siteAccessService->restoreSiteAccess();
     }
 
     /**
@@ -99,7 +80,6 @@ class ContentPreviewHelper implements SiteAccessAware
     public function setPreviewActive($previewActive)
     {
         $this->previewActive = (bool)$previewActive;
-        $this->originalSiteAccess = clone $this->originalSiteAccess;
     }
 
     /**

--- a/src/lib/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/src/lib/MVC/Symfony/Controller/Content/PreviewController.php
@@ -121,6 +121,10 @@ class PreviewController
         }
 
         $siteAccess = $this->previewHelper->getOriginalSiteAccess();
+        if ($siteAccess === null) {
+            throw new BadStateException('siteAccess', 'no SiteAccess currently set, cannot preview');
+        }
+
         // Only switch if $siteAccessName is set and different from original
         if ($siteAccessName !== null && $siteAccessName !== $siteAccess->name) {
             $siteAccess = $this->previewHelper->changeConfigScope($siteAccessName);

--- a/src/lib/MVC/Symfony/Routing/Generator.php
+++ b/src/lib/MVC/Symfony/Routing/Generator.php
@@ -23,9 +23,11 @@ abstract class Generator
 
     protected SiteAccessRouterInterface $siteAccessRouter;
 
-    private ?SiteAccessServiceInterface $siteAccessService = null;
-
     protected ?LoggerInterface $logger;
+
+    public function __construct(private readonly SiteAccessServiceInterface $siteAccessService)
+    {
+    }
 
     public function setRequestContext(RequestContext $requestContext): void
     {
@@ -35,11 +37,6 @@ abstract class Generator
     public function setSiteAccessRouter(SiteAccessRouterInterface $siteAccessRouter): void
     {
         $this->siteAccessRouter = $siteAccessRouter;
-    }
-
-    public function setSiteAccessService(?SiteAccessServiceInterface $siteAccessService = null): void
-    {
-        $this->siteAccessService = $siteAccessService;
     }
 
     public function setLogger(?LoggerInterface $logger = null): void
@@ -57,7 +54,7 @@ abstract class Generator
      */
     public function generate(mixed $urlResource, array $parameters, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
-        $siteAccess = $this->siteAccessService?->getCurrent();
+        $siteAccess = $this->siteAccessService->getCurrent();
         $requestContext = $this->requestContext;
 
         // Retrieving the appropriate SiteAccess to generate the link for.
@@ -69,7 +66,7 @@ abstract class Generator
                     $siteAccess->matcher->getRequest()
                 );
             } elseif (isset($this->logger)) {
-                $siteAccess = $this->siteAccessService?->getCurrent();
+                $siteAccess = $this->siteAccessService->getCurrent();
                 $this->logger->notice("Could not generate a link using provided 'siteaccess' parameter: {$parameters['siteaccess']}. Generating using current context.");
                 unset($parameters['siteaccess']);
             }

--- a/src/lib/MVC/Symfony/Routing/Generator.php
+++ b/src/lib/MVC/Symfony/Routing/Generator.php
@@ -8,8 +8,8 @@
 namespace Ibexa\Core\MVC\Symfony\Routing;
 
 use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -17,13 +17,13 @@ use Symfony\Component\Routing\RequestContext;
 /**
  * Base class for Ibexa Url generation.
  */
-abstract class Generator implements SiteAccessAware
+abstract class Generator
 {
     protected RequestContext $requestContext;
 
     protected SiteAccessRouterInterface $siteAccessRouter;
 
-    protected ?SiteAccess $siteAccess;
+    private ?SiteAccessServiceInterface $siteAccessService = null;
 
     protected ?LoggerInterface $logger;
 
@@ -37,9 +37,9 @@ abstract class Generator implements SiteAccessAware
         $this->siteAccessRouter = $siteAccessRouter;
     }
 
-    public function setSiteAccess(?SiteAccess $siteAccess = null): void
+    public function setSiteAccessService(?SiteAccessServiceInterface $siteAccessService = null): void
     {
-        $this->siteAccess = $siteAccess;
+        $this->siteAccessService = $siteAccessService;
     }
 
     public function setLogger(?LoggerInterface $logger = null): void
@@ -57,7 +57,7 @@ abstract class Generator implements SiteAccessAware
      */
     public function generate(mixed $urlResource, array $parameters, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
-        $siteAccess = $this->siteAccess;
+        $siteAccess = $this->siteAccessService?->getCurrent();
         $requestContext = $this->requestContext;
 
         // Retrieving the appropriate SiteAccess to generate the link for.
@@ -69,7 +69,7 @@ abstract class Generator implements SiteAccessAware
                     $siteAccess->matcher->getRequest()
                 );
             } elseif (isset($this->logger)) {
-                $siteAccess = $this->siteAccess;
+                $siteAccess = $this->siteAccessService?->getCurrent();
                 $this->logger->notice("Could not generate a link using provided 'siteaccess' parameter: {$parameters['siteaccess']}. Generating using current context.");
                 unset($parameters['siteaccess']);
             }

--- a/src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/src/lib/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Routing\Generator;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -47,8 +48,15 @@ class UrlAliasGenerator extends Generator
     /**
      * @param array<string, string> $unsafeCharMap
      */
-    public function __construct(Repository $repository, RouterInterface $defaultRouter, ConfigResolverInterface $configResolver, array $unsafeCharMap = [])
-    {
+    public function __construct(
+        Repository $repository,
+        RouterInterface $defaultRouter,
+        ConfigResolverInterface $configResolver,
+        SiteAccessServiceInterface $siteAccessService,
+        array $unsafeCharMap = []
+    ) {
+        parent::__construct($siteAccessService);
+
         $this->repository = $repository;
         $this->defaultRouter = $defaultRouter;
         $this->configResolver = $configResolver;

--- a/src/lib/MVC/Symfony/Security/HttpUtils.php
+++ b/src/lib/MVC/Symfony/Security/HttpUtils.php
@@ -10,15 +10,21 @@ namespace Ibexa\Core\MVC\Symfony\Security;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Security\Http\HttpUtils as BaseHttpUtils;
 
 class HttpUtils extends BaseHttpUtils
 {
-    private ?SiteAccessServiceInterface $siteAccessService = null;
-
-    public function setSiteAccessService(?SiteAccessServiceInterface $siteAccessService = null): void
-    {
-        $this->siteAccessService = $siteAccessService;
+    public function __construct(
+        ?UrlGeneratorInterface $urlGenerator = null,
+        UrlMatcherInterface|RequestMatcherInterface|null $urlMatcher = null,
+        ?string $domainRegexp = null,
+        ?string $secureDomainRegexp = null,
+        private ?SiteAccessServiceInterface $siteAccessService = null,
+    ) {
+        parent::__construct($urlGenerator, $urlMatcher, $domainRegexp, $secureDomainRegexp);
     }
 
     private function analyzeLink(string $path): string

--- a/src/lib/MVC/Symfony/Security/HttpUtils.php
+++ b/src/lib/MVC/Symfony/Security/HttpUtils.php
@@ -8,22 +8,22 @@
 namespace Ibexa\Core\MVC\Symfony\Security;
 
 use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\HttpUtils as BaseHttpUtils;
 
-class HttpUtils extends BaseHttpUtils implements SiteAccessAware
+class HttpUtils extends BaseHttpUtils
 {
-    private ?SiteAccess $siteAccess;
+    private ?SiteAccessServiceInterface $siteAccessService = null;
 
-    public function setSiteAccess(?SiteAccess $siteAccess = null): void
+    public function setSiteAccessService(?SiteAccessServiceInterface $siteAccessService = null): void
     {
-        $this->siteAccess = $siteAccess;
+        $this->siteAccessService = $siteAccessService;
     }
 
     private function analyzeLink(string $path): string
     {
-        $matcher = $this->siteAccess?->matcher;
+        $matcher = $this->siteAccessService?->getCurrent()?->matcher;
         if ($path[0] === '/' && $matcher instanceof SiteAccess\URILexer) {
             $path = $matcher->analyseLink($path);
         }

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessAware.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessAware.php
@@ -11,6 +11,8 @@ use Ibexa\Core\MVC\Symfony\SiteAccess;
 
 /**
  * Interface for SiteAccess aware services.
+ *
+ * @deprecated 6.0, to be removed in 7.0. Use \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface::getCurrent() instead.
  */
 interface SiteAccessAware
 {

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -25,23 +25,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class SiteAccessService implements SiteAccessServiceInterface, EventSubscriberInterface
 {
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess[] */
-    private array $siteAccessStack;
+    private array $siteAccessStack = [];
 
-    /**
-     * @param \Ibexa\Core\MVC\Symfony\SiteAccess $siteAccess the shared, container-wide default
-     *        SiteAccess, used as the initial stack entry until a real request (or an explicit
-     *        changeSiteAccess() call) establishes the actual current one. This preserves
-     *        getCurrent()'s pre-existing guarantee of never being null once the container is built,
-     *        which code such as ComplexConfigProcessor relies on outside of an HTTP request cycle
-     *        (CLI warm-up, integration tests, etc.).
-     */
     public function __construct(
         private readonly SiteAccessProviderInterface $provider,
         private readonly ConfigResolverInterface $configResolver,
-        private readonly EventDispatcherInterface $eventDispatcher,
-        SiteAccess $siteAccess
+        private readonly EventDispatcherInterface $eventDispatcher
     ) {
-        $this->siteAccessStack = [$siteAccess];
     }
 
     public static function getSubscribedEvents(): array
@@ -94,7 +84,16 @@ class SiteAccessService implements SiteAccessServiceInterface, EventSubscriberIn
 
     public function getCurrent(): ?SiteAccess
     {
-        return $this->siteAccessStack !== [] ? end($this->siteAccessStack) : null;
+        if ($this->siteAccessStack === []) {
+            return null;
+        }
+
+        // Defensive: a SiteAccess with an "uninitialized" matcher (see
+        // SiteAccess::MATCHING_TYPE_UNINITIALIZED) is not a real current SiteAccess even if it
+        // somehow ended up on the stack — surface it as null rather than a misleading value.
+        $current = end($this->siteAccessStack);
+
+        return $current->matchingType !== SiteAccess::MATCHING_TYPE_UNINITIALIZED ? $current : null;
     }
 
     public function changeSiteAccess(SiteAccess $siteAccess): SiteAccess

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -11,22 +11,56 @@ namespace Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
+use Ibexa\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use function iterator_to_array;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 
-class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
+class SiteAccessService implements SiteAccessServiceInterface, EventSubscriberInterface
 {
-    private ?SiteAccess $siteAccess = null;
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess[] */
+    private array $siteAccessStack = [];
 
     public function __construct(
         private readonly SiteAccessProviderInterface $provider,
-        private readonly ConfigResolverInterface $configResolver
+        private readonly ConfigResolverInterface $configResolver,
+        private readonly EventDispatcherInterface $eventDispatcher
     ) {
     }
 
-    public function setSiteAccess(?SiteAccess $siteAccess = null): void
+    public static function getSubscribedEvents(): array
     {
-        $this->siteAccess = $siteAccess;
+        return [
+            MVCEvents::SITEACCESS => 'onSiteAccessMatch',
+            KernelEvents::FINISH_REQUEST => 'onKernelFinishRequest',
+        ];
+    }
+
+    /**
+     * Establishes the base of the SiteAccess stack for a top-level request, or pushes an
+     * additional entry for a sub-request (e.g. content preview, fragments, ESI).
+     */
+    public function onSiteAccessMatch(PostSiteAccessMatchEvent $event): void
+    {
+        if ($event->getRequestType() === HttpKernelInterface::MAIN_REQUEST) {
+            $this->siteAccessStack = [$event->getSiteAccess()];
+        } else {
+            $this->siteAccessStack[] = $event->getSiteAccess();
+        }
+    }
+
+    /**
+     * Undoes the push performed by onSiteAccessMatch() for the request/sub-request that just finished.
+     */
+    public function onKernelFinishRequest(FinishRequestEvent $event): void
+    {
+        $this->popSiteAccessStack();
     }
 
     public function exists(string $name): bool
@@ -50,12 +84,31 @@ class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
 
     public function getCurrent(): ?SiteAccess
     {
-        return $this->siteAccess ?? null;
+        return $this->siteAccessStack !== [] ? end($this->siteAccessStack) : null;
+    }
+
+    public function changeSiteAccess(SiteAccess $siteAccess): SiteAccess
+    {
+        $this->siteAccessStack[] = $siteAccess;
+        $this->eventDispatcher->dispatch(new ScopeChangeEvent($siteAccess), MVCEvents::CONFIG_SCOPE_CHANGE);
+
+        return $siteAccess;
+    }
+
+    public function restoreSiteAccess(): ?SiteAccess
+    {
+        $this->popSiteAccessStack();
+        $siteAccess = $this->getCurrent();
+        if ($siteAccess !== null) {
+            $this->eventDispatcher->dispatch(new ScopeChangeEvent($siteAccess), MVCEvents::CONFIG_SCOPE_RESTORE);
+        }
+
+        return $siteAccess;
     }
 
     public function getSiteAccessesRelation(?SiteAccess $siteAccess = null): array
     {
-        $siteAccess = $siteAccess ?? $this->siteAccess;
+        $siteAccess ??= $this->getCurrent();
         if ($siteAccess === null) {
             throw new InvalidArgumentException('siteAccess', 'no SiteAccess given and none currently set');
         }
@@ -86,5 +139,17 @@ class SiteAccessService implements SiteAccessServiceInterface, SiteAccessAware
         $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', 'ibexa.site_access.config', $siteAccessName);
 
         return $saRelationMap[$repository][$rootLocationId];
+    }
+
+    /**
+     * Pops the SiteAccess stack, but never below one remaining entry: the bottom-most entry
+     * (the current top-level request's SiteAccess, or the CLI SiteAccess established via
+     * changeSiteAccess()) must survive an unbalanced restore or an unrelated sub-request finishing.
+     */
+    private function popSiteAccessStack(): void
+    {
+        if (count($this->siteAccessStack) > 1) {
+            array_pop($this->siteAccessStack);
+        }
     }
 }

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -25,13 +25,23 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class SiteAccessService implements SiteAccessServiceInterface, EventSubscriberInterface
 {
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess[] */
-    private array $siteAccessStack = [];
+    private array $siteAccessStack;
 
+    /**
+     * @param \Ibexa\Core\MVC\Symfony\SiteAccess $siteAccess the shared, container-wide default
+     *        SiteAccess, used as the initial stack entry until a real request (or an explicit
+     *        changeSiteAccess() call) establishes the actual current one. This preserves
+     *        getCurrent()'s pre-existing guarantee of never being null once the container is built,
+     *        which code such as ComplexConfigProcessor relies on outside of an HTTP request cycle
+     *        (CLI warm-up, integration tests, etc.).
+     */
     public function __construct(
         private readonly SiteAccessProviderInterface $provider,
         private readonly ConfigResolverInterface $configResolver,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private readonly EventDispatcherInterface $eventDispatcher,
+        SiteAccess $siteAccess
     ) {
+        $this->siteAccessStack = [$siteAccess];
     }
 
     public static function getSubscribedEvents(): array

--- a/src/lib/MVC/Symfony/SiteAccess/SiteAccessServiceInterface.php
+++ b/src/lib/MVC/Symfony/SiteAccess/SiteAccessServiceInterface.php
@@ -37,4 +37,17 @@ interface SiteAccessServiceInterface
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentException if no SiteAccess is given and none is currently set
      */
     public function getSiteAccessesRelation(?SiteAccess $siteAccess = null): array;
+
+    /**
+     * Switches the current SiteAccess to $siteAccess, remembering the previous one so it can be
+     * restored later via restoreSiteAccess(). Dispatches a ScopeChangeEvent under
+     * MVCEvents::CONFIG_SCOPE_CHANGE.
+     */
+    public function changeSiteAccess(SiteAccess $siteAccess): SiteAccess;
+
+    /**
+     * Restores the SiteAccess that was current before the last changeSiteAccess() call.
+     * Dispatches a ScopeChangeEvent under MVCEvents::CONFIG_SCOPE_RESTORE.
+     */
+    public function restoreSiteAccess(): ?SiteAccess;
 }

--- a/src/lib/Resources/settings/roles.yml
+++ b/src/lib/Resources/settings/roles.yml
@@ -71,7 +71,7 @@ services:
 
     Ibexa\Core\Limitation\SiteAccessLimitationType:
         class: Ibexa\Core\Limitation\SiteAccessLimitationType
-        arguments: ['@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService']
+        arguments: ['@Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface']
         tags:
             - {name: ibexa.permissions.limitation_type, alias: SiteAccess}
 

--- a/tests/bundle/Core/DependencyInjection/Compiler/ChainRoutingPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ChainRoutingPassTest.php
@@ -90,10 +90,10 @@ class ChainRoutingPassTest extends AbstractCompilerPassTestCase
         $this->compile();
 
         // Assertion for default router
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'router.default',
-            'setSiteAccessService',
-            [new Reference(SiteAccessServiceInterface::class)]
+            '$siteAccessService',
+            new Reference(SiteAccessServiceInterface::class)
         );
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'router.default',

--- a/tests/bundle/Core/DependencyInjection/Compiler/ChainRoutingPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/ChainRoutingPassTest.php
@@ -9,8 +9,8 @@ namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Compiler;
 
 use Ibexa\Bundle\Core\DependencyInjection\Compiler\ChainRoutingPass;
 use Ibexa\Core\MVC\Symfony\Routing\ChainRouter;
-use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Router;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -74,7 +74,7 @@ class ChainRoutingPassTest extends AbstractCompilerPassTestCase
     {
         $defaultRouter = new Definition();
         $this->setDefinition('router.default', $defaultRouter);
-        $this->setDefinition(SiteAccess::class, new Definition());
+        $this->setDefinition(SiteAccessServiceInterface::class, new Definition());
         $this->setDefinition('ibexa.config.resolver', new Definition());
         $this->setDefinition(Router::class, new Definition());
 
@@ -92,8 +92,8 @@ class ChainRoutingPassTest extends AbstractCompilerPassTestCase
         // Assertion for default router
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'router.default',
-            'setSiteAccess',
-            [new Reference(SiteAccess::class)]
+            'setSiteAccessService',
+            [new Reference(SiteAccessServiceInterface::class)]
         );
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'router.default',

--- a/tests/bundle/Core/DependencyInjection/Compiler/FragmentPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/FragmentPassTest.php
@@ -12,6 +12,7 @@ use Ibexa\Bundle\Core\Fragment\DecoratedFragmentRenderer;
 use Ibexa\Bundle\Core\Fragment\FragmentListenerFactory;
 use Ibexa\Bundle\Core\Fragment\InlineFragmentRenderer;
 use Ibexa\Bundle\Core\Fragment\SiteAccessSerializerInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -67,7 +68,11 @@ class FragmentPassTest extends AbstractCompilerPassTestCase
         $decoratedInlineDef = $this->container->getDefinition('fragment.renderer.inline');
         self::assertSame(['kernel.fragment_renderer' => [[]]], $decoratedInlineDef->getTags());
         self::assertEquals(
-            [new Reference('fragment.renderer.inline.inner'), new Reference(SiteAccessSerializerInterface::class)],
+            [
+                new Reference('fragment.renderer.inline.inner'),
+                new Reference(SiteAccessSerializerInterface::class),
+                new Reference(SiteAccessServiceInterface::class),
+            ],
             $decoratedInlineDef->getArguments()
         );
         self::assertSame(InlineFragmentRenderer::class, $decoratedInlineDef->getClass());
@@ -76,7 +81,11 @@ class FragmentPassTest extends AbstractCompilerPassTestCase
         $decoratedEsiDef = $this->container->getDefinition('fragment.renderer.esi');
         self::assertSame(['kernel.fragment_renderer' => [[]]], $decoratedEsiDef->getTags());
         self::assertEquals(
-            [new Reference('fragment.renderer.esi.inner'), new Reference(SiteAccessSerializerInterface::class)],
+            [
+                new Reference('fragment.renderer.esi.inner'),
+                new Reference(SiteAccessSerializerInterface::class),
+                new Reference(SiteAccessServiceInterface::class),
+            ],
             $decoratedEsiDef->getArguments()
         );
 
@@ -84,7 +93,11 @@ class FragmentPassTest extends AbstractCompilerPassTestCase
         $decoratedHincludeDef = $this->container->getDefinition('fragment.renderer.hinclude');
         self::assertSame(['kernel.fragment_renderer' => [[]]], $decoratedHincludeDef->getTags());
         self::assertEquals(
-            [new Reference('fragment.renderer.hinclude.inner'), new Reference(SiteAccessSerializerInterface::class)],
+            [
+                new Reference('fragment.renderer.hinclude.inner'),
+                new Reference(SiteAccessSerializerInterface::class),
+                new Reference(SiteAccessServiceInterface::class),
+            ],
             $decoratedHincludeDef->getArguments()
         );
     }

--- a/tests/bundle/Core/DependencyInjection/Compiler/SecurityPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/SecurityPassTest.php
@@ -43,10 +43,10 @@ final class SecurityPassTest extends AbstractCompilerPassTestCase
     {
         $this->compile();
 
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'security.http_utils',
-            'setSiteAccessService',
-            [new Reference(SiteAccessServiceInterface::class)]
+            '$siteAccessService',
+            new Reference(SiteAccessServiceInterface::class)
         );
     }
 

--- a/tests/bundle/Core/DependencyInjection/Compiler/SecurityPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/SecurityPassTest.php
@@ -13,7 +13,7 @@ use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Security\Authentication\AnonymousUserAccessListener;
-use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -29,7 +29,7 @@ final class SecurityPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('security.http_utils', new Definition());
         $this->setDefinition('security.authentication.success_handler', new Definition());
         $this->setDefinition(ConfigResolverInterface::class, new Definition());
-        $this->setDefinition(SiteAccess::class, new Definition());
+        $this->setDefinition(SiteAccessServiceInterface::class, new Definition());
         $this->setDefinition(PermissionResolver::class, new Definition());
         $this->setDefinition(UserService::class, new Definition());
     }
@@ -45,8 +45,8 @@ final class SecurityPassTest extends AbstractCompilerPassTestCase
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'security.http_utils',
-            'setSiteAccess',
-            [new Reference(SiteAccess::class)]
+            'setSiteAccessService',
+            [new Reference(SiteAccessServiceInterface::class)]
         );
     }
 

--- a/tests/bundle/Core/EventListener/ConsoleCommandListenerTest.php
+++ b/tests/bundle/Core/EventListener/ConsoleCommandListenerTest.php
@@ -25,9 +25,6 @@ class ConsoleCommandListenerTest extends TestCase
 {
     private const INVALID_SA_NAME = 'foo';
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
-    private $siteAccess;
-
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $siteAccessService;
 
@@ -46,12 +43,10 @@ class ConsoleCommandListenerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->siteAccess = new SiteAccess('test');
         $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
         $this->listener = new ConsoleCommandListener(
             'default',
             $this->getSiteAccessProviderMock(),
-            $this->siteAccess,
             $this->siteAccessService
         );
         $this->inputDefinition = new InputDefinition([new InputOption('siteaccess', null, InputOption::VALUE_OPTIONAL)]);
@@ -99,22 +94,20 @@ class ConsoleCommandListenerTest extends TestCase
     {
         $this->siteAccessService->expects(self::once())
             ->method('changeSiteAccess')
-            ->with($this->siteAccess);
+            ->with(self::equalTo(new SiteAccess('site1', 'cli')));
         $input = new ArrayInput(['--siteaccess' => 'site1'], $this->inputDefinition);
         $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
         $this->listener->onConsoleCommand($event);
-        self::assertEquals(new SiteAccess('site1', 'cli'), $this->siteAccess);
     }
 
     public function testDefaultSiteAccess()
     {
         $this->siteAccessService->expects(self::once())
             ->method('changeSiteAccess')
-            ->with($this->siteAccess);
+            ->with(self::equalTo(new SiteAccess('default', 'cli')));
         $input = new ArrayInput([], $this->inputDefinition);
         $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
         $this->listener->onConsoleCommand($event);
-        self::assertEquals(new SiteAccess('default', 'cli'), $this->siteAccess);
     }
 
     private function getSiteAccessProviderMock(): SiteAccess\SiteAccessProviderInterface

--- a/tests/bundle/Core/EventListener/ConsoleCommandListenerTest.php
+++ b/tests/bundle/Core/EventListener/ConsoleCommandListenerTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Bundle\Core\EventListener;
 use Ibexa\Bundle\Core\EventListener\ConsoleCommandListener;
 use Ibexa\Core\MVC\Exception\InvalidSiteAccessException;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Tests\Bundle\Core\EventListener\Stubs\TestOutput;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
@@ -19,7 +20,6 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\Output;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ConsoleCommandListenerTest extends TestCase
 {
@@ -28,8 +28,8 @@ class ConsoleCommandListenerTest extends TestCase
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteAccess;
 
-    /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $dispatcher;
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessService;
 
     /** @var \Ibexa\Bundle\Core\EventListener\ConsoleCommandListener */
     private $listener;
@@ -47,10 +47,13 @@ class ConsoleCommandListenerTest extends TestCase
     {
         parent::setUp();
         $this->siteAccess = new SiteAccess('test');
-        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $this->listener = new ConsoleCommandListener('default', $this->getSiteAccessProviderMock(), $this->dispatcher);
-        $this->listener->setSiteAccess($this->siteAccess);
-        $this->dispatcher->addSubscriber($this->listener);
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $this->listener = new ConsoleCommandListener(
+            'default',
+            $this->getSiteAccessProviderMock(),
+            $this->siteAccess,
+            $this->siteAccessService
+        );
         $this->inputDefinition = new InputDefinition([new InputOption('siteaccess', null, InputOption::VALUE_OPTIONAL)]);
         $this->testOutput = new TestOutput(Output::VERBOSITY_QUIET, true);
         $this->command = $this->createMock(Command::class);
@@ -71,8 +74,8 @@ class ConsoleCommandListenerTest extends TestCase
         $this->expectException(InvalidSiteAccessException::class);
         $this->expectExceptionMessageMatches('/^Invalid SiteAccess \'foo\', matched by .+\\. Valid SiteAccesses are/');
 
-        $this->dispatcher->expects(self::never())
-            ->method('dispatch');
+        $this->siteAccessService->expects(self::never())
+            ->method('changeSiteAccess');
         $input = new ArrayInput(['--siteaccess' => 'foo'], $this->inputDefinition);
         $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
         $this->listener->setDebug(true);
@@ -84,8 +87,8 @@ class ConsoleCommandListenerTest extends TestCase
         $this->expectException(InvalidSiteAccessException::class);
         $this->expectExceptionMessageMatches('/^Invalid SiteAccess \'foo\', matched by .+\\.$/');
 
-        $this->dispatcher->expects(self::never())
-            ->method('dispatch');
+        $this->siteAccessService->expects(self::never())
+            ->method('changeSiteAccess');
         $input = new ArrayInput(['--siteaccess' => 'foo'], $this->inputDefinition);
         $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
         $this->listener->setDebug(false);
@@ -94,8 +97,9 @@ class ConsoleCommandListenerTest extends TestCase
 
     public function testValidSiteAccess()
     {
-        $this->dispatcher->expects(self::once())
-            ->method('dispatch');
+        $this->siteAccessService->expects(self::once())
+            ->method('changeSiteAccess')
+            ->with($this->siteAccess);
         $input = new ArrayInput(['--siteaccess' => 'site1'], $this->inputDefinition);
         $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
         $this->listener->onConsoleCommand($event);
@@ -104,8 +108,9 @@ class ConsoleCommandListenerTest extends TestCase
 
     public function testDefaultSiteAccess()
     {
-        $this->dispatcher->expects(self::once())
-            ->method('dispatch');
+        $this->siteAccessService->expects(self::once())
+            ->method('changeSiteAccess')
+            ->with($this->siteAccess);
         $input = new ArrayInput([], $this->inputDefinition);
         $event = new ConsoleCommandEvent($this->command, $input, $this->testOutput);
         $this->listener->onConsoleCommand($event);

--- a/tests/bundle/Core/Fragment/DecoratedFragmentRendererTest.php
+++ b/tests/bundle/Core/Fragment/DecoratedFragmentRendererTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Bundle\Core\Fragment;
 use Ibexa\Bundle\Core\Fragment\DecoratedFragmentRenderer;
 use Ibexa\Bundle\Core\Fragment\SiteAccessSerializer;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,10 +26,13 @@ class DecoratedFragmentRendererTest extends FragmentRendererBaseTestCase
 {
     protected FragmentRendererInterface & MockObject $innerRenderer;
 
+    protected SiteAccessServiceInterface & MockObject $siteAccessService;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->innerRenderer = $this->createMock(FragmentRendererInterface::class);
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
     }
 
     public function testSetFragmentPathNotRoutableRenderer(): void
@@ -39,8 +43,9 @@ class DecoratedFragmentRendererTest extends FragmentRendererBaseTestCase
             ->expects(self::never())
             ->method('analyseLink');
 
+        $this->siteAccessService->method('getCurrent')->willReturn($siteAccess);
+
         $renderer = $this->getRenderer();
-        $renderer->setSiteAccess($siteAccess);
         if ($renderer instanceof RoutableFragmentRenderer) {
             $renderer->setFragmentPath('foo');
         }
@@ -56,13 +61,14 @@ class DecoratedFragmentRendererTest extends FragmentRendererBaseTestCase
             ->with('/foo')
             ->willReturn('/bar/foo');
 
+        $this->siteAccessService->method('getCurrent')->willReturn($siteAccess);
+
         $innerRenderer = $this->createMock(RoutableFragmentRenderer::class);
         $innerRenderer
             ->expects(self::once())
             ->method('setFragmentPath')
             ->with('/bar/foo');
-        $renderer = new DecoratedFragmentRenderer($innerRenderer, new SiteAccessSerializer($this->getSerializer()));
-        $renderer->setSiteAccess($siteAccess);
+        $renderer = new DecoratedFragmentRenderer($innerRenderer, new SiteAccessSerializer($this->getSerializer()), $this->siteAccessService);
         $renderer->setFragmentPath('/foo');
     }
 
@@ -137,11 +143,8 @@ class DecoratedFragmentRendererTest extends FragmentRendererBaseTestCase
         return $request;
     }
 
-    /**
-     * @return \Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface&\Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessAware
-     */
     public function getRenderer(): FragmentRendererInterface
     {
-        return new DecoratedFragmentRenderer($this->innerRenderer, new SiteAccessSerializer($this->getSerializer()));
+        return new DecoratedFragmentRenderer($this->innerRenderer, new SiteAccessSerializer($this->getSerializer()), $this->siteAccessService);
     }
 }

--- a/tests/bundle/Core/Routing/DefaultRouterTest.php
+++ b/tests/bundle/Core/Routing/DefaultRouterTest.php
@@ -12,6 +12,7 @@ use Ibexa\Bundle\Core\SiteAccess\Matcher;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -198,7 +199,7 @@ class DefaultRouterTest extends TestCase
         }
 
         $sa = new SiteAccess($saName, 'test', $matcher);
-        $router->setSiteAccess($sa);
+        $router->setSiteAccessService($this->getSiteAccessService($sa));
 
         $requestContext = new RequestContext();
         $urlComponents = parse_url($urlGenerated);
@@ -274,7 +275,7 @@ class DefaultRouterTest extends TestCase
 
         $router = new DefaultRouter($this->container, 'foo', [], $this->requestContext);
         $router->setConfigResolver($this->configResolver);
-        $router->setSiteAccess(new SiteAccess('test', 'test', $this->createMock(Matcher::class)));
+        $router->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'test', $this->createMock(Matcher::class))));
         $router->setSiteAccessRouter($siteAccessRouter);
         $refRouter = new ReflectionObject($router);
         $refGenerator = $refRouter->getProperty('generator');
@@ -341,5 +342,16 @@ class DefaultRouterTest extends TestCase
         }
 
         return $requestContext;
+    }
+
+    /**
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getSiteAccessService(SiteAccess $siteAccess)
+    {
+        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $siteAccessService->method('getCurrent')->willReturn($siteAccess);
+
+        return $siteAccessService;
     }
 }

--- a/tests/bundle/Core/Routing/DefaultRouterTest.php
+++ b/tests/bundle/Core/Routing/DefaultRouterTest.php
@@ -53,12 +53,12 @@ class DefaultRouterTest extends TestCase
      *
      * @return \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Bundle\Core\Routing\DefaultRouter
      */
-    protected function generateRouter(array $mockedMethods = [])
+    protected function generateRouter(array $mockedMethods = [], ?SiteAccessServiceInterface $siteAccessService = null)
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject&\Ibexa\Bundle\Core\Routing\DefaultRouter $router */
         $router = $this
             ->getMockBuilder($this->getRouterClass())
-            ->setConstructorArgs([$this->container, 'foo', [], $this->requestContext])
+            ->setConstructorArgs([$this->container, 'foo', [], $this->requestContext, null, null, null, $siteAccessService])
             ->setMethods(array_merge($mockedMethods))
             ->getMock();
         $router->setConfigResolver($this->configResolver);
@@ -171,8 +171,10 @@ class DefaultRouterTest extends TestCase
             ->with($routeName)
             ->willReturn($urlGenerated);
 
+        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+
         /** @var \Ibexa\Bundle\Core\Routing\DefaultRouter&\PHPUnit\Framework\MockObject\MockObject $router */
-        $router = $this->generateRouter(['getGenerator']);
+        $router = $this->generateRouter(['getGenerator'], $siteAccessService);
         $router
             ->expects(self::any())
             ->method('getGenerator')
@@ -199,7 +201,7 @@ class DefaultRouterTest extends TestCase
         }
 
         $sa = new SiteAccess($saName, 'test', $matcher);
-        $router->setSiteAccessService($this->getSiteAccessService($sa));
+        $siteAccessService->method('getCurrent')->willReturn($sa);
 
         $requestContext = new RequestContext();
         $urlComponents = parse_url($urlGenerated);
@@ -273,9 +275,14 @@ class DefaultRouterTest extends TestCase
             ->method('setContext')
             ->with($this->requestContext);
 
-        $router = new DefaultRouter($this->container, 'foo', [], $this->requestContext);
+        $router = new DefaultRouter(
+            $this->container,
+            'foo',
+            [],
+            $this->requestContext,
+            siteAccessService: $this->getSiteAccessService(new SiteAccess('test', 'test', $this->createMock(Matcher::class)))
+        );
         $router->setConfigResolver($this->configResolver);
-        $router->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'test', $this->createMock(Matcher::class))));
         $router->setSiteAccessRouter($siteAccessRouter);
         $refRouter = new ReflectionObject($router);
         $refGenerator = $refRouter->getProperty('generator');

--- a/tests/bundle/Core/SiteAccess/Config/IOConfigResolverTest.php
+++ b/tests/bundle/Core/SiteAccess/Config/IOConfigResolverTest.php
@@ -12,7 +12,7 @@ use Ibexa\Bundle\Core\SiteAccess\Config\ComplexConfigProcessor;
 use Ibexa\Bundle\Core\SiteAccess\Config\IOConfigResolver;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,14 +25,14 @@ class IOConfigResolverTest extends TestCase
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $configResolver;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $siteAccessService;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
-        $this->siteAccessService = $this->createMock(SiteAccessService::class);
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
     }
 
     public function testGetUrlPrefix(): void

--- a/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
+++ b/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
@@ -14,8 +14,14 @@ use Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension;
 use Ibexa\Bundle\IO\DependencyInjection\ConfigurationFactory;
 use Ibexa\Bundle\IO\DependencyInjection\IbexaIOExtension;
 use Ibexa\Core\IO\UrlDecorator\AbsolutePrefix;
+use Ibexa\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
 use Ibexa\Tests\Integration\Core\Repository\Container\Compiler\SetAllServicesPublicPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Yaml\Yaml;
 
 class IbexaIOExtensionTest extends AbstractExtensionTestCase
@@ -86,6 +92,15 @@ class IbexaIOExtensionTest extends AbstractExtensionTestCase
         );
         $this->buildMinimalContainerForUrlPrefixTest();
 
+        // Simulate SiteAccess matching having happened for the "site" siteaccess, since
+        // ComplexConfigProcessor now resolves the current SiteAccess via SiteAccessService
+        // rather than reading a pre-set property.
+        $siteAccessService = $this->container->get(SiteAccessService::class);
+        self::assertInstanceOf(SiteAccessService::class, $siteAccessService);
+        $siteAccessService->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent(new SiteAccess('site'), new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
+
         $decorator = $this->container->get(AbsolutePrefix::class);
 
         self::assertEquals(
@@ -101,6 +116,9 @@ class IbexaIOExtensionTest extends AbstractExtensionTestCase
         $this->container->setParameter('kernel.debug', true);
         $this->container->setParameter('kernel.project_dir', self::FIXTURES_DIR);
         $this->container->setParameter('kernel.cache_dir', self::FIXTURES_DIR . '/cache');
+        // needed by Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService, pulled in transitively
+        // via the AliasGeneratorDecorator service definition
+        $this->container->register('event_dispatcher', EventDispatcher::class);
 
         $this->container->addCompilerPass(new ChainConfigResolverPass());
         $this->container->addCompilerPass(new SetAllServicesPublicPass());

--- a/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
+++ b/tests/bundle/IO/DependencyInjection/IbexaIOExtensionTest.php
@@ -95,6 +95,10 @@ class IbexaIOExtensionTest extends AbstractExtensionTestCase
         // Simulate SiteAccess matching having happened for the "site" siteaccess, since
         // ComplexConfigProcessor now resolves the current SiteAccess via SiteAccessService
         // rather than reading a pre-set property.
+        //
+        // Fetched by concrete class (not SiteAccessServiceInterface): onSiteAccessMatch() is a
+        // subscriber-only method not part of the interface, and SetAllServicesPublicPass only
+        // exposes real service definitions, not the interface alias.
         $siteAccessService = $this->container->get(SiteAccessService::class);
         self::assertInstanceOf(SiteAccessService::class, $siteAccessService);
         $siteAccessService->onSiteAccessMatch(

--- a/tests/integration/Core/LegacyTestContainerBuilder.php
+++ b/tests/integration/Core/LegacyTestContainerBuilder.php
@@ -13,7 +13,7 @@ use Ibexa\Bundle\Core\SiteAccess\Config\ComplexConfigProcessor;
 use Ibexa\Contracts\Core\SiteAccess\ConfigProcessor;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\Base\Container\Compiler;
-use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Tests\Integration\Core\Repository\Container\Compiler\SetAllServicesPublicPass;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Config\FileLocator;
@@ -166,7 +166,7 @@ final class LegacyTestContainerBuilder extends ContainerBuilder
 
         $definition = new Definition(ComplexConfigProcessor::class);
         $definition->setArgument('$configResolver', new Reference(ConfigResolverInterface::class));
-        $definition->setArgument('$siteAccessService', new Reference(SiteAccessService::class));
+        $definition->setArgument('$siteAccessService', new Reference(SiteAccessServiceInterface::class));
 
         $this->setDefinition(ConfigProcessor::class, $definition);
     }

--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -112,6 +112,7 @@ services:
             - '@ibexa.siteaccess.provider'
             - '@ibexa.config.resolver'
             - '@Symfony\Component\EventDispatcher\EventDispatcher'
+            - '@Ibexa\Core\MVC\Symfony\SiteAccess'
 
     Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface:
         alias: 'Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'

--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -106,13 +106,21 @@ services:
     Ibexa\Core\MVC\Symfony\SiteAccess:
         arguments: ['default', !php/const Ibexa\Core\MVC\Symfony\SiteAccess::MATCHING_TYPE_UNINITIALIZED]
 
+    # Dedicated SiteAccess used to seed SiteAccessService below: integration tests never dispatch a
+    # real request, so this establishes a default current SiteAccess the same way ConsoleCommandListener
+    # does for CLI (a fresh SiteAccess passed to changeSiteAccess(), no shared/mutated singleton).
+    ibexa.test.default_site_access:
+        class: Ibexa\Core\MVC\Symfony\SiteAccess
+        arguments: ['default']
+
     Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService:
         class: Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService
         arguments:
             - '@ibexa.siteaccess.provider'
             - '@ibexa.config.resolver'
             - '@Symfony\Component\EventDispatcher\EventDispatcher'
-            - '@Ibexa\Core\MVC\Symfony\SiteAccess'
+        calls:
+            - [changeSiteAccess, ['@ibexa.test.default_site_access']]
 
     Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface:
         alias: 'Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'

--- a/tests/integration/Core/Resources/settings/common.yml
+++ b/tests/integration/Core/Resources/settings/common.yml
@@ -111,8 +111,7 @@ services:
         arguments:
             - '@ibexa.siteaccess.provider'
             - '@ibexa.config.resolver'
-        calls:
-            - [setSiteAccess, ['@Ibexa\Core\MVC\Symfony\SiteAccess']]
+            - '@Symfony\Component\EventDispatcher\EventDispatcher'
 
     Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface:
         alias: 'Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService'

--- a/tests/lib/Helper/ContentPreviewHelperTest.php
+++ b/tests/lib/Helper/ContentPreviewHelperTest.php
@@ -10,17 +10,15 @@ namespace Ibexa\Tests\Core\Helper;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content as APIContent;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location as APILocation;
 use Ibexa\Core\Helper\ContentPreviewHelper;
-use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
-use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContentPreviewHelperTest extends TestCase
 {
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
-    private $eventDispatcher;
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessService;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $siteAccessRouter;
@@ -31,9 +29,9 @@ class ContentPreviewHelperTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
         $this->siteAccessRouter = $this->createMock(SiteAccessRouterInterface::class);
-        $this->previewHelper = new ContentPreviewHelper($this->eventDispatcher, $this->siteAccessRouter);
+        $this->previewHelper = new ContentPreviewHelper($this->siteAccessRouter, $this->siteAccessService);
     }
 
     public function testChangeConfigScope()
@@ -47,14 +45,12 @@ class ContentPreviewHelperTest extends TestCase
             ->with(self::equalTo($newSiteAccessName))
             ->willReturn($newSiteAccess);
 
-        $event = new ScopeChangeEvent($newSiteAccess);
-        $this->eventDispatcher
+        $this->siteAccessService
             ->expects(self::once())
-            ->method('dispatch')
-            ->with(self::equalTo($event), MVCEvents::CONFIG_SCOPE_CHANGE);
+            ->method('changeSiteAccess')
+            ->with($newSiteAccess)
+            ->willReturn($newSiteAccess);
 
-        $originalSiteAccess = new SiteAccess('foo', 'bar');
-        $this->previewHelper->setSiteAccess($originalSiteAccess);
         self::assertEquals(
             $newSiteAccess,
             $this->previewHelper->changeConfigScope($newSiteAccessName)
@@ -64,13 +60,11 @@ class ContentPreviewHelperTest extends TestCase
     public function testRestoreConfigScope()
     {
         $originalSiteAccess = new SiteAccess('foo', 'bar');
-        $event = new ScopeChangeEvent($originalSiteAccess);
-        $this->eventDispatcher
+        $this->siteAccessService
             ->expects(self::once())
-            ->method('dispatch')
-            ->with(self::equalTo($event), MVCEvents::CONFIG_SCOPE_RESTORE);
+            ->method('restoreSiteAccess')
+            ->willReturn($originalSiteAccess);
 
-        $this->previewHelper->setSiteAccess($originalSiteAccess);
         self::assertEquals(
             $originalSiteAccess,
             $this->previewHelper->restoreConfigScope()
@@ -80,7 +74,9 @@ class ContentPreviewHelperTest extends TestCase
     public function testPreviewActive()
     {
         $originalSiteAccess = new SiteAccess('foo', 'bar');
-        $this->previewHelper->setSiteAccess($originalSiteAccess);
+        $this->siteAccessService
+            ->method('getCurrent')
+            ->willReturn($originalSiteAccess);
 
         self::assertFalse($this->previewHelper->isPreviewActive());
         $this->previewHelper->setPreviewActive(true);
@@ -88,7 +84,7 @@ class ContentPreviewHelperTest extends TestCase
         $this->previewHelper->setPreviewActive(false);
         self::assertFalse($this->previewHelper->isPreviewActive());
 
-        self::assertNotSame($originalSiteAccess, $this->previewHelper->getOriginalSiteAccess());
+        self::assertSame($originalSiteAccess, $this->previewHelper->getOriginalSiteAccess());
     }
 
     public function testPreviewedContent()

--- a/tests/lib/MVC/Symfony/Routing/GeneratorTest.php
+++ b/tests/lib/MVC/Symfony/Routing/GeneratorTest.php
@@ -29,12 +29,16 @@ class GeneratorTest extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $logger;
 
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessService;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->siteAccessRouter = $this->createMock(SiteAccessRouterInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
-        $this->generator = $this->getMockForAbstractClass(Generator::class);
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $this->generator = $this->getMockForAbstractClass(Generator::class, [$this->siteAccessService]);
         $this->generator->setSiteAccessRouter($this->siteAccessRouter);
         $this->generator->setLogger($this->logger);
     }
@@ -60,7 +64,7 @@ class GeneratorTest extends TestCase
     public function testSimpleGenerate($urlResource, array $parameters, $referenceType)
     {
         $matcher = $this->createMock(URILexer::class);
-        $this->generator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'fake', $matcher)));
+        $this->siteAccessService->method('getCurrent')->willReturn(new SiteAccess('test', 'fake', $matcher));
 
         $baseUrl = '/base/url';
         $requestContext = new RequestContext($baseUrl);
@@ -93,7 +97,7 @@ class GeneratorTest extends TestCase
     public function testGenerateWithSiteAccessNoReverseMatch($urlResource, array $parameters, $referenceType)
     {
         $matcher = $this->createMock(URILexer::class);
-        $this->generator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'test', $matcher)));
+        $this->siteAccessService->method('getCurrent')->willReturn(new SiteAccess('test', 'test', $matcher));
 
         $baseUrl = '/base/url';
         $requestContext = new RequestContext($baseUrl);
@@ -127,16 +131,5 @@ class GeneratorTest extends TestCase
             ->expects(self::once())
             ->method('notice');
         self::assertSame($fullUri, $this->generator->generate($urlResource, $parameters + ['siteaccess' => $siteAccessName], $referenceType));
-    }
-
-    /**
-     * @return \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private function getSiteAccessService(SiteAccess $siteAccess)
-    {
-        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
-        $siteAccessService->method('getCurrent')->willReturn($siteAccess);
-
-        return $siteAccessService;
     }
 }

--- a/tests/lib/MVC/Symfony/Routing/GeneratorTest.php
+++ b/tests/lib/MVC/Symfony/Routing/GeneratorTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Routing;
 use Ibexa\Core\MVC\Symfony\Routing\Generator;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess\URILexer;
 use Ibexa\Core\Repository\Values\Content\Location;
 use PHPUnit\Framework\TestCase;
@@ -59,7 +60,7 @@ class GeneratorTest extends TestCase
     public function testSimpleGenerate($urlResource, array $parameters, $referenceType)
     {
         $matcher = $this->createMock(URILexer::class);
-        $this->generator->setSiteAccess(new SiteAccess('test', 'fake', $matcher));
+        $this->generator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'fake', $matcher)));
 
         $baseUrl = '/base/url';
         $requestContext = new RequestContext($baseUrl);
@@ -92,7 +93,7 @@ class GeneratorTest extends TestCase
     public function testGenerateWithSiteAccessNoReverseMatch($urlResource, array $parameters, $referenceType)
     {
         $matcher = $this->createMock(URILexer::class);
-        $this->generator->setSiteAccess(new SiteAccess('test', 'test', $matcher));
+        $this->generator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'test', $matcher)));
 
         $baseUrl = '/base/url';
         $requestContext = new RequestContext($baseUrl);
@@ -126,5 +127,16 @@ class GeneratorTest extends TestCase
             ->expects(self::once())
             ->method('notice');
         self::assertSame($fullUri, $this->generator->generate($urlResource, $parameters + ['siteaccess' => $siteAccessName], $referenceType));
+    }
+
+    /**
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getSiteAccessService(SiteAccess $siteAccess)
+    {
+        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $siteAccessService->method('getCurrent')->willReturn($siteAccess);
+
+        return $siteAccessService;
     }
 }

--- a/tests/lib/MVC/Symfony/Routing/UrlAliasGeneratorTest.php
+++ b/tests/lib/MVC/Symfony/Routing/UrlAliasGeneratorTest.php
@@ -16,6 +16,7 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Core\Repository\Mapper\RoleDomainMapper;
 use Ibexa\Core\Repository\Permission\LimitationService;
 use Ibexa\Core\Repository\Permission\PermissionResolver;
@@ -176,7 +177,7 @@ class UrlAliasGeneratorTest extends TestCase
             ->with($location, false)
             ->will(self::returnValue([$urlAlias]));
 
-        $this->urlAliasGenerator->setSiteAccess(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class)));
+        $this->urlAliasGenerator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class))));
 
         self::assertSame($expected, $this->urlAliasGenerator->doGenerate($location, $parameters));
     }
@@ -274,7 +275,7 @@ class UrlAliasGeneratorTest extends TestCase
                 )
             );
 
-        $this->urlAliasGenerator->setSiteAccess(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class)));
+        $this->urlAliasGenerator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class))));
 
         self::assertSame($expected, $this->urlAliasGenerator->doGenerate($location, $parameters));
     }
@@ -385,10 +386,12 @@ class UrlAliasGeneratorTest extends TestCase
             ->with($location, null, false, ['ger-DE'])
             ->willReturn($treeRootUrlAliases[$location->id]);
 
-        $this->urlAliasGenerator->setSiteAccess(
-            new SiteAccess(
-                $gerSiteAccess,
-                'default',
+        $this->urlAliasGenerator->setSiteAccessService(
+            $this->getSiteAccessService(
+                new SiteAccess(
+                    $gerSiteAccess,
+                    'default',
+                )
             )
         );
 
@@ -522,6 +525,17 @@ class UrlAliasGeneratorTest extends TestCase
                 '/prod',
             ],
         ];
+    }
+
+    /**
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getSiteAccessService(SiteAccess $siteAccess)
+    {
+        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $siteAccessService->method('getCurrent')->willReturn($siteAccess);
+
+        return $siteAccessService;
     }
 
     protected function getPermissionResolverMock()

--- a/tests/lib/MVC/Symfony/Routing/UrlAliasGeneratorTest.php
+++ b/tests/lib/MVC/Symfony/Routing/UrlAliasGeneratorTest.php
@@ -52,6 +52,9 @@ class UrlAliasGeneratorTest extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject */
     private $configResolver;
 
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessService;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -59,6 +62,7 @@ class UrlAliasGeneratorTest extends TestCase
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->siteAccessRouter = $this->createMock(SiteAccessRouterInterface::class);
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
         $repositoryClass = Repository::class;
         $this->repository = $repository = $this
             ->getMockBuilder($repositoryClass)
@@ -95,6 +99,7 @@ class UrlAliasGeneratorTest extends TestCase
             $this->repository,
             $this->router,
             $this->configResolver,
+            $this->siteAccessService,
             $urlAliasCharmap
         );
         $this->urlAliasGenerator->setLogger($this->logger);
@@ -177,7 +182,7 @@ class UrlAliasGeneratorTest extends TestCase
             ->with($location, false)
             ->will(self::returnValue([$urlAlias]));
 
-        $this->urlAliasGenerator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class))));
+        $this->siteAccessService->method('getCurrent')->willReturn(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class)));
 
         self::assertSame($expected, $this->urlAliasGenerator->doGenerate($location, $parameters));
     }
@@ -275,7 +280,7 @@ class UrlAliasGeneratorTest extends TestCase
                 )
             );
 
-        $this->urlAliasGenerator->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class))));
+        $this->siteAccessService->method('getCurrent')->willReturn(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class)));
 
         self::assertSame($expected, $this->urlAliasGenerator->doGenerate($location, $parameters));
     }
@@ -386,12 +391,10 @@ class UrlAliasGeneratorTest extends TestCase
             ->with($location, null, false, ['ger-DE'])
             ->willReturn($treeRootUrlAliases[$location->id]);
 
-        $this->urlAliasGenerator->setSiteAccessService(
-            $this->getSiteAccessService(
-                new SiteAccess(
-                    $gerSiteAccess,
-                    'default',
-                )
+        $this->siteAccessService->method('getCurrent')->willReturn(
+            new SiteAccess(
+                $gerSiteAccess,
+                'default',
             )
         );
 
@@ -525,17 +528,6 @@ class UrlAliasGeneratorTest extends TestCase
                 '/prod',
             ],
         ];
-    }
-
-    /**
-     * @return \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private function getSiteAccessService(SiteAccess $siteAccess)
-    {
-        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
-        $siteAccessService->method('getCurrent')->willReturn($siteAccess);
-
-        return $siteAccessService;
     }
 
     protected function getPermissionResolverMock()

--- a/tests/lib/MVC/Symfony/Routing/UrlAliasRouterTest.php
+++ b/tests/lib/MVC/Symfony/Routing/UrlAliasRouterTest.php
@@ -18,6 +18,7 @@ use Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use Ibexa\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Matcher;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\Core\MVC\Symfony\View\Manager as ViewManager;
 use Ibexa\Core\Repository\Repository;
 use Ibexa\Core\Repository\Values\Content\Location;
@@ -77,6 +78,7 @@ class UrlAliasRouterTest extends TestCase
                     $repository,
                     $this->createMock(RouterInterface::class),
                     $this->createMock(ConfigResolverInterface::class),
+                    $this->createMock(SiteAccessServiceInterface::class),
                 ]
             )
             ->getMock();

--- a/tests/lib/MVC/Symfony/Security/HttpUtilsTest.php
+++ b/tests/lib/MVC/Symfony/Security/HttpUtilsTest.php
@@ -22,8 +22,7 @@ class HttpUtilsTest extends TestCase
     public function testGenerateUriStandard($uri, $isUriRouteName, $expected)
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $httpUtils = new HttpUtils($urlGenerator);
-        $httpUtils->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test')));
+        $httpUtils = new HttpUtils($urlGenerator, siteAccessService: $this->getSiteAccessService(new SiteAccess('test')));
         $request = Request::create('http://ezpublish.dev/');
         $request->attributes->set('siteaccess', new SiteAccess('test'));
         $requestAttributes = ['foo' => 'bar', 'some' => 'thing'];
@@ -68,8 +67,7 @@ class HttpUtilsTest extends TestCase
         }
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $httpUtils = new HttpUtils($urlGenerator);
-        $httpUtils->setSiteAccessService($this->getSiteAccessService($siteAccess));
+        $httpUtils = new HttpUtils($urlGenerator, siteAccessService: $this->getSiteAccessService($siteAccess));
         $request = Request::create('http://ezpublish.dev/');
         $request->attributes->set('siteaccess', $siteAccess);
         $requestAttributes = ['foo' => 'bar', 'some' => 'thing'];
@@ -100,8 +98,7 @@ class HttpUtilsTest extends TestCase
 
     public function testCheckRequestPathStandard()
     {
-        $httpUtils = new HttpUtils();
-        $httpUtils->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test')));
+        $httpUtils = new HttpUtils(siteAccessService: $this->getSiteAccessService(new SiteAccess('test')));
         $request = Request::create('http://ezpublish.dev/foo/bar');
         self::assertTrue($httpUtils->checkRequestPath($request, '/foo/bar'));
     }
@@ -122,8 +119,7 @@ class HttpUtilsTest extends TestCase
             $siteAccess->matcher = $matcher;
         }
 
-        $httpUtils = new HttpUtils();
-        $httpUtils->setSiteAccessService($this->getSiteAccessService($siteAccess));
+        $httpUtils = new HttpUtils(siteAccessService: $this->getSiteAccessService($siteAccess));
         $request = Request::create($requestUri);
         self::assertSame($expected, $httpUtils->checkRequestPath($request, $path));
     }

--- a/tests/lib/MVC/Symfony/Security/HttpUtilsTest.php
+++ b/tests/lib/MVC/Symfony/Security/HttpUtilsTest.php
@@ -9,6 +9,7 @@ namespace Ibexa\Tests\Core\MVC\Symfony\Security;
 
 use Ibexa\Core\MVC\Symfony\Security\HttpUtils;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -22,7 +23,7 @@ class HttpUtilsTest extends TestCase
     {
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $httpUtils = new HttpUtils($urlGenerator);
-        $httpUtils->setSiteAccess(new SiteAccess('test'));
+        $httpUtils->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test')));
         $request = Request::create('http://ezpublish.dev/');
         $request->attributes->set('siteaccess', new SiteAccess('test'));
         $requestAttributes = ['foo' => 'bar', 'some' => 'thing'];
@@ -68,7 +69,7 @@ class HttpUtilsTest extends TestCase
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $httpUtils = new HttpUtils($urlGenerator);
-        $httpUtils->setSiteAccess($siteAccess);
+        $httpUtils->setSiteAccessService($this->getSiteAccessService($siteAccess));
         $request = Request::create('http://ezpublish.dev/');
         $request->attributes->set('siteaccess', $siteAccess);
         $requestAttributes = ['foo' => 'bar', 'some' => 'thing'];
@@ -100,7 +101,7 @@ class HttpUtilsTest extends TestCase
     public function testCheckRequestPathStandard()
     {
         $httpUtils = new HttpUtils();
-        $httpUtils->setSiteAccess(new SiteAccess('test'));
+        $httpUtils->setSiteAccessService($this->getSiteAccessService(new SiteAccess('test')));
         $request = Request::create('http://ezpublish.dev/foo/bar');
         self::assertTrue($httpUtils->checkRequestPath($request, '/foo/bar'));
     }
@@ -122,7 +123,7 @@ class HttpUtilsTest extends TestCase
         }
 
         $httpUtils = new HttpUtils();
-        $httpUtils->setSiteAccess($siteAccess);
+        $httpUtils->setSiteAccessService($this->getSiteAccessService($siteAccess));
         $request = Request::create($requestUri);
         self::assertSame($expected, $httpUtils->checkRequestPath($request, $path));
     }
@@ -137,5 +138,16 @@ class HttpUtilsTest extends TestCase
             ['/foo', '/test_access', 'http://ezpublish.dev/test_access/foo/bar?some=thing&toto=tata', false],
             ['/foo/bar', '/blabla', 'http://ezpublish.dev/blabla/foo/bar', true],
         ];
+    }
+
+    /**
+     * @return \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getSiteAccessService(SiteAccess $siteAccess)
+    {
+        $siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
+        $siteAccessService->method('getCurrent')->willReturn($siteAccess);
+
+        return $siteAccessService;
     }
 }

--- a/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
@@ -42,9 +42,6 @@ class SiteAccessServiceTest extends TestCase
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteAccess;
 
-    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
-    private $defaultSiteAccess;
-
     /** @var \ArrayIterator */
     private $availableSiteAccesses;
 
@@ -58,21 +55,28 @@ class SiteAccessServiceTest extends TestCase
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->siteAccess = new SiteAccess('current');
-        $this->defaultSiteAccess = new SiteAccess('uninitialized_default', SiteAccess::MATCHING_TYPE_UNINITIALIZED);
         $this->availableSiteAccesses = $this->getAvailableSitAccesses(['current', 'first_sa', 'second_sa', 'default']);
         $this->configResolverParameters = $this->getConfigResolverParameters();
     }
 
-    /**
-     * Before any request has matched, getCurrent() must return the constructor-seeded default
-     * SiteAccess rather than null — this preserves the pre-existing guarantee (relied on by e.g.
-     * ComplexConfigProcessor) that getCurrent() is never null once the container is built.
-     */
-    public function testGetCurrentSiteAccessReturnsSeedBeforeAnyMatch(): void
+    public function testGetCurrentSiteAccessIsNullWhenStackIsEmpty(): void
     {
         $service = $this->createSiteAccessService();
 
-        self::assertSame($this->defaultSiteAccess, $service->getCurrent());
+        self::assertNull($service->getCurrent());
+    }
+
+    /**
+     * A SiteAccess with an "uninitialized" matcher (see SiteAccess::MATCHING_TYPE_UNINITIALIZED)
+     * is not a real current SiteAccess — getCurrent() must surface it as null.
+     */
+    public function testGetCurrentSiteAccessIsNullWhenTopOfStackIsUninitialized(): void
+    {
+        $service = $this->createSiteAccessService();
+
+        $service->changeSiteAccess(new SiteAccess('default', SiteAccess::MATCHING_TYPE_UNINITIALIZED));
+
+        self::assertNull($service->getCurrent());
     }
 
     public function testGetCurrentSiteAccessAfterMainRequestMatch(): void
@@ -96,8 +100,7 @@ class SiteAccessServiceTest extends TestCase
         $service = new SiteAccessService(
             $staticSiteAccessProvider,
             $this->createMock(ConfigResolverInterface::class),
-            $this->eventDispatcher,
-            $this->defaultSiteAccess
+            $this->eventDispatcher
         );
 
         self::assertEquals(
@@ -115,8 +118,7 @@ class SiteAccessServiceTest extends TestCase
         $service = new SiteAccessService(
             $staticSiteAccessProvider,
             $this->createMock(ConfigResolverInterface::class),
-            $this->eventDispatcher,
-            $this->defaultSiteAccess
+            $this->eventDispatcher
         );
 
         $this->expectException(NotFoundException::class);
@@ -295,8 +297,7 @@ class SiteAccessServiceTest extends TestCase
         return new SiteAccessService(
             $this->provider,
             $this->configResolver,
-            $this->eventDispatcher,
-            $this->defaultSiteAccess
+            $this->eventDispatcher
         );
     }
 

--- a/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
@@ -42,6 +42,9 @@ class SiteAccessServiceTest extends TestCase
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteAccess;
 
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
+    private $defaultSiteAccess;
+
     /** @var \ArrayIterator */
     private $availableSiteAccesses;
 
@@ -55,20 +58,26 @@ class SiteAccessServiceTest extends TestCase
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->siteAccess = new SiteAccess('current');
+        $this->defaultSiteAccess = new SiteAccess('uninitialized_default', SiteAccess::MATCHING_TYPE_UNINITIALIZED);
         $this->availableSiteAccesses = $this->getAvailableSitAccesses(['current', 'first_sa', 'second_sa', 'default']);
         $this->configResolverParameters = $this->getConfigResolverParameters();
     }
 
-    public function testGetCurrentSiteAccessIsNullWhenStackIsEmpty(): void
+    /**
+     * Before any request has matched, getCurrent() must return the constructor-seeded default
+     * SiteAccess rather than null — this preserves the pre-existing guarantee (relied on by e.g.
+     * ComplexConfigProcessor) that getCurrent() is never null once the container is built.
+     */
+    public function testGetCurrentSiteAccessReturnsSeedBeforeAnyMatch(): void
     {
-        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $service = $this->createSiteAccessService();
 
-        self::assertNull($service->getCurrent());
+        self::assertSame($this->defaultSiteAccess, $service->getCurrent());
     }
 
     public function testGetCurrentSiteAccessAfterMainRequestMatch(): void
     {
-        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $service = $this->createSiteAccessService();
 
         $siteAccess = new SiteAccess('default');
         $service->onSiteAccessMatch(
@@ -87,7 +96,8 @@ class SiteAccessServiceTest extends TestCase
         $service = new SiteAccessService(
             $staticSiteAccessProvider,
             $this->createMock(ConfigResolverInterface::class),
-            $this->eventDispatcher
+            $this->eventDispatcher,
+            $this->defaultSiteAccess
         );
 
         self::assertEquals(
@@ -105,7 +115,8 @@ class SiteAccessServiceTest extends TestCase
         $service = new SiteAccessService(
             $staticSiteAccessProvider,
             $this->createMock(ConfigResolverInterface::class),
-            $this->eventDispatcher
+            $this->eventDispatcher,
+            $this->defaultSiteAccess
         );
 
         $this->expectException(NotFoundException::class);
@@ -147,7 +158,7 @@ class SiteAccessServiceTest extends TestCase
      */
     public function testChangeSiteAccessAndRestoreSiteAccessBehaveAsLifoStack(): void
     {
-        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $service = $this->createSiteAccessService();
 
         $original = new SiteAccess('original');
         $service->onSiteAccessMatch(
@@ -182,7 +193,7 @@ class SiteAccessServiceTest extends TestCase
 
     public function testOnSiteAccessMatchWithMainRequestResetsTheStack(): void
     {
-        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $service = $this->createSiteAccessService();
 
         $service->onSiteAccessMatch(
             new PostSiteAccessMatchEvent(new SiteAccess('first'), new Request(), HttpKernelInterface::MAIN_REQUEST)
@@ -206,7 +217,7 @@ class SiteAccessServiceTest extends TestCase
 
     public function testOnSiteAccessMatchWithSubRequestPushesWithoutResetting(): void
     {
-        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $service = $this->createSiteAccessService();
 
         $main = new SiteAccess('main');
         $service->onSiteAccessMatch(
@@ -226,7 +237,7 @@ class SiteAccessServiceTest extends TestCase
 
     public function testOnKernelFinishRequestNeverPopsBelowOneRemainingEntry(): void
     {
-        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $service = $this->createSiteAccessService();
 
         $original = new SiteAccess('original');
         $service->onSiteAccessMatch(
@@ -246,7 +257,7 @@ class SiteAccessServiceTest extends TestCase
      */
     public function testSubRequestNestingScenario(): void
     {
-        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $service = $this->createSiteAccessService();
 
         $original = new SiteAccess('original');
         $service->onSiteAccessMatch(
@@ -279,9 +290,19 @@ class SiteAccessServiceTest extends TestCase
         );
     }
 
+    private function createSiteAccessService(): SiteAccessService
+    {
+        return new SiteAccessService(
+            $this->provider,
+            $this->configResolver,
+            $this->eventDispatcher,
+            $this->defaultSiteAccess
+        );
+    }
+
     private function getSiteAccessService(): SiteAccessService
     {
-        $siteAccessService = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $siteAccessService = $this->createSiteAccessService();
         $siteAccessService->onSiteAccessMatch(
             new PostSiteAccessMatchEvent($this->siteAccess, new Request(), HttpKernelInterface::MAIN_REQUEST)
         );

--- a/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
+++ b/tests/lib/MVC/Symfony/SiteAccess/SiteAccessServiceTest.php
@@ -11,11 +11,18 @@ namespace Ibexa\Tests\Core\MVC\Symfony\SiteAccess;
 use ArrayIterator;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use Ibexa\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use Ibexa\Core\MVC\Symfony\MVCEvents;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\Provider\StaticSiteAccessProvider;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class SiteAccessServiceTest extends TestCase
 {
@@ -28,6 +35,9 @@ class SiteAccessServiceTest extends TestCase
 
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $configResolver;
+
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $eventDispatcher;
 
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteAccess;
@@ -43,26 +53,29 @@ class SiteAccessServiceTest extends TestCase
         parent::setUp();
         $this->provider = $this->createMock(SiteAccessProviderInterface::class);
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->siteAccess = new SiteAccess('current');
         $this->availableSiteAccesses = $this->getAvailableSitAccesses(['current', 'first_sa', 'second_sa', 'default']);
         $this->configResolverParameters = $this->getConfigResolverParameters();
     }
 
-    public function testGetCurrentSiteAccess(): void
+    public function testGetCurrentSiteAccessIsNullWhenStackIsEmpty(): void
     {
-        $service = new SiteAccessService(
-            $this->createMock(SiteAccessProviderInterface::class),
-            $this->createMock(ConfigResolverInterface::class)
-        );
+        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
 
         self::assertNull($service->getCurrent());
+    }
+
+    public function testGetCurrentSiteAccessAfterMainRequestMatch(): void
+    {
+        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
 
         $siteAccess = new SiteAccess('default');
-        $service->setSiteAccess($siteAccess);
-        self::assertSame($siteAccess, $service->getCurrent());
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($siteAccess, new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
 
-        $service->setSiteAccess(null);
-        self::assertNull($service->getCurrent());
+        self::assertSame($siteAccess, $service->getCurrent());
     }
 
     public function testGetSiteAccess(): void
@@ -73,7 +86,8 @@ class SiteAccessServiceTest extends TestCase
         );
         $service = new SiteAccessService(
             $staticSiteAccessProvider,
-            $this->createMock(ConfigResolverInterface::class)
+            $this->createMock(ConfigResolverInterface::class),
+            $this->eventDispatcher
         );
 
         self::assertEquals(
@@ -90,7 +104,8 @@ class SiteAccessServiceTest extends TestCase
         );
         $service = new SiteAccessService(
             $staticSiteAccessProvider,
-            $this->createMock(ConfigResolverInterface::class)
+            $this->createMock(ConfigResolverInterface::class),
+            $this->eventDispatcher
         );
 
         $this->expectException(NotFoundException::class);
@@ -126,10 +141,150 @@ class SiteAccessServiceTest extends TestCase
         );
     }
 
+    /**
+     * changeSiteAccess()/restoreSiteAccess() must behave as a real LIFO stack, and each call
+     * must dispatch a ScopeChangeEvent carrying the relevant SiteAccess under the right event name.
+     */
+    public function testChangeSiteAccessAndRestoreSiteAccessBehaveAsLifoStack(): void
+    {
+        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+
+        $original = new SiteAccess('original');
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($original, new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
+
+        $first = new SiteAccess('first_change');
+        $second = new SiteAccess('second_change');
+
+        $this->eventDispatcher
+            ->expects(self::exactly(4))
+            ->method('dispatch')
+            ->withConsecutive(
+                [self::equalTo(new ScopeChangeEvent($first)), MVCEvents::CONFIG_SCOPE_CHANGE],
+                [self::equalTo(new ScopeChangeEvent($second)), MVCEvents::CONFIG_SCOPE_CHANGE],
+                [self::equalTo(new ScopeChangeEvent($first)), MVCEvents::CONFIG_SCOPE_RESTORE],
+                [self::equalTo(new ScopeChangeEvent($original)), MVCEvents::CONFIG_SCOPE_RESTORE]
+            );
+
+        self::assertSame($first, $service->changeSiteAccess($first));
+        self::assertSame($first, $service->getCurrent());
+
+        self::assertSame($second, $service->changeSiteAccess($second));
+        self::assertSame($second, $service->getCurrent());
+
+        self::assertSame($first, $service->restoreSiteAccess());
+        self::assertSame($first, $service->getCurrent());
+
+        self::assertSame($original, $service->restoreSiteAccess());
+        self::assertSame($original, $service->getCurrent());
+    }
+
+    public function testOnSiteAccessMatchWithMainRequestResetsTheStack(): void
+    {
+        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent(new SiteAccess('first'), new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent(new SiteAccess('sub'), new Request(), HttpKernelInterface::SUB_REQUEST)
+        );
+
+        $second = new SiteAccess('second');
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($second, new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
+
+        self::assertSame($second, $service->getCurrent());
+
+        // The stack was fully reset by the second MAIN_REQUEST match: an unbalanced
+        // finish-request must not be able to reveal any of the previous entries.
+        $service->onKernelFinishRequest($this->createFinishRequestEvent());
+        self::assertSame($second, $service->getCurrent());
+    }
+
+    public function testOnSiteAccessMatchWithSubRequestPushesWithoutResetting(): void
+    {
+        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+
+        $main = new SiteAccess('main');
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($main, new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
+
+        $sub = new SiteAccess('sub');
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($sub, new Request(), HttpKernelInterface::SUB_REQUEST)
+        );
+
+        self::assertSame($sub, $service->getCurrent());
+
+        $service->onKernelFinishRequest($this->createFinishRequestEvent());
+        self::assertSame($main, $service->getCurrent());
+    }
+
+    public function testOnKernelFinishRequestNeverPopsBelowOneRemainingEntry(): void
+    {
+        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+
+        $original = new SiteAccess('original');
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($original, new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
+
+        // Simulate an extra, unbalanced finish-request event.
+        $service->onKernelFinishRequest($this->createFinishRequestEvent());
+
+        self::assertSame($original, $service->getCurrent());
+    }
+
+    /**
+     * Sub-request nesting scenario: a preview scope change followed by a sub-request (e.g. a
+     * fragment/ESI render) must unwind back to the preview scope once the sub-request finishes,
+     * and restoreSiteAccess() must then bring back the original SiteAccess.
+     */
+    public function testSubRequestNestingScenario(): void
+    {
+        $service = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+
+        $original = new SiteAccess('original');
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($original, new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
+
+        $preview = new SiteAccess('preview');
+        $service->changeSiteAccess($preview);
+        self::assertSame($preview, $service->getCurrent());
+
+        $subSiteAccess = new SiteAccess('sub');
+        $service->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($subSiteAccess, new Request(), HttpKernelInterface::SUB_REQUEST)
+        );
+        self::assertSame($subSiteAccess, $service->getCurrent());
+
+        $service->onKernelFinishRequest($this->createFinishRequestEvent());
+        self::assertSame($preview, $service->getCurrent());
+
+        self::assertSame($original, $service->restoreSiteAccess());
+        self::assertSame($original, $service->getCurrent());
+    }
+
+    private function createFinishRequestEvent(): FinishRequestEvent
+    {
+        return new FinishRequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+
     private function getSiteAccessService(): SiteAccessService
     {
-        $siteAccessService = new SiteAccessService($this->provider, $this->configResolver);
-        $siteAccessService->setSiteAccess($this->siteAccess);
+        $siteAccessService = new SiteAccessService($this->provider, $this->configResolver, $this->eventDispatcher);
+        $siteAccessService->onSiteAccessMatch(
+            new PostSiteAccessMatchEvent($this->siteAccess, new Request(), HttpKernelInterface::MAIN_REQUEST)
+        );
 
         return $siteAccessService;
     }


### PR DESCRIPTION
> [!WARNING]
> This branch includes a temporary commit (`dependencies.json`) that points the Behat CI job at
> [ibexa/behat#191](https://github.com/ibexa/behat/pull/191) so the "Commands use the default
> siteaccess if not specified" scenario can run (and pass) before that companion PR merges.
> **Must be removed before merging this PR.**

| :ticket: Issue | [IBX-12204](https://ibexa.atlassian.net/browse/IBX-12204) |
|----------------|-----------|

<!--
#### Related PRs:
- https://github.com/ibexa/core/pull/1
-->

#### Description:

A `ConfigScopeListener` already reacts to `MVCEvents::CONFIG_SCOPE_CHANGE`/`CONFIG_SCOPE_RESTORE` and broadcasts the new SiteAccess to every `VersatileScopeInterface` config resolver and every `SiteAccessAware` view manager/view provider — but `SiteAccessService` itself was never one of those broadcast targets. It kept a single value, injected once via `SiteAccessAware::setSiteAccess()` from request matching, that never updated when a scope change was dispatched (see [IBX-8074](https://ibexa.atlassian.net/browse/IBX-8074)). Every scope-change call site (`ContentPreviewHelper`, `ConsoleCommandListener`) also had to hand-build a `ScopeChangeEvent` and dispatch it itself, with no supported API for it.

This PR makes `SiteAccessService` the single owner of "what is the current SiteAccess right now":

- Added `SiteAccessService::changeSiteAccess(SiteAccess $siteAccess): SiteAccess` and `restoreSiteAccess(): ?SiteAccess`, which wrap the existing `ScopeChangeEvent` dispatch under `MVCEvents::CONFIG_SCOPE_CHANGE`/`CONFIG_SCOPE_RESTORE` — no new event types, just a supported API instead of hand-dispatching.
- `SiteAccessService` now maintains a real LIFO stack of `SiteAccess` changes instead of a single injected value:
  - It implements `EventSubscriberInterface` and subscribes to `MVCEvents::SITEACCESS`: on a `MAIN_REQUEST` match it resets the stack to `[$siteAccess]`; on a `SUB_REQUEST` match (fragments, ESI, content-preview's internal sub-request) it pushes onto the stack.
  - It also subscribes to `KernelEvents::FINISH_REQUEST`, which pops the stack — but never below 1 remaining entry. That single "floor guard" is shared with `restoreSiteAccess()`, so a sub-request's own push is always safely undone by its own finish, and an unbalanced `restoreSiteAccess()` call (or CLI's one-time `changeSiteAccess()` floor) can never strip the stack down to empty.
  - `getCurrent()` returns the top of the stack, or `null` if it's empty — it does **not** fall back to the shared, container-wide `SiteAccess` singleton. `SiteAccessService` (and `ConsoleCommandListener`, see below) intentionally stop relying on that singleton altogether; a SiteAccess with an "uninitialized" matcher (`SiteAccess::MATCHING_TYPE_UNINITIALIZED`) is treated as null defensively even if one somehow ends up on the stack.
- `SiteAccessAware` is marked `@deprecated` (no runtime deprecation notice — it's still legitimately used by consumers not migrated here) in favor of calling `SiteAccessService::getCurrent()` directly.
- Migrated the straightforward "read-only" `SiteAccessAware` consumers to constructor-inject `SiteAccessServiceInterface` and call `getCurrent()` instead of storing a value via `setSiteAccess()`: `ContentPreviewHelper`, `ConsoleCommandListener`, `HttpUtils`, `DefaultRouter`, `Generator` (and `UrlAliasGenerator`), `AliasGeneratorDecorator`, `DecoratedFragmentRenderer`/`InlineFragmentRenderer`.
  - `ConsoleCommandListener` no longer mutates the shared `SiteAccess` singleton at all — it constructs a fresh `SiteAccess` for the CLI invocation and hands it to `changeSiteAccess()`. `ConfigResolver` and friends still read that singleton directly for the `MATCHING_TYPE_UNINITIALIZED` sentinel (see IBX-12192) and are intentionally **not** migrated in this PR (would require a circular DI dependency back onto `SiteAccessService`, plus non-trivial caching/broadcast semantics). Same reasoning excludes `SiteAccess\Router`, `View\Manager`/`Provider\Configured`.
  - IO/repository integration tests never dispatch a request or console command, so `IbexaTestKernel` and `LegacyTestContainerBuilder`'s test settings now explicitly seed `SiteAccessService` via `changeSiteAccess()` with a freshly-constructed default `SiteAccess`, the same mechanism CLI uses.
  - Found and fixed a latent null-dereference bug in `ComplexConfigProcessor` while migrating it: it read `$this->siteAccessService->getCurrent()->name` with no null check. Added a `getCurrentSiteAccessName()` guard that throws `InvalidArgumentException`, matching the precedent already set in `SiteAccessService::getSiteAccessesRelation()`.
  - Small, intentional behavior change worth flagging: `DecoratedFragmentRenderer`/`InlineFragmentRenderer` previously only ever saw the *original* request's SiteAccess when rewriting fragment paths (they weren't part of `ConfigScopeListener`'s scope-change broadcast). They now correctly reflect whatever `SiteAccessService::getCurrent()` says, including during an active content-preview scope change — this is a correctness fix, not a regression.
- Updated DI wiring accordingly: `routing.yml`, `services.yml`, `helpers.yml`, `image.yml`, and the `SecurityPass`/`ChainRoutingPass`/`FragmentPass` compiler passes now pass `SiteAccessServiceInterface` as a constructor argument instead of the old `setSiteAccess()` calls; `SiteAccessService` itself gained an `EventDispatcherInterface` constructor argument and a `kernel.event_subscriber` tag. For `HttpUtils` and `DefaultRouter` — which extend Symfony framework base classes with their own evolving constructors — the new parameter is appended as a nullable, named-argument-bound constructor parameter (`$definition->setArgument('$siteAccessService', ...)`), so the existing positional arguments coming from Symfony's own service definitions are left untouched.
- Pruned the now-stale `phpstan-baseline.neon` entries left behind by removing `SiteAccessAware`/`setSiteAccess()` from the migrated classes.

**Known BC break (intentional):** any custom Symfony console command that type-hints the shared `Ibexa\Core\MVC\Symfony\SiteAccess` service directly to read the CLI-resolved siteaccess will no longer see it updated — `ConsoleCommandListener` used to mutate that shared singleton in place specifically for such consumers, but no longer does (see above). Commands relying on this must switch to injecting `SiteAccessServiceInterface` and calling `getCurrent()` instead. Audited the rest of the public `ibexa/*` org for the same pattern and found exactly two affected spots, both now fixed:
  - `Ibexa\Bundle\Core\Command\DebugConfigResolverCommand` (`ibexa:debug:config-resolver`) in this repo — fixed in this PR.
  - `ibexa/behat`'s `TestSiteaccessCommand` fixture command (used by `src/bundle/Core/Features/Console/console.feature`'s "Commands use the default siteaccess if not specified" scenario) — fixed in companion PR [ibexa/behat#191](https://github.com/ibexa/behat/pull/191), cross-tested here via the temporary `dependencies.json` (see warning at the top).

Verified: `phpstan analyse` clean, and the `unit_core`/`bundle_core`/`bundle_io` PHPUnit suites pass (6567/864/27 tests respectively, no failures — only pre-existing PHPUnit-deprecation warnings unrelated to this change).

#### For QA:

Two scenarios worth exercising manually:
1. **CLI scope change**: run any console command with `--siteaccess=<name>` and confirm `SiteAccessService::getCurrent()` (and `ConfigResolver`) reflect that siteaccess for the whole command run.
2. **Nested scope change (content preview)**: open content preview for a Location under a SiteAccess different from the admin one, and confirm both the previewed page's rendering *and* any generated fragment/ESI URLs inside it reflect the previewed SiteAccess (this exercises the sub-request push/pop path plus the fragment-renderer behavior fix above).

New unit test coverage lives in `SiteAccessServiceTest` for the stack semantics specifically: nested `changeSiteAccess()`/`restoreSiteAccess()` pairs behaving as LIFO, `MAIN_REQUEST` resetting vs. `SUB_REQUEST` pushing, the finish_request floor guard never popping below 1 entry, and a full sub-request-nesting scenario.

#### Documentation:

`SiteAccessAware` is now `@deprecated` — worth a mention in the deprecation notes for this release, pointing integrators at `SiteAccessServiceInterface::getCurrent()`/`changeSiteAccess()`/`restoreSiteAccess()` instead of the old `setSiteAccess()` + hand-dispatched `ScopeChangeEvent` pattern.

The BC break above should also be called out explicitly in the release/upgrade notes: custom console commands reading the shared `SiteAccess` service to determine the CLI-resolved siteaccess must switch to `SiteAccessServiceInterface::getCurrent()`.


[IBX-12204]: https://ibexa.atlassian.net/browse/IBX-12204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IBX-8074]: https://ibexa.atlassian.net/browse/IBX-8074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
