### PR TITLE
IBX-11952: Made system resilient to `Accept-Language: *` locale

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7987,18 +7987,6 @@ parameters:
 			path: src/lib/MVC/Symfony/Locale/LocaleConverter.php
 
 		-
-			message: '#^Method Ibexa\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProvider\:\:__construct\(\) has parameter \$languageCodesMap with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/MVC/Symfony/Locale/UserLanguagePreferenceProvider.php
-
-		-
-			message: '#^Property Ibexa\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProvider\:\:\$languageCodesMap type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/lib/MVC/Symfony/Locale/UserLanguagePreferenceProvider.php
-
-		-
 			message: '#^Method Ibexa\\Core\\MVC\\Symfony\\Matcher\\ClassNameMatcherFactory\:\:__construct\(\) has parameter \$matchConfig with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -42839,60 +42827,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: tests/lib/MVC/Symfony/Locale/LocaleConverterTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:getLanguageCodesMap\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:providerForTestGetPreferredLanguages\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:providerForTestGetPreferredLanguagesWithUserPreferredLanguage\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:testGetPreferredLanguagesWithUserPreferredLanguage\(\) has parameter \$expectedEzLanguageCodes with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:testGetPreferredLanguagesWithUserPreferredLanguage\(\) has parameter \$userLanguages with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:testGetPreferredLanguagesWithoutUserLanguage\(\) has parameter \$expectedEzLanguageCodes with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:testGetPreferredLanguagesWithoutUserLanguage\(\) has parameter \$userLanguages with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Parameter \#1 \$filename of static method Symfony\\Component\\Yaml\\Yaml\:\:parseFile\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
-
-		-
-			message: '#^Property Ibexa\\Tests\\Core\\MVC\\Symfony\\Locale\\UserLanguagePreferenceProviderTest\:\:\$userLanguagePreferenceProvider is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
 
 		-
 			message: '#^Method Ibexa\\Tests\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\BaseTestCase\:\:getContentInfoMock\(\) has parameter \$properties with no value type specified in iterable type array\.$#'

--- a/src/lib/MVC/Symfony/Locale/UserLanguagePreferenceProvider.php
+++ b/src/lib/MVC/Symfony/Locale/UserLanguagePreferenceProvider.php
@@ -13,36 +13,17 @@ use Ibexa\Contracts\Core\Repository\UserPreferenceService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class UserLanguagePreferenceProvider implements UserLanguagePreferenceProviderInterface
+final readonly class UserLanguagePreferenceProvider implements UserLanguagePreferenceProviderInterface
 {
-    /** @var \Symfony\Component\HttpFoundation\RequestStack */
-    private $requestStack;
-
-    /** @var \Ibexa\Contracts\Core\Repository\UserPreferenceService */
-    private $userPreferenceService;
-
-    /** @var array */
-    private $languageCodesMap;
-
-    /** @var string */
-    private $localeFallback;
-
     /**
-     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
-     * @param \Ibexa\Contracts\Core\Repository\UserPreferenceService $userPreferenceService
-     * @param array $languageCodesMap
-     * @param string $localeFallback
+     * @param array<string, list<string>> $languageCodesMap
      */
     public function __construct(
-        RequestStack $requestStack,
-        UserPreferenceService $userPreferenceService,
-        array $languageCodesMap,
-        string $localeFallback
+        private RequestStack $requestStack,
+        private UserPreferenceService $userPreferenceService,
+        private array $languageCodesMap,
+        private string $localeFallback
     ) {
-        $this->requestStack = $requestStack;
-        $this->userPreferenceService = $userPreferenceService;
-        $this->languageCodesMap = $languageCodesMap;
-        $this->localeFallback = $localeFallback;
     }
 
     public function getPreferredLocales(?Request $request = null): array
@@ -51,7 +32,12 @@ class UserLanguagePreferenceProvider implements UserLanguagePreferenceProviderIn
 
         $request = $request ?? $this->requestStack->getCurrentRequest();
         if (null !== $request) {
-            $browserLanguages = $request->getLanguages();
+            // `Accept-Language: *` (RFC 7231 wildcard, "any language") is not a concrete
+            // locale; exclude it so it never reaches locale/translator handling downstream.
+            $browserLanguages = array_values(array_filter(
+                $request->getLanguages(),
+                static fn (string $language): bool => '*' !== $language
+            ));
             if ([] !== $browserLanguages) {
                 $languages = $browserLanguages;
             }
@@ -60,7 +46,7 @@ class UserLanguagePreferenceProvider implements UserLanguagePreferenceProviderIn
         try {
             $preferredLanguage = $this->userPreferenceService->getUserPreference('language')->value;
             array_unshift($languages, $preferredLanguage);
-        } catch (NotFoundException $e) {
+        } catch (NotFoundException) {
         }
 
         return array_unique($languages);

--- a/tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
+++ b/tests/lib/MVC/Symfony/Locale/UserLanguagePreferenceProviderTest.php
@@ -12,26 +12,22 @@ use Ibexa\Contracts\Core\Repository\UserPreferenceService;
 use Ibexa\Contracts\Core\Repository\Values\UserPreference\UserPreference;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Yaml\Yaml;
 
-class UserLanguagePreferenceProviderTest extends TestCase
+final class UserLanguagePreferenceProviderTest extends TestCase
 {
-    private const LOCALE_FALLBACK = 'en';
-    private const LANGUAGE_PREFERENCE_NAME = 'language';
-    private const LANGUAGE_PREFERENCE_VALUE = 'no';
+    private const string LOCALE_FALLBACK = 'en';
+    private const string LANGUAGE_PREFERENCE_NAME = 'language';
+    private const string LANGUAGE_PREFERENCE_VALUE = 'no';
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    private $userLanguagePreferenceProvider;
+    private RequestStack & MockObject $requestStackMock;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\HttpFoundation\RequestStack */
-    private $requestStackMock;
-
-    /** @var \Ibexa\Contracts\Core\Repository\UserPreferenceService */
-    private $userPreferenceServiceMock;
+    private UserPreferenceService $userPreferenceServiceMock;
 
     protected function setUp(): void
     {
@@ -47,20 +43,13 @@ class UserLanguagePreferenceProviderTest extends TestCase
             ->method('getUserPreference')
             ->with(self::LANGUAGE_PREFERENCE_NAME)
             ->willReturn($userLanguagePreference);
-
-        $this->userLanguagePreferenceProvider = new UserLanguagePreferenceProvider(
-            $this->requestStackMock,
-            $this->userPreferenceServiceMock,
-            $this->getLanguageCodesMap(),
-            self::LOCALE_FALLBACK
-        );
     }
 
     /**
      * @dataProvider providerForTestGetPreferredLanguages
      *
-     * @param array $userLanguages
-     * @param array $expectedEzLanguageCodes
+     * @param list<string> $userLanguages
+     * @param list<string> $expectedEzLanguageCodes
      */
     public function testGetPreferredLanguagesWithoutUserLanguage(array $userLanguages, array $expectedEzLanguageCodes): void
     {
@@ -98,11 +87,13 @@ class UserLanguagePreferenceProviderTest extends TestCase
     /**
      * @dataProvider providerForTestGetPreferredLanguagesWithUserPreferredLanguage
      *
-     * @param array $userLanguages
-     * @param array $expectedEzLanguageCodes
+     * @param list<string> $userLanguages
+     * @param list<string> $expectedEzLanguageCodes
      */
-    public function testGetPreferredLanguagesWithUserPreferredLanguage(array $userLanguages, array $expectedEzLanguageCodes): void
-    {
+    public function testGetPreferredLanguagesWithUserPreferredLanguage(
+        array $userLanguages,
+        array $expectedEzLanguageCodes
+    ): void {
         $request = new Request();
         $request->headers = new HeaderBag(
             [
@@ -128,10 +119,50 @@ class UserLanguagePreferenceProviderTest extends TestCase
         );
     }
 
+    public function testGetPreferredLocalesExcludesAcceptLanguageWildcard(): void
+    {
+        $request = new Request();
+        $request->headers = new HeaderBag(
+            [
+                'Accept-Language' => '*',
+            ]
+        );
+        $this
+            ->requestStackMock
+            ->expects(self::once())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $userPreferenceServiceMock = $this->createMock(UserPreferenceService::class);
+        $userPreferenceServiceMock
+            ->method('getUserPreference')
+            ->with(self::LANGUAGE_PREFERENCE_NAME)
+            ->will(
+                self::throwException(
+                    new NotFoundException(
+                        'User Preference',
+                        self::LANGUAGE_PREFERENCE_NAME
+                    )
+                )
+            );
+
+        $userLanguagePreferenceProvider = new UserLanguagePreferenceProvider(
+            $this->requestStackMock,
+            $userPreferenceServiceMock,
+            $this->getLanguageCodesMap(),
+            self::LOCALE_FALLBACK
+        );
+
+        self::assertSame(
+            [self::LOCALE_FALLBACK],
+            $userLanguagePreferenceProvider->getPreferredLocales()
+        );
+    }
+
     /**
      * @see testGetPreferredLanguages
      *
-     * @return array
+     * @return array<int, array{list<string>, list<string>}>
      */
     public function providerForTestGetPreferredLanguages(): array
     {
@@ -147,7 +178,7 @@ class UserLanguagePreferenceProviderTest extends TestCase
     /**
      * @see testGetPreferredLanguages
      *
-     * @return array
+     * @return array<int, array{list<string>, list<string>}>
      */
     public function providerForTestGetPreferredLanguagesWithUserPreferredLanguage(): array
     {
@@ -160,11 +191,17 @@ class UserLanguagePreferenceProviderTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<string, list<string>>
+     */
     private function getLanguageCodesMap(): array
     {
-        $config = Yaml::parseFile(
-            realpath(dirname(__DIR__, 5) . '/src/bundle/Core/Resources/config/locale.yml')
+        $configFilePath = realpath(
+            dirname(__DIR__, 5) . '/src/bundle/Core/Resources/config/locale.yml'
         );
+        self::assertNotFalse($configFilePath);
+
+        $config = Yaml::parseFile($configFilePath);
 
         return $config['parameters']['ibexa.locale.browser_map'];
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-11952 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/2003

#### Description:
This issue surface while working on MCP integration for SaaS. MCP clients (MCP Inspector, Claude etc) send `Accept-Language: *`. The MCP routes in SaaS by default resolve to the admin siteaccess, where Ibexa AdminUi's `RequestLocaleListener` feeds the request's preferred locale into `setLocale('*')`.

It is rejected by the `Symfony translator ("Invalid \"*\" locale")` and the request 500s. MCP is a locale-agnostic JSON-RPC API and concerning `Accept-Language: *` (RFC 7231 "any language") is a valid header value but not a concrete locale, we should be at least prepared to have a fallback instead of crashing the application.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
