### PR TITLE
Restricted `doctrine/orm` version to below 3.6.8 in `composer.json`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/annotations": "^2.0",
         "doctrine/dbal": "^3.8.2",
         "doctrine/doctrine-bundle": "^2.19",
-        "doctrine/orm": "^3.3 <3.6.8",
+        "doctrine/orm": "^3.3",
         "doctrine/persistence": "^3.3.1",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "friendsofsymfony/http-cache-bundle": "^3.0",
@@ -79,6 +79,7 @@
     },
     "conflict": {
         "doctrine/dbal": "2.7.0",
+        "doctrine/orm": ">=3.6.8",
         "ezsystems/ezplatform-kernel": "*",
         "ezsystems/ezpublish-legacy": "*",
         "friendsofphp/php-cs-fixer": "3.5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/annotations": "^2.0",
         "doctrine/dbal": "^3.8.2",
         "doctrine/doctrine-bundle": "^2.19",
-        "doctrine/orm": "^3.3",
+        "doctrine/orm": "^3.3 <3.6.8",
         "doctrine/persistence": "^3.3.1",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "friendsofsymfony/http-cache-bundle": "^3.0",


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
https://github.com/doctrine/orm/pull/12483/changes

```
3.6.8 [Latest](https://github.com/doctrine/orm/releases/latest)
@[github-actions](https://github.com/apps/github-actions) github-actions released this 12 hours ago
```

proper fix is to bump dbal to 4.X which is down the line.
#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
